### PR TITLE
feat: implement bulk memory operations (memory.init/copy/fill)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,8 +83,8 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 - [x] 数据段初始化 (data segment)
 - [x] 元素段初始化 (element segment)
 
-### 3.5 批量内存操作
-- [ ] memory.init / memory.copy / memory.fill
+### 3.5 批量内存操作 ✅
+- [x] memory.init / memory.copy / memory.fill
 - [ ] data.drop / elem.drop
 
 ### 3.6 引用类型
@@ -154,4 +154,4 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 ---
 
 **当前状态**: Phase 3 进行中
-**下一步**: memory.init / memory.copy / memory.fill
+**下一步**: data.drop / elem.drop

--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -242,8 +242,9 @@ fn ExecContext::exec_instr(
     | I64Store16(_, _)
     | I64Store32(_, _) => self.exec_memory_store(instr)
 
-    // Memory size/grow
-    MemorySize | MemoryGrow => self.exec_memory_misc(instr)
+    // Memory size/grow and bulk operations
+    MemorySize | MemoryGrow | MemoryInit(_) | MemoryCopy | MemoryFill =>
+      self.exec_memory_misc(instr)
 
     // Control flow operations
     Block(_, _)

--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -1959,3 +1959,220 @@ test "module initialization: element segment" {
     _ => fail("Expected I32 result")
   }
 }
+
+///|
+test "bulk memory: memory.fill" {
+  // Function: fill memory[0..4] with 0x42, then read back
+  let func : @wasmoon.FunctionCode = {
+    locals: [],
+    body: [
+      I32Const(0), // dest
+      I32Const(0x42), // value
+      I32Const(4), // len
+      MemoryFill, // fill
+      I32Const(0),
+      I32Load(2, 0),
+    ],
+  } // read back
+  let func_type : @wasmoon.FuncType = {
+    params: [],
+    results: [@wasmoon.ValueType::I32],
+  }
+  let mod : @wasmoon.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [{ limits: { min: 1, max: None } }],
+    globals: [],
+    exports: [{ name: "test", desc: @wasmoon.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    // 0x42424242 = 1111638594
+    I32(n) => inspect(n, content="1111638594")
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "bulk memory: memory.copy non-overlapping" {
+  // Store 0x12345678 at address 0, then copy to address 100
+  let func : @wasmoon.FunctionCode = {
+    locals: [],
+    body: [
+      I32Const(0),
+      I32Const(0x12345678),
+      I32Store(2, 0), // store at address 0
+      I32Const(100), // dest
+      I32Const(0), // src
+      I32Const(4), // len
+      MemoryCopy, // copy
+      I32Const(100),
+      I32Load(2, 0),
+    ],
+  } // read from dest
+  let func_type : @wasmoon.FuncType = {
+    params: [],
+    results: [@wasmoon.ValueType::I32],
+  }
+  let mod : @wasmoon.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [{ limits: { min: 1, max: None } }],
+    globals: [],
+    exports: [{ name: "test", desc: @wasmoon.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    I32(n) => inspect(n, content="305419896") // 0x12345678
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "bulk memory: memory.copy overlapping backward" {
+  // Fill memory[0..8] with pattern, then copy memory[0..4] to memory[2..6]
+  // This tests backward copy when dest > src
+  let func : @wasmoon.FunctionCode = {
+    locals: [],
+    body: [
+      // Store [0x01, 0x02, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00] at address 0
+      I32Const(0),
+      I32Const(0x04030201),
+      I32Store(2, 0),
+      // Copy from 0 to 2, length 4
+      // Expected: [0x01, 0x02, 0x01, 0x02, 0x03, 0x04, 0x00, 0x00]
+      I32Const(2), // dest
+      I32Const(0), // src
+      I32Const(4), // len
+      MemoryCopy,
+      // Read from address 2
+      I32Const(2),
+      I32Load(2, 0),
+    ],
+  }
+  let func_type : @wasmoon.FuncType = {
+    params: [],
+    results: [@wasmoon.ValueType::I32],
+  }
+  let mod : @wasmoon.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [{ limits: { min: 1, max: None } }],
+    globals: [],
+    exports: [{ name: "test", desc: @wasmoon.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    // At address 2: [0x01, 0x02, 0x03, 0x04] = 0x04030201
+    I32(n) => inspect(n, content="67305985")
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "bulk memory: memory.init from data segment" {
+  // Module with a data segment, use memory.init to copy part of it
+  let func : @wasmoon.FunctionCode = {
+    locals: [],
+    body: [
+      I32Const(100), // dest in memory
+      I32Const(0), // src offset in data segment
+      I32Const(4), // len
+      MemoryInit(0), // init from data segment 0
+      I32Const(100),
+      I32Load(2, 0),
+    ],
+  }
+  let func_type : @wasmoon.FuncType = {
+    params: [],
+    results: [@wasmoon.ValueType::I32],
+  }
+  // Data: 0xDEADBEEF in little-endian
+  let data_bytes = Bytes::from_array([b'\xEF', b'\xBE', b'\xAD', b'\xDE'])
+  let mod : @wasmoon.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [{ limits: { min: 1, max: None } }],
+    globals: [],
+    exports: [{ name: "test", desc: @wasmoon.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [{ memory_idx: 0, offset: [I32Const(0)], init: data_bytes }],
+  }
+  let (store, instance) = instantiate_module_with_init(mod) catch {
+    _ => fail("instantiate_module_with_init failed")
+  }
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    I32(n) => inspect(n, content="-559038737") // 0xDEADBEEF as signed i32
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "bulk memory: memory.init with offset" {
+  // Use memory.init with non-zero source offset
+  let func : @wasmoon.FunctionCode = {
+    locals: [],
+    body: [
+      I32Const(0), // dest in memory
+      I32Const(2), // src offset in data segment (skip first 2 bytes)
+      I32Const(2), // len (copy last 2 bytes)
+      MemoryInit(0),
+      I32Const(0),
+      I32Load16U(1, 0),
+    ],
+  } // load 16-bit unsigned
+  let func_type : @wasmoon.FuncType = {
+    params: [],
+    results: [@wasmoon.ValueType::I32],
+  }
+  // Data: [0x11, 0x22, 0x33, 0x44]
+  let data_bytes = Bytes::from_array([b'\x11', b'\x22', b'\x33', b'\x44'])
+  let mod : @wasmoon.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [{ limits: { min: 1, max: None } }],
+    globals: [],
+    exports: [{ name: "test", desc: @wasmoon.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [{ memory_idx: 0, offset: [I32Const(0)], init: data_bytes }],
+  }
+  let (store, instance) = instantiate_module_with_init(mod) catch {
+    _ => fail("instantiate_module_with_init failed")
+  }
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    // Reading [0x33, 0x44] as little-endian u16: 0x4433 = 17459
+    I32(n) => inspect(n, content="17459")
+    _ => fail("Expected I32 result")
+  }
+}

--- a/executor/instr_memory.mbt
+++ b/executor/instr_memory.mbt
@@ -207,7 +207,7 @@ fn ExecContext::exec_memory_store(
 }
 
 ///|
-/// Execute memory size/grow instruction
+/// Execute memory size/grow/bulk instruction
 fn ExecContext::exec_memory_misc(
   self : ExecContext,
   instr : @wasmoon.Instruction,
@@ -224,6 +224,41 @@ fn ExecContext::exec_memory_misc(
       let mem = self.store.get_mem(0)
       let result = mem.grow(delta)
       self.stack.push(I32(result))
+    }
+    // memory.init: copy data from data segment to memory
+    MemoryInit(data_idx) => {
+      let n = self.stack.pop_i32() // length
+      let s = self.stack.pop_i32() // source offset in data segment
+      let d = self.stack.pop_i32() // destination in memory
+      let mem_addr = self.instance.mem_addrs[0]
+      let mem = self.store.get_mem(mem_addr)
+      let data_segment = self.instance.data_segments[data_idx]
+      // Extract the slice from data segment
+      if s < 0 || n < 0 || s + n > data_segment.init.length() {
+        raise @runtime.RuntimeError::OutOfBoundsMemoryAccess
+      }
+      // Copy bytes directly to memory
+      for i in 0..<n {
+        mem.store_byte(d + i, data_segment.init[s + i])
+      }
+    }
+    // memory.copy: copy within memory
+    MemoryCopy => {
+      let n = self.stack.pop_i32() // length
+      let s = self.stack.pop_i32() // source
+      let d = self.stack.pop_i32() // destination
+      let mem_addr = self.instance.mem_addrs[0]
+      let mem = self.store.get_mem(mem_addr)
+      mem.copy(d, s, n)
+    }
+    // memory.fill: fill memory region with a value
+    MemoryFill => {
+      let n = self.stack.pop_i32() // length
+      let val = self.stack.pop_i32() // value (byte)
+      let d = self.stack.pop_i32() // destination
+      let mem_addr = self.instance.mem_addrs[0]
+      let mem = self.store.get_mem(mem_addr)
+      mem.fill(d, val.land(0xFF).to_byte(), n)
     }
     _ => raise @runtime.RuntimeError::Unreachable
   }

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -141,6 +141,9 @@ pub(all) enum Instruction {
   I64Store32(Int, Int)
   MemorySize
   MemoryGrow
+  MemoryInit(Int)
+  MemoryCopy
+  MemoryFill
   I32Const(Int)
   I64Const(Int64)
   F32Const(Float)

--- a/runtime/memory.mbt
+++ b/runtime/memory.mbt
@@ -370,3 +370,51 @@ pub fn Memory::init_data(
     self.data[dest + i] = data[i]
   }
 }
+
+///|
+/// Copy memory within the same memory instance
+/// Handles overlapping regions correctly
+pub fn Memory::copy(
+  self : Memory,
+  dest : Int,
+  src : Int,
+  len : Int,
+) -> Unit raise RuntimeError {
+  if dest < 0 ||
+    src < 0 ||
+    dest + len > self.data.length() ||
+    src + len > self.data.length() {
+    raise OutOfBoundsMemoryAccess
+  }
+  if len == 0 {
+    return
+  }
+  // Handle overlapping regions
+  if dest <= src {
+    // Copy forward
+    for i in 0..<len {
+      self.data[dest + i] = self.data[src + i]
+    }
+  } else {
+    // Copy backward to handle overlap when dest > src
+    for i = len - 1; i >= 0; i = i - 1 {
+      self.data[dest + i] = self.data[src + i]
+    }
+  }
+}
+
+///|
+/// Fill memory region with a byte value
+pub fn Memory::fill(
+  self : Memory,
+  dest : Int,
+  value : Byte,
+  len : Int,
+) -> Unit raise RuntimeError {
+  if dest < 0 || dest + len > self.data.length() {
+    raise OutOfBoundsMemoryAccess
+  }
+  for i in 0..<len {
+    self.data[dest + i] = value
+  }
+}

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -66,6 +66,8 @@ type Label
 impl Show for Label
 
 type Memory
+fn Memory::copy(Self, Int, Int, Int) -> Unit raise RuntimeError
+fn Memory::fill(Self, Int, Byte, Int) -> Unit raise RuntimeError
 fn Memory::grow(Self, Int) -> Int
 fn Memory::init_data(Self, Int, Bytes) -> Unit raise RuntimeError
 fn Memory::load_byte(Self, Int) -> Byte raise RuntimeError

--- a/wasmoon.mbt
+++ b/wasmoon.mbt
@@ -94,6 +94,9 @@ pub(all) enum Instruction {
   I64Store32(Int, Int)
   MemorySize
   MemoryGrow
+  MemoryInit(Int) // data segment index
+  MemoryCopy
+  MemoryFill
 
   // Numeric instructions - Constants
   I32Const(Int)


### PR DESCRIPTION
## Summary
- Add `memory.init` instruction to copy data from data segments to memory
- Add `memory.copy` instruction to copy within memory (handles overlapping regions correctly)
- Add `memory.fill` instruction to fill memory regions with a byte value
- Add `Memory::copy` and `Memory::fill` methods to runtime
- Add 5 comprehensive tests for bulk memory operations

## Test plan
- [x] Test memory.fill: fill region and verify content
- [x] Test memory.copy: non-overlapping copy
- [x] Test memory.copy: overlapping backward copy (dest > src)
- [x] Test memory.init: copy from data segment
- [x] Test memory.init: copy with source offset
- [x] All 63 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)