### PR TITLE
docs: update README quickstart to use WAT format

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -434,6 +434,30 @@
 
 ---
 
+## 2025-11-30
+
+### Git 操作规范
+
+#### 1. 不要使用 `git push -f` (force push)
+- ❌ **错误做法**: 使用 `git commit --amend` 修改已推送的 commit，然后 `git push -f`
+  ```bash
+  git commit --amend --no-edit
+  git push -f  # 强制推送，覆盖远程历史
+  ```
+- ✅ **正确做法**: 创建新的 commit 来修复问题
+  ```bash
+  git add -A
+  git commit -m "fix: mark internal types as priv in wat module"
+  git push
+  ```
+- **原因**:
+  1. 如果有人已经基于该分支工作，force push 会导致他们的历史混乱
+  2. 丢失了 commit 历史，难以追溯修改过程
+  3. 在 PR review 中无法清楚看到每次修改的内容
+- **例外**: 只有在 commit 尚未推送到远程时，才可以使用 `--amend`
+
+---
+
 ## 待补充
 
 _请在此处继续添加新的意见和建议_

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -9,6 +9,8 @@ Wasmoon is a WebAssembly interpreter written in MoonBit, targeting WebAssembly 1
 ## Features
 
 - **Binary Parser**: Full WASM binary format parsing with LEB128 decoding
+- **WAT Parser**: Parse WebAssembly Text Format to WASM modules
+- **Disassembler**: Convert WASM binary to WAT-like text format
 - **Instruction Set**: 190+ instruction variants
 - **Numeric Operations**: i32, i64, f32, f64 arithmetic, comparison, and bitwise operations
 - **Runtime**: Stack-based execution with memory, tables, and globals
@@ -24,30 +26,14 @@ moon add Milky2018/wasmoon
 ```moonbit
 ///|
 test "add function example" {
-  // Create a module with an add function
-  let mod : @types.Module = {
-    types: [
-      {
-        params: [@types.ValueType::I32, @types.ValueType::I32],
-        results: [@types.ValueType::I32],
-      },
-    ],
-    imports: [],
-    funcs: [0],
-    tables: [],
-    memories: [],
-    globals: [],
-    exports: [{ name: "add", desc: @types.ExportDesc::Func(0) }],
-    start: None,
-    elems: [],
-    codes: [
-      {
-        locals: [],
-        body: [@types.LocalGet(0), @types.LocalGet(1), @types.I32Add],
-      },
-    ],
-    datas: [],
-  }
+  // Define a module using WAT (WebAssembly Text Format)
+  let wat =
+    #|(module
+    #|  (func (export "add") (param i32 i32) (result i32)
+    #|    local.get 0
+    #|    local.get 1
+    #|    i32.add))
+  let mod = @wat.parse(wat)
 
   // Instantiate and execute
   let (store, instance) = @executor.instantiate_module(mod)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/moon.pkg.json
+++ b/moon.pkg.json
@@ -1,6 +1,7 @@
 {
   "test-import": [
     "Milky2018/wasmoon/types",
-    "Milky2018/wasmoon/executor"
+    "Milky2018/wasmoon/executor",
+    "Milky2018/wasmoon/wat"
   ]
 }


### PR DESCRIPTION
## Summary
- Replace manual Module construction with WAT text format in quickstart example
- Add WAT Parser and Disassembler to Features list
- Restore README.md symlink to README.mbt.md
- Add git push -f warning to ERRATA.md

## Changes
The quickstart example is now much cleaner and more readable:

```wat
(module
  (func (export "add") (param i32 i32) (result i32)
    local.get 0
    local.get 1
    i32.add))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)