### PR TITLE
fix: ensure call_exported_func only raises RuntimeError

### DIFF
--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -348,7 +348,7 @@ pub fn call_exported_func(
   instance : @runtime.ModuleInstance,
   name : String,
   args : Array[@wasmoon.Value],
-) -> Array[@wasmoon.Value] raise {
+) -> Array[@wasmoon.Value] raise @runtime.RuntimeError {
   // Find the export
   fn find_export(
     exports : Array[@wasmoon.Export],
@@ -374,8 +374,28 @@ pub fn call_exported_func(
       match exp.desc {
         Func(func_idx) => {
           let ctx = ExecContext::new(store, instance)
-          ctx.call_func(func_idx, args)
-        }
+          // Catch any leaked ControlSignal and convert to RuntimeError
+          ctx.call_func(func_idx, args) catch {
+            @runtime.Branch(_) | @runtime.Return => raise @runtime.Unreachable
+            @runtime.StackUnderflow => raise @runtime.StackUnderflow
+            @runtime.StackOverflow => raise @runtime.StackOverflow
+            @runtime.TypeMismatch => raise @runtime.TypeMismatch
+            @runtime.OutOfBoundsMemoryAccess =>
+              raise @runtime.OutOfBoundsMemoryAccess
+            @runtime.OutOfBoundsTableAccess =>
+              raise @runtime.OutOfBoundsTableAccess
+            @runtime.UndefinedElement => raise @runtime.UndefinedElement
+            @runtime.UninitializedElement => raise @runtime.UninitializedElement
+            @runtime.IndirectCallTypeMismatch =>
+              raise @runtime.IndirectCallTypeMismatch
+            @runtime.DivisionByZero => raise @runtime.DivisionByZero
+            @runtime.IntegerOverflow => raise @runtime.IntegerOverflow
+            @runtime.InvalidConversion => raise @runtime.InvalidConversion
+            @runtime.Unreachable => raise @runtime.Unreachable
+            @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
+            _ => raise @runtime.Unreachable
+          }
+        } // Unknown error
         _ => raise @runtime.UndefinedElement
       }
     None => raise @runtime.UndefinedElement

--- a/executor/pkg.generated.mbti
+++ b/executor/pkg.generated.mbti
@@ -7,7 +7,7 @@ import(
 )
 
 // Values
-fn call_exported_func(@runtime.Store, @runtime.ModuleInstance, String, Array[@wasmoon.Value]) -> Array[@wasmoon.Value] raise
+fn call_exported_func(@runtime.Store, @runtime.ModuleInstance, String, Array[@wasmoon.Value]) -> Array[@wasmoon.Value] raise @runtime.RuntimeError
 
 fn instantiate_module(@wasmoon.Module) -> (@runtime.Store, @runtime.ModuleInstance)
 


### PR DESCRIPTION
## Summary
- Add explicit error type annotation `raise @runtime.RuntimeError` to `call_exported_func`
- Catch `ControlSignal` (`Branch`/`Return`) and convert to `Unreachable`
- Re-raise all `RuntimeError` variants explicitly
- Prevents internal control flow signals from leaking to external callers

## Test plan
- [x] 39 tests pass
- [x] `moon check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)