### PR TITLE
fix: validate imports and raise UnknownImport on missing imports

### DIFF
--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -344,16 +344,18 @@ pub fn instantiate_module_with_init(
 
 ///|
 /// Create a module instance with imports using an existing store
+/// Raises UnknownImport if any required import is not provided
 pub fn instantiate_module_with_imports(
   store : @runtime.Store,
   mod : @wasmoon.Module,
   imports : @runtime.Imports,
-) -> @runtime.ModuleInstance {
+) -> @runtime.ModuleInstance raise @runtime.RuntimeError {
   // Process imports first
   let func_addrs : Array[Int] = []
   let func_type_indices : Array[Int] = []
   let mem_addrs : Array[Int] = []
   let table_addrs : Array[Int] = []
+  let global_addrs : Array[Int] = []
 
   // Import functions and memories first (they come before module definitions in the index space)
   for imp in mod.imports {
@@ -364,19 +366,23 @@ pub fn instantiate_module_with_imports(
             func_addrs.push(addr)
             func_type_indices.push(type_idx)
           }
-          _ => () // Import not found, skip for now
+          _ => raise @runtime.UnknownImport
         }
       Memory(_) =>
         match imports.resolve(imp.mod_name, imp.name) {
           Some(Memory(addr)) => mem_addrs.push(addr)
-          _ => () // Import not found, skip for now
+          _ => raise @runtime.UnknownImport
         }
       Table(_) =>
         match imports.resolve(imp.mod_name, imp.name) {
           Some(Table(addr)) => table_addrs.push(addr)
-          _ => () // Import not found, skip for now
+          _ => raise @runtime.UnknownImport
         }
-      _ => () // Handle other import types later
+      Global(_) =>
+        match imports.resolve(imp.mod_name, imp.name) {
+          Some(Global(addr)) => global_addrs.push(addr)
+          _ => raise @runtime.UnknownImport
+        }
     }
   }
 
@@ -410,7 +416,7 @@ pub fn instantiate_module_with_imports(
     func_type_indices,
     table_addrs,
     mem_addrs,
-    global_addrs: [],
+    global_addrs,
     exports: mod.exports,
     elem_segments: mod.elems,
     data_segments: mod.datas,
@@ -469,6 +475,7 @@ pub fn call_exported_func(
             @runtime.InvalidConversion => raise @runtime.InvalidConversion
             @runtime.Unreachable => raise @runtime.Unreachable
             @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
+            @runtime.UnknownImport => raise @runtime.UnknownImport
             _ => raise @runtime.Unreachable
           }
         } // Unknown error

--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -1336,3 +1336,41 @@ test "memory import: write to imported memory" {
   }
   inspect(value, content="42")
 }
+
+///|
+test "import validation: missing import raises error" {
+  let store = @runtime.Store::new()
+
+  // Create a module that requires an import but don't provide it
+  let func : @wasmoon.FunctionCode = { locals: [], body: [I32Const(1)] }
+  let func_type : @wasmoon.FuncType = {
+    params: [],
+    results: [@wasmoon.ValueType::I32],
+  }
+  let mod : @wasmoon.Module = {
+    types: [func_type],
+    imports: [{ mod_name: "env", name: "missing_func", desc: Func(0) }],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "test", desc: @wasmoon.ExportDesc::Func(1) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+
+  // Empty imports - should fail
+  let imports = @runtime.Imports::new()
+
+  // Should raise UnknownImport
+  let result = try {
+    let _ = instantiate_module_with_imports(store, mod, imports)
+    false // Should not reach here
+  } catch {
+    @runtime.UnknownImport => true // Expected
+    _ => false
+  }
+  inspect(result, content="true")
+}

--- a/executor/pkg.generated.mbti
+++ b/executor/pkg.generated.mbti
@@ -11,7 +11,7 @@ fn call_exported_func(@runtime.Store, @runtime.ModuleInstance, String, Array[@wa
 
 fn instantiate_module(@wasmoon.Module) -> (@runtime.Store, @runtime.ModuleInstance)
 
-fn instantiate_module_with_imports(@runtime.Store, @wasmoon.Module, @runtime.Imports) -> @runtime.ModuleInstance
+fn instantiate_module_with_imports(@runtime.Store, @wasmoon.Module, @runtime.Imports) -> @runtime.ModuleInstance raise @runtime.RuntimeError
 
 fn instantiate_module_with_init(@wasmoon.Module) -> (@runtime.Store, @runtime.ModuleInstance)
 

--- a/runtime/error.mbt
+++ b/runtime/error.mbt
@@ -13,4 +13,5 @@ pub(all) suberror RuntimeError {
   InvalidConversion
   Unreachable
   CallStackExhausted
+  UnknownImport // Import not found during instantiation
 } derive(Show)

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub(all) suberror RuntimeError {
   InvalidConversion
   Unreachable
   CallStackExhausted
+  UnknownImport
 }
 impl Show for RuntimeError
 


### PR DESCRIPTION
## Summary
Following wasmtime's approach: missing imports should raise an error rather than being silently skipped.

- Add `UnknownImport` error variant to `RuntimeError`
- `instantiate_module_with_imports` now raises `UnknownImport` if any required import is not provided
- Add global import handling
- Add test for missing import validation

## Test plan
- [x] All tests pass (43/43)
- [x] New test verifies missing import raises error

🤖 Generated with [Claude Code](https://claude.com/claude-code)