### PR TITLE
fix: cleanup compiler warnings

### DIFF
--- a/parser/parser.mbt
+++ b/parser/parser.mbt
@@ -11,7 +11,6 @@ suberror ParserError {
   InvalidMagicNumber
   UnsupportedVersion
   InvalidValueType(Int)
-  InvalidSectionId(Int)
   LEB128TooLarge
   SectionSizeMismatch
   UnknownOpcode(Int)

--- a/runtime/frame.mbt
+++ b/runtime/frame.mbt
@@ -1,11 +1,4 @@
 ///|
-/// Label for structured control flow (blocks, loops, if)
-struct Label {
-  arity : Int // number of values to keep when branching
-  continuation : Int // instruction pointer to jump to
-} derive(Show)
-
-///|
 /// Call frame for function execution
 struct Frame {
   func_idx : Int

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -62,9 +62,6 @@ fn Imports::add_table(Self, String, String, Int) -> Unit
 fn Imports::new() -> Self
 fn Imports::resolve(Self, String, String) -> ExternVal?
 
-type Label
-impl Show for Label
-
 pub(all) struct Linker {
   store : Store
   modules : Array[(String, ModuleInstance)]

--- a/validator/pkg.generated.mbti
+++ b/validator/pkg.generated.mbti
@@ -28,13 +28,6 @@ pub(all) suberror ValidationError {
 impl Show for ValidationError
 
 // Types and methods
-type LabelInfo
-
-type LabelKind
-
-type OperandStack
-
-type ValidationContext
 
 // Type aliases
 

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -21,7 +21,7 @@ pub(all) suberror ValidationError {
 
 ///|
 /// Label information for control flow validation
-struct LabelInfo {
+priv struct LabelInfo {
   kind : LabelKind // block or loop
   block_type : @types.BlockType
   stack_height : Int // stack height when entering the block
@@ -29,14 +29,14 @@ struct LabelInfo {
 
 ///|
 /// Kind of control structure for label resolution
-enum LabelKind {
+priv enum LabelKind {
   BlockLabel // br jumps to end, uses results
   LoopLabel // br jumps to start, uses params
 }
 
 ///|
 /// Validation context for a module
-struct ValidationContext {
+priv struct ValidationContext {
   types : Array[@types.FuncType]
   funcs : Array[Int] // type indices
   tables : Array[@types.TableType]
@@ -108,7 +108,7 @@ fn ValidationContext::new(mod : @types.Module) -> ValidationContext {
 ///|
 /// Operand stack for type validation
 /// Uses Option to represent polymorphic stack (after unreachable)
-struct OperandStack {
+priv struct OperandStack {
   stack : Array[@types.ValueType]
   mut polymorphic : Bool // true after unreachable instruction
 }
@@ -956,7 +956,6 @@ fn validate_instr(
       }
       stack.set_polymorphic()
     }
-    _ => () // Other instructions not yet validated
   }
 }
 


### PR DESCRIPTION
## Summary
- Mark internal types as `priv` in validator (`LabelInfo`, `LabelKind`, `ValidationContext`, `OperandStack`)
- Remove unreachable default branch in `validate_instruction`
- Remove unused `InvalidSectionId` error variant in parser
- Remove unused `Label` type in runtime/frame

## Result
Reduces warnings from 18 to 10. Remaining warnings are for code reserved for future use:
- `stack_height` field
- `height()` function
- `reset_polymorphic()` function  
- `call_func_inst()` function
- `source_filename` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)