### PR TITLE
fix: cleanup unused code and improve test reporting

### DIFF
--- a/cmd/main/main.mbt
+++ b/cmd/main/main.mbt
@@ -195,10 +195,11 @@ async fn run_tests_internal(
   json_content : String,
   base_dir : String,
 ) -> @testsuite.TestResult raise Error {
-  let commands = @testsuite.parse_json_test_file(json_content)
+  let parsed = @testsuite.parse_json_test_file(json_content)
   let result = @testsuite.TestResult::new()
+  result.source_filename = parsed.source_filename
   let ctx = @testsuite.TestContext::new()
-  for cmd in commands {
+  for cmd in parsed.commands {
     run_test_command_async(ctx, cmd.command, cmd.line, result, base_dir)
   }
   result

--- a/executor/instr_call.mbt
+++ b/executor/instr_call.mbt
@@ -101,27 +101,6 @@ fn ExecContext::call_func_inst_with_context(
 }
 
 ///|
-/// Call a function instance (WASM or host) - backward compatible version
-fn ExecContext::call_func_inst(
-  self : ExecContext,
-  func_inst : @runtime.FuncInst,
-  args : Array[@types.Value],
-  num_results : Int,
-) -> Unit raise {
-  match func_inst {
-    WasmFunc(code) => self.call_wasm_func(code, args, num_results)
-    HostFunc(host_fn) => {
-      // Call host function directly
-      let results = host_fn(args)
-      // Push results onto the stack
-      for result in results {
-        self.stack.push(result)
-      }
-    }
-  }
-}
-
-///|
 /// Call a WASM function with a specific module instance context
 fn ExecContext::call_wasm_func_with_instance(
   self : ExecContext,

--- a/testsuite/pkg.generated.mbti
+++ b/testsuite/pkg.generated.mbti
@@ -8,7 +8,7 @@ import(
 )
 
 // Values
-fn parse_json_test_file(String) -> Array[TestCommandWithLine] raise TestRunnerError
+fn parse_json_test_file(String) -> ParsedTestFile raise TestRunnerError
 
 fn parse_test_value(TestValue) -> @types.Value
 
@@ -39,6 +39,11 @@ pub(all) struct JsonValue {
 }
 impl Show for JsonValue
 impl @json.FromJson for JsonValue
+
+pub struct ParsedTestFile {
+  source_filename : String?
+  commands : Array[TestCommandWithLine]
+}
 
 pub enum TestAction {
   Invoke(String?, String, Array[TestValue])
@@ -77,11 +82,12 @@ fn TestContext::load_module(Self, Bytes, String?) -> @runtime.ModuleInstance rai
 fn TestContext::new() -> Self
 fn TestContext::set_current_module(Self, @runtime.ModuleInstance) -> Unit
 
-pub struct TestResult {
+pub(all) struct TestResult {
   mut passed : Int
   mut failed : Int
   mut skipped : Int
   failures : Array[String]
+  mut source_filename : String?
 }
 fn TestResult::add_failed(Self, String) -> Unit
 fn TestResult::add_passed(Self) -> Unit

--- a/testsuite/runner.mbt
+++ b/testsuite/runner.mbt
@@ -82,16 +82,17 @@ pub struct TestValue {
 
 ///|
 /// Test result
-pub struct TestResult {
+pub(all) struct TestResult {
   mut passed : Int
   mut failed : Int
   mut skipped : Int
   failures : Array[String]
+  mut source_filename : String? // Source .wast filename for better error reporting
 } derive(Show)
 
 ///|
 pub fn TestResult::new() -> TestResult {
-  { passed: 0, failed: 0, skipped: 0, failures: [] }
+  { passed: 0, failed: 0, skipped: 0, failures: [], source_filename: None }
 }
 
 ///|
@@ -101,10 +102,14 @@ pub fn TestResult::add_passed(self : TestResult) -> Unit {
 }
 
 ///|
-/// Increment failed count
+/// Increment failed count with source file context
 pub fn TestResult::add_failed(self : TestResult, msg : String) -> Unit {
   self.failed += 1
-  self.failures.push(msg)
+  let full_msg = match self.source_filename {
+    Some(filename) => "[\{filename}] \{msg}"
+    None => msg
+  }
+  self.failures.push(full_msg)
 }
 
 ///|
@@ -293,10 +298,17 @@ fn json_command_to_test_command(
 }
 
 ///|
+/// Parsed test file with source filename and commands
+pub struct ParsedTestFile {
+  source_filename : String?
+  commands : Array[TestCommandWithLine]
+}
+
+///|
 /// Parse a JSON test file into a list of commands
 pub fn parse_json_test_file(
   json_content : String,
-) -> Array[TestCommandWithLine] raise TestRunnerError {
+) -> ParsedTestFile raise TestRunnerError {
   let json = @json.parse(json_content) catch {
     e => raise ParseError("JSON parse error: \{e}")
   }
@@ -307,7 +319,7 @@ pub fn parse_json_test_file(
   for jc in test_file.commands {
     commands.push(json_command_to_test_command(jc))
   }
-  commands
+  { source_filename: test_file.source_filename, commands }
 }
 
 ///|
@@ -555,10 +567,11 @@ pub fn run_json_tests(
   base_dir : String,
   read_file_fn : (String) -> Bytes raise Error,
 ) -> TestResult raise TestRunnerError {
-  let commands = parse_json_test_file(json_content)
+  let parsed = parse_json_test_file(json_content)
   let result = TestResult::new()
+  result.source_filename = parsed.source_filename
   let ctx = TestContext::new()
-  for cmd in commands {
+  for cmd in parsed.commands {
     run_test_command_with_line(ctx, cmd, result, base_dir, read_file_fn)
   }
   result

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -24,7 +24,6 @@ pub(all) suberror ValidationError {
 priv struct LabelInfo {
   kind : LabelKind // block or loop
   block_type : @types.BlockType
-  stack_height : Int // stack height when entering the block
 }
 
 ///|
@@ -163,16 +162,6 @@ fn OperandStack::pop_any(
 ///|
 fn OperandStack::set_polymorphic(self : OperandStack) -> Unit {
   self.polymorphic = true
-}
-
-///|
-fn OperandStack::height(self : OperandStack) -> Int {
-  self.stack.length()
-}
-
-///|
-fn OperandStack::reset_polymorphic(self : OperandStack) -> Unit {
-  self.polymorphic = false
 }
 
 ///|
@@ -801,11 +790,7 @@ fn validate_instr(
         block_stack.push(param)
       }
       // Push label for block (br jumps to end, uses results)
-      let label : LabelInfo = {
-        kind: BlockLabel,
-        block_type: bt,
-        stack_height: params.length(),
-      }
+      let label : LabelInfo = { kind: BlockLabel, block_type: bt }
       ctx.labels.push(label)
       // Validate body
       validate_expr(ctx, block_stack, body)
@@ -835,11 +820,7 @@ fn validate_instr(
         block_stack.push(param)
       }
       // Push label for loop (br jumps to start, uses params)
-      let label : LabelInfo = {
-        kind: LoopLabel,
-        block_type: bt,
-        stack_height: params.length(),
-      }
+      let label : LabelInfo = { kind: LoopLabel, block_type: bt }
       ctx.labels.push(label)
       // Validate body
       validate_expr(ctx, block_stack, body)
@@ -865,11 +846,7 @@ fn validate_instr(
         stack.pop(params[i])
       }
       // Push label for if (br jumps to end, uses results)
-      let label : LabelInfo = {
-        kind: BlockLabel,
-        block_type: bt,
-        stack_height: params.length(),
-      }
+      let label : LabelInfo = { kind: BlockLabel, block_type: bt }
       ctx.labels.push(label)
       // Validate then branch
       let then_stack = OperandStack::new()


### PR DESCRIPTION
## Summary
- Remove unused `stack_height` field from `LabelInfo` in validator
- Remove unused `height()` and `reset_polymorphic()` functions in validator
- Remove unused `call_func_inst` function in executor (replaced by `call_func_inst_with_context`)
- Add `source_filename` to `TestResult` for better error messages
- Test failure reports now include the source `.wast` filename

## Result
- All 167 tests pass
- Zero compiler warnings (reduced from 10)
- Better test failure diagnostics with source file context

🤖 Generated with [Claude Code](https://claude.com/claude-code)