### PR TITLE
feat: implement symbol resolution for cross-module function calls

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,7 +105,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 
 ### 4.2 多模块支持
 - [x] 模块链接
-- [ ] 符号解析
+- [x] 符号解析
 
 ---
 
@@ -153,5 +153,5 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 
 ---
 
-**当前状态**: Phase 4 进行中
-**下一步**: 符号解析
+**当前状态**: Phase 5 进行中
+**下一步**: 通过官方测试套件 (wasm-testsuite)

--- a/executor/context.mbt
+++ b/executor/context.mbt
@@ -5,7 +5,7 @@
 struct ExecContext {
   stack : @runtime.Stack
   store : @runtime.Store
-  instance : @runtime.ModuleInstance
+  mut instance : @runtime.ModuleInstance // mutable for cross-module call context switching
   frames : Array[@runtime.Frame]
   mut current_frame : Int
 } derive(Show)

--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -695,6 +695,9 @@ pub fn instantiate_with_linker(
   let store = linker.get_store()
   let instance = instantiate_module_with_imports(store, mod, imports)
 
+  // Register the instance with the store for cross-module call resolution
+  let _ = store.register_instance(instance)
+
   // Initialize data segments (copy data to memory)
   for data in mod.datas {
     if instance.mem_addrs.length() > data.memory_idx {

--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -2950,9 +2950,95 @@ test "module linking: import memory from another module" {
 
 ///|
 test "module linking: three modules chain" {
-  // This test is skipped for now as it requires cross-module context switching
-  // which is a more complex feature to implement properly.
-  // The basic import/export between two modules works correctly.
-  // TODO: Implement proper cross-module call context for multi-level imports
-  inspect(true, content="true") // Skip test
+  // Module A exports add(x, y) -> x + y
+  // Module B imports add from A, exports double(x) -> add(x, x)
+  // Module C imports double from B, exports quad(x) -> double(double(x))
+  let linker = @runtime.Linker::new()
+
+  // Module A
+  let add_func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), LocalGet(1), I32Add],
+  }
+  let add_type : @types.FuncType = {
+    params: [@types.ValueType::I32, @types.ValueType::I32],
+    results: [@types.ValueType::I32],
+  }
+  let mod_a : @types.Module = {
+    types: [add_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "add", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [add_func],
+    datas: [],
+  }
+  let _ = instantiate_with_linker(linker, "math", mod_a) catch {
+    _ => fail("Failed to instantiate math")
+  }
+
+  // Module B: double(x) = add(x, x)
+  let double_func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), LocalGet(0), Call(0)],
+  } // Call imported add
+  let unary_type : @types.FuncType = {
+    params: [@types.ValueType::I32],
+    results: [@types.ValueType::I32],
+  }
+  let mod_b : @types.Module = {
+    types: [add_type, unary_type],
+    imports: [
+      { mod_name: "math", name: "add", desc: @types.ImportDesc::Func(0) },
+    ],
+    funcs: [1], // double uses unary_type
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "double", desc: @types.ExportDesc::Func(1) }],
+    start: None,
+    elems: [],
+    codes: [double_func],
+    datas: [],
+  }
+  let _ = instantiate_with_linker(linker, "utils", mod_b) catch {
+    _ => fail("Failed to instantiate utils")
+  }
+
+  // Module C: quad(x) = double(double(x))
+  let quad_func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), Call(0), Call(0)],
+  } // double(double(x))
+  let mod_c : @types.Module = {
+    types: [unary_type],
+    imports: [
+      { mod_name: "utils", name: "double", desc: @types.ImportDesc::Func(0) },
+    ],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "quad", desc: @types.ExportDesc::Func(1) }],
+    start: None,
+    elems: [],
+    codes: [quad_func],
+    datas: [],
+  }
+  let instance_c = instantiate_with_linker(linker, "app", mod_c) catch {
+    _ => fail("Failed to instantiate app")
+  }
+
+  // quad(5) = double(double(5)) = double(10) = 20
+  let results = call_exported_func(linker.get_store(), instance_c, "quad", [
+    @types.Value::I32(5),
+  ])
+  match results[0] {
+    I32(n) => inspect(n, content="20")
+    _ => fail("Expected I32 result")
+  }
 }

--- a/executor/instr_call.mbt
+++ b/executor/instr_call.mbt
@@ -18,7 +18,12 @@ fn ExecContext::exec_call(self : ExecContext, func_idx : Int) -> Unit raise {
 
   // Get the function instance and execute
   let func_inst = self.store.get_func_inst(store_addr)
-  self.call_func_inst(func_inst, args, func_type.results.length())
+  self.call_func_inst_with_context(
+    store_addr,
+    func_inst,
+    args,
+    func_type.results.length(),
+  )
 }
 
 ///|
@@ -54,11 +59,49 @@ fn ExecContext::exec_call_indirect(
 
   // Get the function instance and execute
   let func_inst = self.store.get_func_inst(store_addr)
-  self.call_func_inst(func_inst, args, expected_type.results.length())
+  self.call_func_inst_with_context(
+    store_addr,
+    func_inst,
+    args,
+    expected_type.results.length(),
+  )
 }
 
 ///|
-/// Call a function instance (WASM or host)
+/// Call a function instance with proper context switching for cross-module calls
+fn ExecContext::call_func_inst_with_context(
+  self : ExecContext,
+  store_addr : Int,
+  func_inst : @runtime.FuncInst,
+  args : Array[@types.Value],
+  num_results : Int,
+) -> Unit raise {
+  match func_inst {
+    WasmFunc(code) =>
+      // Check if this function belongs to a different module
+      match self.store.get_func_owner(store_addr) {
+        Some(owner_instance) =>
+          // Call with the owner's context
+          self.call_wasm_func_with_instance(
+            owner_instance, code, args, num_results,
+          )
+        None =>
+          // No registered owner, use current instance (backward compatibility)
+          self.call_wasm_func(code, args, num_results)
+      }
+    HostFunc(host_fn) => {
+      // Call host function directly
+      let results = host_fn(args)
+      // Push results onto the stack
+      for result in results {
+        self.stack.push(result)
+      }
+    }
+  }
+}
+
+///|
+/// Call a function instance (WASM or host) - backward compatible version
 fn ExecContext::call_func_inst(
   self : ExecContext,
   func_inst : @runtime.FuncInst,
@@ -76,6 +119,56 @@ fn ExecContext::call_func_inst(
       }
     }
   }
+}
+
+///|
+/// Call a WASM function with a specific module instance context
+fn ExecContext::call_wasm_func_with_instance(
+  self : ExecContext,
+  target_instance : @runtime.ModuleInstance,
+  func : @types.FunctionCode,
+  args : Array[@types.Value],
+  num_results : Int,
+) -> Unit raise {
+  // Create locals array: params + local variables
+  let locals : Array[@types.Value] = []
+
+  // Add parameters first
+  for arg in args {
+    locals.push(arg)
+  }
+
+  // Add local variables (initialized to default values)
+  for local_type in func.locals {
+    locals.push(
+      match local_type {
+        I32 => I32(0)
+        I64 => I64(0L)
+        F32 => F32(0.0)
+        F64 => F64(0.0)
+        FuncRef => Null
+        ExternRef => Null
+        _ => Null
+      },
+    )
+  }
+
+  // Save current instance and switch to target instance
+  let saved_instance = self.instance
+  self.instance = target_instance
+
+  // Create and push frame
+  let frame = @runtime.Frame::new(-1, locals, num_results)
+  self.push_frame(frame)
+
+  // Execute function body
+  self.exec_expr(func.body)
+
+  // Pop frame
+  self.pop_frame()
+
+  // Restore original instance
+  self.instance = saved_instance
 }
 
 ///|

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -148,6 +148,8 @@ pub struct Store {
   tables : Array[Table]
   mems : Array[Memory]
   globals : Array[GlobalInstance]
+  func_owners : Array[Int]
+  instances : Array[ModuleInstance]
 }
 fn Store::alloc_func(Self, @types.FunctionCode) -> Int
 fn Store::alloc_global(Self, GlobalInstance) -> Int
@@ -156,10 +158,12 @@ fn Store::alloc_mem(Self, Memory) -> Int
 fn Store::alloc_table(Self, Table) -> Int
 fn Store::get_func(Self, Int) -> @types.FunctionCode raise RuntimeError
 fn Store::get_func_inst(Self, Int) -> FuncInst raise RuntimeError
+fn Store::get_func_owner(Self, Int) -> ModuleInstance?
 fn Store::get_global(Self, Int) -> GlobalInstance raise RuntimeError
 fn Store::get_mem(Self, Int) -> Memory raise RuntimeError
 fn Store::get_table(Self, Int) -> Table raise RuntimeError
 fn Store::new() -> Self
+fn Store::register_instance(Self, ModuleInstance) -> Int
 impl Show for Store
 
 type Table

--- a/runtime/store.mbt
+++ b/runtime/store.mbt
@@ -5,11 +5,23 @@ pub struct Store {
   tables : Array[Table]
   mems : Array[Memory]
   globals : Array[GlobalInstance]
+  // Maps function address to its owning module instance address
+  // Used for cross-module call context switching
+  func_owners : Array[Int] // -1 means host function or not yet registered
+  // Registered module instances by their address/index
+  instances : Array[ModuleInstance]
 } derive(Show)
 
 ///|
 pub fn Store::new() -> Store {
-  { funcs: [], tables: [], mems: [], globals: [] }
+  {
+    funcs: [],
+    tables: [],
+    mems: [],
+    globals: [],
+    func_owners: [],
+    instances: [],
+  }
 }
 
 ///|
@@ -17,6 +29,7 @@ pub fn Store::new() -> Store {
 pub fn Store::alloc_func(self : Store, func : @types.FunctionCode) -> Int {
   let idx = self.funcs.length()
   self.funcs.push(FuncInst::WasmFunc(func))
+  self.func_owners.push(-1) // Owner not yet known
   idx
 }
 
@@ -28,6 +41,7 @@ pub fn Store::alloc_host_func(
 ) -> Int {
   let idx = self.funcs.length()
   self.funcs.push(FuncInst::HostFunc(func))
+  self.func_owners.push(-1) // Host functions don't have an owner
   idx
 }
 
@@ -100,4 +114,37 @@ pub fn Store::get_global(
     raise UndefinedElement
   }
   self.globals[idx]
+}
+
+///|
+/// Register a module instance and set ownership for its functions
+/// Only sets ownership for functions that don't already have an owner
+/// (imported functions already belong to their original module)
+pub fn Store::register_instance(self : Store, instance : ModuleInstance) -> Int {
+  let instance_idx = self.instances.length()
+  self.instances.push(instance)
+  // Set ownership only for functions that don't have an owner yet
+  // Imported functions will already have their owner set
+  for func_addr in instance.func_addrs {
+    if func_addr >= 0 && func_addr < self.func_owners.length() {
+      // Only set if not already owned (-1 means unowned)
+      if self.func_owners[func_addr] < 0 {
+        self.func_owners[func_addr] = instance_idx
+      }
+    }
+  }
+  instance_idx
+}
+
+///|
+/// Get the owning module instance for a function address
+pub fn Store::get_func_owner(self : Store, func_addr : Int) -> ModuleInstance? {
+  if func_addr < 0 || func_addr >= self.func_owners.length() {
+    return None
+  }
+  let owner_idx = self.func_owners[func_addr]
+  if owner_idx < 0 || owner_idx >= self.instances.length() {
+    return None
+  }
+  Some(self.instances[owner_idx])
 }


### PR DESCRIPTION
## Summary
- Add `func_owners` array in Store to track function-to-module instance mapping
- Add `instances` array in Store to maintain all registered module instances
- Add `register_instance` to register modules and set function ownership (only for unowned functions)
- Add `get_func_owner` to retrieve the owning module instance for a function address
- Make `ExecContext.instance` mutable to enable context switching during calls
- Add `call_func_inst_with_context` to switch to the correct module context before executing
- Add `call_wasm_func_with_instance` to execute functions with a specific module context
- Preserve ownership for imported functions (they retain their original module context)

This enables complex multi-module call chains like A→B→C where:
- Module A exports `add(x,y) -> x + y`
- Module B imports `add` from A, exports `double(x) -> add(x,x)`
- Module C imports `double` from B, exports `quad(x) -> double(double(x))`

When C calls quad(5), the chain correctly executes:
1. quad calls double with context switch to B
2. double calls add with context switch to A
3. Results propagate back correctly: quad(5) = 20

## Test plan
- [x] Basic import from another module (existing test)
- [x] Shared memory import between modules (existing test)
- [x] Three-module chain A→B→C with nested imports (now passing!)
- [x] All 102 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)