### PR TITLE
feat: implement reference type instructions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,8 +87,8 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 - [x] memory.init / memory.copy / memory.fill
 - [x] data.drop / elem.drop
 
-### 3.6 引用类型
-- [ ] ref.null / ref.is_null / ref.func
+### 3.6 引用类型 ✅
+- [x] ref.null / ref.is_null / ref.func
 
 ### 3.7 多返回值
 - [ ] 函数多返回值支持
@@ -154,4 +154,4 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 ---
 
 **当前状态**: Phase 3 进行中
-**下一步**: ref.null / ref.is_null / ref.func
+**下一步**: 函数多返回值支持

--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -96,6 +96,26 @@ fn ExecContext::exec_instr(
 
     }
 
+    // Reference type instructions
+    RefNull(ref_type) =>
+      match ref_type {
+        FuncRef => self.stack.push(Null)
+        ExternRef => self.stack.push(Null)
+        _ => raise @runtime.RuntimeError::TypeMismatch
+      }
+    RefIsNull => {
+      let value = self.stack.pop()
+      match value {
+        Null => self.stack.push(I32(1))
+        _ => self.stack.push(I32(0))
+      }
+    }
+    RefFunc(func_idx) => {
+      // Get the store address for the function
+      let func_addr = self.instance.func_addrs[func_idx]
+      self.stack.push(FuncRef(func_addr))
+    }
+
     // i32 numeric operations
     I32Add
     | I32Sub

--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -2329,3 +2329,183 @@ test "bulk memory: data.drop is idempotent" {
   let _ = call_exported_func(store, instance, "drop", [])
   inspect(instance.dropped_datas[0], content="true")
 }
+
+///|
+test "reference types: ref.null funcref" {
+  // Function: push null funcref and check if it's null
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [RefNull(@types.ValueType::FuncRef), RefIsNull],
+  }
+  let func_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "test", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    I32(n) => inspect(n, content="1") // null ref returns 1 for ref.is_null
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "reference types: ref.null externref" {
+  // Function: push null externref and check if it's null
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [RefNull(@types.ValueType::ExternRef), RefIsNull],
+  }
+  let func_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "test", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    I32(n) => inspect(n, content="1") // null ref returns 1 for ref.is_null
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "reference types: ref.func" {
+  // Function 0: returns 42
+  // Function 1: get ref to func 0 and check it's not null
+  let func0 : @types.FunctionCode = { locals: [], body: [I32Const(42)] }
+  let func1 : @types.FunctionCode = {
+    locals: [],
+    body: [RefFunc(0), RefIsNull],
+  }
+  let i32_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [i32_type],
+    imports: [],
+    funcs: [0, 0], // both have type 0
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "test", desc: @types.ExportDesc::Func(1) }],
+    start: None,
+    elems: [],
+    codes: [func0, func1],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    I32(n) => inspect(n, content="0") // non-null ref returns 0 for ref.is_null
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "reference types: ref.is_null with non-null value" {
+  // Test ref.is_null with a FuncRef value (from table)
+  // Function 0: dummy function
+  // Function 1: get funcref from table and check if null
+  let dummy_func : @types.FunctionCode = { locals: [], body: [I32Const(0)] }
+  let check_func : @types.FunctionCode = {
+    locals: [],
+    body: [I32Const(0), TableGet(0), RefIsNull], // get table[0], check if null
+  }
+  let i32_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [i32_type],
+    imports: [],
+    funcs: [0, 0],
+    tables: [
+      { elem_type: @types.ValueType::FuncRef, limits: { min: 1, max: None } },
+    ],
+    memories: [],
+    globals: [],
+    exports: [{ name: "test", desc: @types.ExportDesc::Func(1) }],
+    start: None,
+    elems: [{ table_idx: 0, offset: [I32Const(0)], init: [0] }], // table[0] = func 0
+    codes: [dummy_func, check_func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module_with_init(mod) catch {
+    _ => fail("instantiate_module_with_init failed")
+  }
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    I32(n) => inspect(n, content="0") // non-null ref returns 0
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "reference types: ref.func used with table.set" {
+  // Create function reference and store it in table, then call via call_indirect
+  // func 0: returns 100
+  // func 1: use ref.func to get reference to func 0, store in table, call via indirect
+  let target_func : @types.FunctionCode = { locals: [], body: [I32Const(100)] }
+  let test_func : @types.FunctionCode = {
+    locals: [],
+    body: [
+      I32Const(0), // table index
+      RefFunc(0), // get reference to func 0
+      TableSet(0), // table[0] = ref to func 0
+      I32Const(0), // table index for call_indirect
+      CallIndirect(0, 0),
+    ],
+  } // call table[0] with type 0
+  let i32_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [i32_type],
+    imports: [],
+    funcs: [0, 0],
+    tables: [
+      { elem_type: @types.ValueType::FuncRef, limits: { min: 1, max: None } },
+    ],
+    memories: [],
+    globals: [],
+    exports: [{ name: "test", desc: @types.ExportDesc::Func(1) }],
+    start: None,
+    elems: [],
+    codes: [target_func, test_func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  let results = call_exported_func(store, instance, "test", [])
+  match results[0] {
+    I32(n) => inspect(n, content="100") // should call func 0 and get 100
+    _ => fail("Expected I32 result")
+  }
+}

--- a/parser/parser.mbt
+++ b/parser/parser.mbt
@@ -603,6 +603,22 @@ fn Parser::read_instruction(
     0xBD => I64ReinterpretF64
     0xBE => F32ReinterpretI32
     0xBF => F64ReinterpretI64
+    // Reference type instructions
+    0xD0 => {
+      // ref.null: read reftype (0x70 = funcref, 0x6F = externref)
+      let reftype = self.read_byte()
+      match reftype {
+        0x70 => RefNull(@types.ValueType::FuncRef)
+        0x6F => RefNull(@types.ValueType::ExternRef)
+        _ => raise UnknownOpcode(0xD000 + reftype)
+      }
+    }
+    0xD1 => RefIsNull
+    0xD2 => {
+      // ref.func: read function index
+      let func_idx = self.read_u32()
+      RefFunc(func_idx)
+    }
     // Saturating truncation instructions (0xFC prefix)
     0xFC => {
       let subopcode = self.read_u32()

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -146,6 +146,9 @@ pub(all) enum Instruction {
   MemoryCopy
   MemoryFill
   ElemDrop(Int)
+  RefNull(ValueType)
+  RefIsNull
+  RefFunc(Int)
   I32Const(Int)
   I64Const(Int64)
   F32Const(Float)

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -100,6 +100,11 @@ pub(all) enum Instruction {
   MemoryFill
   ElemDrop(Int) // element segment index
 
+  // Reference type instructions
+  RefNull(ValueType) // ref.null: push null reference of given type
+  RefIsNull // ref.is_null: test if reference is null
+  RefFunc(Int) // ref.func: push reference to function by index
+
   // Numeric instructions - Constants
   I32Const(Int)
   I64Const(Int64)


### PR DESCRIPTION
## Summary
- Add `RefNull(ValueType)`, `RefIsNull`, `RefFunc(Int)` instruction variants
- Executor handles reference type instructions:
  - `ref.null`: pushes Null value for funcref/externref types
  - `ref.is_null`: tests if reference is null, pushes i32 (1 if null, 0 otherwise)
  - `ref.func`: pushes function reference by index
- Parser handles opcodes 0xD0 (ref.null), 0xD1 (ref.is_null), 0xD2 (ref.func)

## Test plan
- [x] Added test for `ref.null funcref` - verifies null funcref is recognized
- [x] Added test for `ref.null externref` - verifies null externref is recognized
- [x] Added test for `ref.func` - verifies function reference is not null
- [x] Added test for `ref.is_null` with non-null value from table
- [x] Added test for `ref.func` with `table.set` and `call_indirect`
- [x] All 71 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)