### PR TITLE
feat: implement data.drop and elem.drop instructions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,7 +85,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 
 ### 3.5 批量内存操作 ✅
 - [x] memory.init / memory.copy / memory.fill
-- [ ] data.drop / elem.drop
+- [x] data.drop / elem.drop
 
 ### 3.6 引用类型
 - [ ] ref.null / ref.is_null / ref.func
@@ -154,4 +154,4 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 ---
 
 **当前状态**: Phase 3 进行中
-**下一步**: data.drop / elem.drop
+**下一步**: ref.null / ref.is_null / ref.func

--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -243,8 +243,13 @@ fn ExecContext::exec_instr(
     | I64Store32(_, _) => self.exec_memory_store(instr)
 
     // Memory size/grow and bulk operations
-    MemorySize | MemoryGrow | MemoryInit(_) | MemoryCopy | MemoryFill =>
-      self.exec_memory_misc(instr)
+    MemorySize
+    | MemoryGrow
+    | MemoryInit(_)
+    | DataDrop(_)
+    | MemoryCopy
+    | MemoryFill
+    | ElemDrop(_) => self.exec_memory_misc(instr)
 
     // Control flow operations
     Block(_, _)
@@ -374,6 +379,15 @@ pub fn instantiate_module(
 
   // func_addrs: indices into store.funcs
   // func_type_indices: type index for each function (from mod.funcs)
+  // Initialize dropped arrays with false values
+  let dropped_elems : Array[Bool] = []
+  for _ in 0..<mod.elems.length() {
+    dropped_elems.push(false)
+  }
+  let dropped_datas : Array[Bool] = []
+  for _ in 0..<mod.datas.length() {
+    dropped_datas.push(false)
+  }
   let instance : @runtime.ModuleInstance = {
     types: mod.types,
     func_addrs,
@@ -384,6 +398,8 @@ pub fn instantiate_module(
     exports: mod.exports,
     elem_segments: mod.elems,
     data_segments: mod.datas,
+    dropped_elems,
+    dropped_datas,
   }
   (store, instance)
 }
@@ -554,6 +570,15 @@ pub fn instantiate_module_with_imports(
     let addr = store.alloc_global(global_inst)
     global_addrs.push(addr)
   }
+  // Initialize dropped arrays with false values
+  let dropped_elems : Array[Bool] = []
+  for _ in 0..<mod.elems.length() {
+    dropped_elems.push(false)
+  }
+  let dropped_datas : Array[Bool] = []
+  for _ in 0..<mod.datas.length() {
+    dropped_datas.push(false)
+  }
   {
     types: mod.types,
     func_addrs,
@@ -564,6 +589,8 @@ pub fn instantiate_module_with_imports(
     exports: mod.exports,
     elem_segments: mod.elems,
     data_segments: mod.datas,
+    dropped_elems,
+    dropped_datas,
   }
 }
 

--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -2176,3 +2176,156 @@ test "bulk memory: memory.init with offset" {
     _ => fail("Expected I32 result")
   }
 }
+
+///|
+test "bulk memory: data.drop" {
+  // Test data.drop: after dropping, memory.init with non-zero length should trap
+  // Function 0: drop data segment 0
+  // Function 1: try memory.init with length 0 (should succeed even after drop)
+  // Function 2: try memory.init with length > 0 (should fail after drop)
+  let drop_func : @types.FunctionCode = { locals: [], body: [DataDrop(0)] } // drop data segment 0
+  let init_zero_func : @types.FunctionCode = {
+    locals: [],
+    body: [
+      I32Const(0), // dest
+      I32Const(0), // src offset
+      I32Const(0), // len = 0 (should work even after drop)
+      MemoryInit(0),
+      I32Const(1),
+    ],
+  } // return 1 for success
+  let init_nonzero_func : @types.FunctionCode = {
+    locals: [],
+    body: [
+      I32Const(0), // dest
+      I32Const(0), // src offset
+      I32Const(1), // len = 1 (should fail after drop)
+      MemoryInit(0),
+      I32Const(1),
+    ],
+  }
+  let void_type : @types.FuncType = { params: [], results: [] }
+  let i32_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let data_bytes = Bytes::from_array([b'\x42'])
+  let mod : @types.Module = {
+    types: [void_type, i32_type],
+    imports: [],
+    funcs: [0, 1, 1], // drop has type 0, init funcs have type 1
+    tables: [],
+    memories: [{ limits: { min: 1, max: None } }],
+    globals: [],
+    exports: [
+      { name: "drop", desc: @types.ExportDesc::Func(0) },
+      { name: "init_zero", desc: @types.ExportDesc::Func(1) },
+      { name: "init_nonzero", desc: @types.ExportDesc::Func(2) },
+    ],
+    start: None,
+    elems: [],
+    codes: [drop_func, init_zero_func, init_nonzero_func],
+    datas: [{ memory_idx: 0, offset: [I32Const(0)], init: data_bytes }],
+  }
+  let (store, instance) = instantiate_module_with_init(mod) catch {
+    _ => fail("instantiate_module_with_init failed")
+  }
+
+  // Before drop: init_nonzero should work
+  let result1 = call_exported_func(store, instance, "init_nonzero", [])
+  match result1[0] {
+    I32(n) => inspect(n, content="1")
+    _ => fail("Expected I32 result")
+  }
+
+  // Drop the data segment
+  let _ = call_exported_func(store, instance, "drop", [])
+
+  // After drop: init_zero should still work (length 0 is ok)
+  let result2 = call_exported_func(store, instance, "init_zero", [])
+  match result2[0] {
+    I32(n) => inspect(n, content="1")
+    _ => fail("Expected I32 result")
+  }
+
+  // After drop: init_nonzero should fail
+  let trapped = try {
+    let _ = call_exported_func(store, instance, "init_nonzero", [])
+    false
+  } catch {
+    @runtime.OutOfBoundsMemoryAccess => true
+    _ => false
+  }
+  inspect(trapped, content="true")
+}
+
+///|
+test "bulk memory: elem.drop" {
+  // Test elem.drop: after dropping, the segment is marked as dropped
+  // We verify by checking the instance state directly
+  let drop_func : @types.FunctionCode = { locals: [], body: [ElemDrop(0)] } // drop elem segment 0
+  let void_type : @types.FuncType = { params: [], results: [] }
+  let dummy_func : @types.FunctionCode = { locals: [], body: [I32Const(0)] }
+  let i32_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [void_type, i32_type],
+    imports: [],
+    funcs: [0, 1], // drop has type 0, dummy has type 1
+    tables: [
+      { elem_type: @types.ValueType::FuncRef, limits: { min: 2, max: None } },
+    ],
+    memories: [],
+    globals: [],
+    exports: [{ name: "drop", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [{ table_idx: 0, offset: [I32Const(0)], init: [1] }], // elem segment with func 1
+    codes: [drop_func, dummy_func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module_with_init(mod) catch {
+    _ => fail("instantiate_module_with_init failed")
+  }
+
+  // Before drop: elem segment should not be dropped
+  inspect(instance.dropped_elems[0], content="false")
+
+  // Drop the elem segment
+  let _ = call_exported_func(store, instance, "drop", [])
+
+  // After drop: elem segment should be marked as dropped
+  inspect(instance.dropped_elems[0], content="true")
+}
+
+///|
+test "bulk memory: data.drop is idempotent" {
+  // Dropping a segment multiple times should be safe
+  let drop_func : @types.FunctionCode = {
+    locals: [],
+    body: [DataDrop(0), DataDrop(0), DataDrop(0)], // drop 3 times
+  }
+  let void_type : @types.FuncType = { params: [], results: [] }
+  let data_bytes = Bytes::from_array([b'\x42'])
+  let mod : @types.Module = {
+    types: [void_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [{ limits: { min: 1, max: None } }],
+    globals: [],
+    exports: [{ name: "drop", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [drop_func],
+    datas: [{ memory_idx: 0, offset: [I32Const(0)], init: data_bytes }],
+  }
+  let (store, instance) = instantiate_module_with_init(mod) catch {
+    _ => fail("instantiate_module_with_init failed")
+  }
+
+  // Calling drop multiple times should not cause error
+  let _ = call_exported_func(store, instance, "drop", [])
+  inspect(instance.dropped_datas[0], content="true")
+}

--- a/executor/instr_memory.mbt
+++ b/executor/instr_memory.mbt
@@ -230,6 +230,14 @@ fn ExecContext::exec_memory_misc(
       let n = self.stack.pop_i32() // length
       let s = self.stack.pop_i32() // source offset in data segment
       let d = self.stack.pop_i32() // destination in memory
+      // Check if segment has been dropped
+      if self.instance.dropped_datas[data_idx] {
+        // Dropped segments behave as if they have zero length
+        if n != 0 {
+          raise @runtime.RuntimeError::OutOfBoundsMemoryAccess
+        }
+        return
+      }
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
       let data_segment = self.instance.data_segments[data_idx]
@@ -242,6 +250,8 @@ fn ExecContext::exec_memory_misc(
         mem.store_byte(d + i, data_segment.init[s + i])
       }
     }
+    // data.drop: mark data segment as dropped
+    DataDrop(data_idx) => self.instance.dropped_datas[data_idx] = true
     // memory.copy: copy within memory
     MemoryCopy => {
       let n = self.stack.pop_i32() // length
@@ -260,6 +270,8 @@ fn ExecContext::exec_memory_misc(
       let mem = self.store.get_mem(mem_addr)
       mem.fill(d, val.land(0xFF).to_byte(), n)
     }
+    // elem.drop: mark element segment as dropped
+    ElemDrop(elem_idx) => self.instance.dropped_elems[elem_idx] = true
     _ => raise @runtime.RuntimeError::Unreachable
   }
 }

--- a/parser/parser.mbt
+++ b/parser/parser.mbt
@@ -615,6 +615,34 @@ fn Parser::read_instruction(
         5 => I64TruncSatF32U
         6 => I64TruncSatF64S
         7 => I64TruncSatF64U
+        // Bulk memory operations
+        8 => {
+          // memory.init: data_idx, memory_idx (memory_idx must be 0)
+          let data_idx = self.read_u32()
+          let _ = self.read_byte() // memory index, must be 0
+          MemoryInit(data_idx)
+        }
+        9 => {
+          // data.drop: data_idx
+          let data_idx = self.read_u32()
+          DataDrop(data_idx)
+        }
+        10 => {
+          // memory.copy: dest_mem, src_mem (both must be 0)
+          let _ = self.read_byte() // dest memory index
+          let _ = self.read_byte() // src memory index
+          MemoryCopy
+        }
+        11 => {
+          // memory.fill: memory_idx (must be 0)
+          let _ = self.read_byte() // memory index
+          MemoryFill
+        }
+        13 => {
+          // elem.drop: elem_idx
+          let elem_idx = self.read_u32()
+          ElemDrop(elem_idx)
+        }
         _ => raise UnknownOpcode(0xFC00 + subopcode)
       }
     }

--- a/runtime/instance.mbt
+++ b/runtime/instance.mbt
@@ -10,6 +10,8 @@ pub(all) struct ModuleInstance {
   exports : Array[@types.Export]
   elem_segments : Array[@types.Element]
   data_segments : Array[@types.Data]
+  dropped_elems : Array[Bool] // true if elem segment has been dropped
+  dropped_datas : Array[Bool] // true if data segment has been dropped
 } derive(Show)
 
 ///|
@@ -24,5 +26,7 @@ pub fn ModuleInstance::new() -> ModuleInstance {
     exports: [],
     elem_segments: [],
     data_segments: [],
+    dropped_elems: [],
+    dropped_datas: [],
   }
 }

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -109,6 +109,8 @@ pub(all) struct ModuleInstance {
   exports : Array[@types.Export]
   elem_segments : Array[@types.Element]
   data_segments : Array[@types.Data]
+  dropped_elems : Array[Bool]
+  dropped_datas : Array[Bool]
 }
 fn ModuleInstance::new() -> Self
 impl Show for ModuleInstance

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -142,8 +142,10 @@ pub(all) enum Instruction {
   MemorySize
   MemoryGrow
   MemoryInit(Int)
+  DataDrop(Int)
   MemoryCopy
   MemoryFill
+  ElemDrop(Int)
   I32Const(Int)
   I64Const(Int64)
   F32Const(Float)

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -95,8 +95,10 @@ pub(all) enum Instruction {
   MemorySize
   MemoryGrow
   MemoryInit(Int) // data segment index
+  DataDrop(Int) // data segment index
   MemoryCopy
   MemoryFill
+  ElemDrop(Int) // element segment index
 
   // Numeric instructions - Constants
   I32Const(Int)


### PR DESCRIPTION
## Summary
- Add `DataDrop(Int)` and `ElemDrop(Int)` instruction variants to the types
- Track dropped segments in `ModuleInstance` with `dropped_elems`/`dropped_datas` arrays
- `memory.init` now checks for dropped segments and traps if trying to copy non-zero bytes
- Parser handles `0xFC` prefix opcodes for bulk memory operations (memory.init, data.drop, memory.copy, memory.fill, elem.drop)

## Test plan
- [x] Added test for `data.drop` - verifies dropped segments trap on non-zero init
- [x] Added test for `elem.drop` - verifies elem segment is marked as dropped
- [x] Added test for idempotent `data.drop` - verifies multiple drops are safe
- [x] All 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)