### PR TITLE
feat: implement table.fill and table.copy instructions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,10 +73,10 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 - [x] 表导入/导出
 - [x] 全局变量导入/导出
 
-### 3.3 表操作
+### 3.3 表操作 ✅
 - [x] table.get / table.set
 - [x] table.size / table.grow
-- [ ] table.fill / table.copy
+- [x] table.fill / table.copy
 
 ### 3.4 模块初始化
 - [ ] Start function 执行
@@ -154,4 +154,4 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 ---
 
 **当前状态**: Phase 3 进行中
-**下一步**: table.fill / table.copy
+**下一步**: Start function 执行

--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -71,6 +71,24 @@ fn ExecContext::exec_instr(
       let old_size = table.grow(delta, init_val)
       self.stack.push(I32(old_size))
     }
+    TableFill(table_idx) => {
+      let n = self.stack.pop_i32()
+      let value = self.stack.pop()
+      let dest = self.stack.pop_i32()
+      let table_addr = self.instance.table_addrs[table_idx]
+      let table = self.store.get_table(table_addr)
+      table.fill(dest, value, n)
+    }
+    TableCopy(dest_table_idx, src_table_idx) => {
+      let n = self.stack.pop_i32()
+      let src = self.stack.pop_i32()
+      let dest = self.stack.pop_i32()
+      let dest_table_addr = self.instance.table_addrs[dest_table_idx]
+      let src_table_addr = self.instance.table_addrs[src_table_idx]
+      let dest_table = self.store.get_table(dest_table_addr)
+      let src_table = self.store.get_table(src_table_addr)
+      dest_table.copy_from(dest, src_table, src, n)
+    }
 
     // Drop
     Drop => {

--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -1683,3 +1683,111 @@ test "table operations: table.grow" {
   inspect(old_size, content="2") // old size was 2
   inspect(table.size(), content="5") // new size is 5
 }
+
+///|
+test "table operations: table.fill" {
+  // Test table.fill via direct runtime manipulation
+  let store = @runtime.Store::new()
+  let table = @runtime.Table::new(@wasmoon.ValueType::FuncRef, 5, None)
+  let _ = store.alloc_table(table)
+
+  // Fill table[1..4] with FuncRef(42)
+  table.fill(1, @wasmoon.Value::FuncRef(42), 3) catch {
+    _ => fail("table.fill failed")
+  }
+
+  // Verify: table[0] should be Null, table[1..3] should be FuncRef(42), table[4] should be Null
+  inspect(table.get_element(0), content="Null")
+  inspect(table.get_element(1), content="FuncRef(42)")
+  inspect(table.get_element(2), content="FuncRef(42)")
+  inspect(table.get_element(3), content="FuncRef(42)")
+  inspect(table.get_element(4), content="Null")
+}
+
+///|
+test "table operations: table.copy same table" {
+  // Test table.copy within the same table
+  let store = @runtime.Store::new()
+  let table = @runtime.Table::new(@wasmoon.ValueType::FuncRef, 6, None)
+  let _ = store.alloc_table(table)
+
+  // Set some initial values
+  table.set(0, @wasmoon.Value::FuncRef(10)) catch {
+    _ => ()
+  }
+  table.set(1, @wasmoon.Value::FuncRef(20)) catch {
+    _ => ()
+  }
+  table.set(2, @wasmoon.Value::FuncRef(30)) catch {
+    _ => ()
+  }
+
+  // Copy table[0..3] to table[3..6]
+  table.copy_from(3, table, 0, 3) catch {
+    _ => fail("table.copy failed")
+  }
+  inspect(table.get_element(0), content="FuncRef(10)")
+  inspect(table.get_element(1), content="FuncRef(20)")
+  inspect(table.get_element(2), content="FuncRef(30)")
+  inspect(table.get_element(3), content="FuncRef(10)")
+  inspect(table.get_element(4), content="FuncRef(20)")
+  inspect(table.get_element(5), content="FuncRef(30)")
+}
+
+///|
+test "table operations: table.copy between tables" {
+  // Test table.copy between different tables
+  let store = @runtime.Store::new()
+  let table1 = @runtime.Table::new(@wasmoon.ValueType::FuncRef, 4, None)
+  let table2 = @runtime.Table::new(@wasmoon.ValueType::FuncRef, 4, None)
+  let _ = store.alloc_table(table1)
+  let _ = store.alloc_table(table2)
+
+  // Set values in table1
+  table1.set(0, @wasmoon.Value::FuncRef(100)) catch {
+    _ => ()
+  }
+  table1.set(1, @wasmoon.Value::FuncRef(200)) catch {
+    _ => ()
+  }
+
+  // Copy table1[0..2] to table2[1..3]
+  table2.copy_from(1, table1, 0, 2) catch {
+    _ => fail("table.copy failed")
+  }
+  inspect(table2.get_element(0), content="Null")
+  inspect(table2.get_element(1), content="FuncRef(100)")
+  inspect(table2.get_element(2), content="FuncRef(200)")
+  inspect(table2.get_element(3), content="Null")
+}
+
+///|
+test "table operations: table.copy overlapping backward" {
+  // Test table.copy with overlapping regions (dest > src)
+  let store = @runtime.Store::new()
+  let table = @runtime.Table::new(@wasmoon.ValueType::FuncRef, 6, None)
+  let _ = store.alloc_table(table)
+
+  // Set initial values: [1, 2, 3, 0, 0, 0]
+  table.set(0, @wasmoon.Value::FuncRef(1)) catch {
+    _ => ()
+  }
+  table.set(1, @wasmoon.Value::FuncRef(2)) catch {
+    _ => ()
+  }
+  table.set(2, @wasmoon.Value::FuncRef(3)) catch {
+    _ => ()
+  }
+
+  // Copy table[0..3] to table[2..5] (overlapping, dest > src)
+  // Expected: [1, 2, 1, 2, 3, 0]
+  table.copy_from(2, table, 0, 3) catch {
+    _ => fail("table.copy failed")
+  }
+  inspect(table.get_element(0), content="FuncRef(1)")
+  inspect(table.get_element(1), content="FuncRef(2)")
+  inspect(table.get_element(2), content="FuncRef(1)")
+  inspect(table.get_element(3), content="FuncRef(2)")
+  inspect(table.get_element(4), content="FuncRef(3)")
+  inspect(table.get_element(5), content="Null")
+}

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -114,6 +114,8 @@ pub(all) enum Instruction {
   TableSet(Int)
   TableSize(Int)
   TableGrow(Int)
+  TableFill(Int)
+  TableCopy(Int, Int)
   I32Load(Int, Int)
   I64Load(Int, Int)
   F32Load(Int, Int)

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -143,7 +143,10 @@ fn Store::new() -> Self
 impl Show for Store
 
 type Table
+fn Table::copy_from(Self, Int, Self, Int, Int) -> Unit raise RuntimeError
+fn Table::fill(Self, Int, @wasmoon.Value, Int) -> Unit raise RuntimeError
 fn Table::get(Self, Int) -> @wasmoon.Value raise RuntimeError
+fn Table::get_element(Self, Int) -> @wasmoon.Value raise RuntimeError
 fn Table::grow(Self, Int, @wasmoon.Value) -> Int
 fn Table::new(@wasmoon.ValueType, Int, Int?) -> Self
 fn Table::set(Self, Int, @wasmoon.Value) -> Unit raise RuntimeError

--- a/runtime/table.mbt
+++ b/runtime/table.mbt
@@ -50,6 +50,18 @@ pub fn Table::size(self : Table) -> Int {
 }
 
 ///|
+/// Get element without checking for uninitialized (for testing)
+pub fn Table::get_element(
+  self : Table,
+  idx : Int,
+) -> @wasmoon.Value raise RuntimeError {
+  if idx < 0 || idx >= self.size {
+    raise OutOfBoundsTableAccess
+  }
+  self.elements[idx]
+}
+
+///|
 pub fn Table::grow(self : Table, delta : Int, init : @wasmoon.Value) -> Int {
   let old_size = self.size
   let new_size = old_size + delta
@@ -66,4 +78,52 @@ pub fn Table::grow(self : Table, delta : Int, init : @wasmoon.Value) -> Int {
   }
   self.size = new_size
   old_size
+}
+
+///|
+/// Fill a range of table elements with a value
+/// table.fill: fill table[d..d+n] with value
+pub fn Table::fill(
+  self : Table,
+  dest : Int,
+  value : @wasmoon.Value,
+  n : Int,
+) -> Unit raise RuntimeError {
+  if dest < 0 || n < 0 || dest + n > self.size {
+    raise OutOfBoundsTableAccess
+  }
+  for i in 0..<n {
+    self.elements[dest + i] = value
+  }
+}
+
+///|
+/// Copy elements from source table to this table
+/// table.copy: copy src_table[s..s+n] to this_table[d..d+n]
+pub fn Table::copy_from(
+  self : Table,
+  dest : Int,
+  src_table : Table,
+  src : Int,
+  n : Int,
+) -> Unit raise RuntimeError {
+  if dest < 0 ||
+    src < 0 ||
+    n < 0 ||
+    dest + n > self.size ||
+    src + n > src_table.size {
+    raise OutOfBoundsTableAccess
+  }
+  // Handle overlapping regions correctly
+  if dest <= src {
+    // Copy forward
+    for i in 0..<n {
+      self.elements[dest + i] = src_table.elements[src + i]
+    }
+  } else {
+    // Copy backward to handle overlap
+    for i = n - 1; i >= 0; i = i - 1 {
+      self.elements[dest + i] = src_table.elements[src + i]
+    }
+  }
 }

--- a/wasmoon.mbt
+++ b/wasmoon.mbt
@@ -65,6 +65,8 @@ pub(all) enum Instruction {
   TableSet(Int) // table index
   TableSize(Int) // table index
   TableGrow(Int) // table index
+  TableFill(Int) // table index
+  TableCopy(Int, Int) // dest table index, src table index
 
   // Memory instructions
   I32Load(Int, Int) // align, offset


### PR DESCRIPTION
## Summary
- Implement `table.fill` instruction: fill a range of table elements with a value
- Implement `table.copy` instruction: copy elements between tables (or within same table)
- Properly handle overlapping regions in table.copy

## Changes
- `wasmoon.mbt`: Add `TableFill(Int)` and `TableCopy(Int, Int)` to Instruction enum
- `runtime/table.mbt`: Add `Table::fill`, `Table::copy_from`, and `Table::get_element` methods
- `executor/executor.mbt`: Add instruction handlers for TableFill and TableCopy
- `executor/executor_wbtest.mbt`: Add 4 new tests

## Test plan
- [x] All 54 tests pass
- [x] Test table.fill fills correct range
- [x] Test table.copy within same table (non-overlapping)
- [x] Test table.copy between different tables
- [x] Test table.copy with overlapping regions (backward copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)