### PR TITLE
refactor: move ControlSignal from runtime to executor

### DIFF
--- a/executor/error.mbt
+++ b/executor/error.mbt
@@ -1,0 +1,7 @@
+///|
+/// Control flow signal for branching (not an error, but uses exception mechanism)
+/// This is internal to the executor and should not be exposed to external users
+priv suberror ControlSignal {
+  Branch(Int) // Branch with relative depth
+  Return // Return from function
+} derive(Show)

--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -442,7 +442,7 @@ pub fn call_exported_func(
           let ctx = ExecContext::new(store, instance)
           // Catch any leaked ControlSignal and convert to RuntimeError
           ctx.call_func(func_idx, args) catch {
-            @runtime.Branch(_) | @runtime.Return => raise @runtime.Unreachable
+            Branch(_) | Return => raise @runtime.Unreachable
             @runtime.StackUnderflow => raise @runtime.StackUnderflow
             @runtime.StackOverflow => raise @runtime.StackOverflow
             @runtime.TypeMismatch => raise @runtime.TypeMismatch

--- a/executor/instr_control.mbt
+++ b/executor/instr_control.mbt
@@ -10,8 +10,8 @@ fn ExecContext::exec_control(
     // Block: execute body, br 0 jumps to end
     Block(_bt, body) =>
       self.exec_block(body) catch {
-        @runtime.Branch(0) => () // Branch to this block = exit
-        @runtime.Branch(n) => raise @runtime.Branch(n - 1) // Propagate
+        Branch(0) => () // Branch to this block = exit
+        Branch(n) => raise Branch(n - 1) // Propagate
         e => raise e // Re-raise other errors
       }
     // Loop: execute body, br 0 jumps to start
@@ -22,8 +22,8 @@ fn ExecContext::exec_control(
             self.exec_block(body)
             break () // Normal exit
           } catch {
-            @runtime.Branch(0) => continue () // Restart loop
-            @runtime.Branch(n) => raise @runtime.Branch(n - 1)
+            Branch(0) => continue () // Restart loop
+            Branch(n) => raise Branch(n - 1)
             e => raise e
           }
       }
@@ -32,18 +32,18 @@ fn ExecContext::exec_control(
       let cond = self.stack.pop_i32()
       let body = if cond != 0 { then_body } else { else_body }
       self.exec_block(body) catch {
-        @runtime.Branch(0) => () // Branch to this if = exit
-        @runtime.Branch(n) => raise @runtime.Branch(n - 1)
+        Branch(0) => () // Branch to this if = exit
+        Branch(n) => raise Branch(n - 1)
         e => raise e
       }
     }
     // Unconditional branch
-    Br(depth) => raise @runtime.Branch(depth)
+    Br(depth) => raise Branch(depth)
     // Conditional branch
     BrIf(depth) => {
       let cond = self.stack.pop_i32()
       if cond != 0 {
-        raise @runtime.Branch(depth)
+        raise Branch(depth)
       }
     }
     // Table-driven branch
@@ -54,7 +54,7 @@ fn ExecContext::exec_control(
       } else {
         default
       }
-      raise @runtime.Branch(depth)
+      raise Branch(depth)
     }
     // Unreachable trap
     Unreachable => raise @runtime.RuntimeError::Unreachable
@@ -66,7 +66,7 @@ fn ExecContext::exec_control(
       self.stack.push(if cond != 0 { val1 } else { val2 })
     }
     Nop => ()
-    Return => raise @runtime.Return
+    Return => raise Return
     _ => raise @runtime.RuntimeError::Unreachable
   }
 }
@@ -89,7 +89,7 @@ fn ExecContext::exec_expr(
   instrs : Array[@wasmoon.Instruction],
 ) -> Unit raise {
   self.exec_block(instrs) catch {
-    @runtime.Return => () // Normal function return
+    Return => () // Normal function return
     e => raise e
   }
 }

--- a/runtime/error.mbt
+++ b/runtime/error.mbt
@@ -14,10 +14,3 @@ pub(all) suberror RuntimeError {
   Unreachable
   CallStackExhausted
 } derive(Show)
-
-///|
-/// Control flow signal for branching (not an error, but uses exception mechanism)
-pub(all) suberror ControlSignal {
-  Branch(Int) // Branch with relative depth
-  Return // Return from function
-} derive(Show)

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -8,12 +8,6 @@ import(
 // Values
 
 // Errors
-pub(all) suberror ControlSignal {
-  Branch(Int)
-  Return
-}
-impl Show for ControlSignal
-
 pub(all) suberror RuntimeError {
   StackUnderflow
   StackOverflow


### PR DESCRIPTION
## Summary
- Move `ControlSignal` from `runtime` package to `executor` package
- Mark as `priv suberror` to restrict visibility
- `ControlSignal` is an internal implementation detail for control flow, not a public runtime error

## Test plan
- [x] All tests pass (40/40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)