### PR TITLE
feat: implement CFG (Control Flow Graph) for IR

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -180,14 +180,14 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 
 ---
 
-## Phase 6: 中间表示层 (IR) 🔨 进行中
+## Phase 6: 中间表示层 (IR) ✅ 已完成
 
 > 这是实现 JIT 编译器的基础，参考 [Cranelift](https://cranelift.dev/) 的设计
 
 ### 6.1 高级 IR (类似 CLIF)
 - [x] SSA (Static Single Assignment) 形式的 IR 定义
 - [x] 基本块 (Basic Block) 数据结构
-- [ ] 控制流图 (CFG) 构建
+- [x] 控制流图 (CFG) 构建
 - [x] IR 类型系统 (与 WASM 类型对应)
 - [x] IR 指令集定义
   - [x] 算术运算指令
@@ -359,8 +359,8 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 | 阶段 | 目标 | 状态 |
 |------|------|------|
 | Phase 1-5 | 完整的 WASM 解释器 | ✅ 已完成 |
-| Phase 6 | 中间表示层设计 | 🔨 下一步 |
-| Phase 7 | IR 优化 | 📋 计划中 |
+| Phase 6 | 中间表示层设计 | ✅ 已完成 |
+| Phase 7 | IR 优化 | 🔨 下一步 |
 | Phase 8-9 | 指令选择与寄存器分配 | 📋 计划中 |
 | Phase 10 | 代码生成 | 📋 计划中 |
 | Phase 11 | JIT 集成 | 📋 计划中 |
@@ -387,5 +387,5 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 
 ---
 
-**当前状态**: Phase 5 已完成，Phase 6 计划中
-**下一步**: 设计并实现中间表示层 (IR)
+**当前状态**: Phase 6 已完成，Phase 7 计划中
+**下一步**: 实现 IR 优化 (死代码消除、常量折叠等)

--- a/ir/cfg.mbt
+++ b/ir/cfg.mbt
@@ -1,0 +1,273 @@
+// Control Flow Graph (CFG) Construction and Analysis
+// Provides explicit representation of control flow relationships
+
+///|
+/// CFG - Control Flow Graph for a function
+/// Provides predecessor/successor relationships for each block
+pub(all) struct CFG {
+  // Number of blocks in the CFG
+  num_blocks : Int
+  // Successors for each block (indexed by block ID)
+  successors : Array[Array[Int]]
+  // Predecessors for each block (indexed by block ID)
+  predecessors : Array[Array[Int]]
+}
+
+///|
+/// Build a CFG from a function
+pub fn CFG::build(func : Function) -> CFG {
+  let num_blocks = func.blocks.length()
+  // Initialize empty adjacency lists
+  let successors : Array[Array[Int]] = []
+  let predecessors : Array[Array[Int]] = []
+  for i = 0; i < num_blocks; i = i + 1 {
+    successors.push([])
+    predecessors.push([])
+  }
+  // Build edges from terminators
+  for block in func.blocks {
+    match block.terminator {
+      Some(term) => {
+        let targets = get_terminator_targets(term)
+        for target in targets {
+          if target < num_blocks {
+            successors[block.id].push(target)
+            predecessors[target].push(block.id)
+          }
+        }
+      }
+      None => ()
+    }
+  }
+  { num_blocks, successors, predecessors }
+}
+
+///|
+/// Get all target blocks from a terminator
+fn get_terminator_targets(term : Terminator) -> Array[Int] {
+  match term {
+    Jump(target, _) => [target]
+    Brz(_, then_target, else_target) | Brnz(_, then_target, else_target) =>
+      [then_target, else_target]
+    BrTable(_, targets, default_target) => {
+      let result : Array[Int] = []
+      for t in targets {
+        result.push(t)
+      }
+      result.push(default_target)
+      result
+    }
+    Return(_) | Trap(_) => []
+  }
+}
+
+///|
+/// Get successors of a block
+pub fn CFG::get_successors(self : CFG, block_id : Int) -> Array[Int] {
+  if block_id >= 0 && block_id < self.num_blocks {
+    self.successors[block_id]
+  } else {
+    []
+  }
+}
+
+///|
+/// Get predecessors of a block
+pub fn CFG::get_predecessors(self : CFG, block_id : Int) -> Array[Int] {
+  if block_id >= 0 && block_id < self.num_blocks {
+    self.predecessors[block_id]
+  } else {
+    []
+  }
+}
+
+///|
+/// Check if a block has no predecessors (entry block or unreachable)
+pub fn CFG::is_entry_or_unreachable(self : CFG, block_id : Int) -> Bool {
+  if block_id >= 0 && block_id < self.num_blocks {
+    self.predecessors[block_id].length() == 0
+  } else {
+    true
+  }
+}
+
+///|
+/// Check if a block has no successors (exit block)
+pub fn CFG::is_exit_block(self : CFG, block_id : Int) -> Bool {
+  if block_id >= 0 && block_id < self.num_blocks {
+    self.successors[block_id].length() == 0
+  } else {
+    true
+  }
+}
+
+///|
+/// Perform a post-order traversal of the CFG
+/// Returns blocks in post-order (children before parents)
+pub fn CFG::postorder(self : CFG) -> Array[Int] {
+  let visited : Array[Bool] = []
+  for i = 0; i < self.num_blocks; i = i + 1 {
+    visited.push(false)
+  }
+  let result : Array[Int] = []
+  // Start from entry block (block 0)
+  if self.num_blocks > 0 {
+    postorder_visit(self, 0, visited, result)
+  }
+  result
+}
+
+///|
+/// Helper for post-order traversal
+fn postorder_visit(
+  cfg : CFG,
+  block_id : Int,
+  visited : Array[Bool],
+  result : Array[Int],
+) -> Unit {
+  if block_id < 0 || block_id >= cfg.num_blocks || visited[block_id] {
+    return
+  }
+  visited[block_id] = true
+  // Visit all successors first
+  for succ in cfg.successors[block_id] {
+    postorder_visit(cfg, succ, visited, result)
+  }
+  // Then add this block
+  result.push(block_id)
+}
+
+///|
+/// Perform a reverse post-order traversal of the CFG
+/// Returns blocks in reverse post-order (parents before children)
+/// This is useful for dataflow analysis
+pub fn CFG::reverse_postorder(self : CFG) -> Array[Int] {
+  let po = self.postorder()
+  po.rev_inplace()
+  po
+}
+
+///|
+/// Compute dominators using simple iterative algorithm
+/// Returns immediate dominator for each block (-1 for entry block)
+pub fn CFG::compute_dominators(self : CFG) -> Array[Int] {
+  let idom : Array[Int] = []
+  // Initialize all to undefined (-1)
+  for i = 0; i < self.num_blocks; i = i + 1 {
+    idom.push(-1)
+  }
+  if self.num_blocks == 0 {
+    return idom
+  }
+  // Entry block dominates itself
+  idom[0] = 0
+  // Get reverse post-order for iteration
+  let rpo = self.reverse_postorder()
+  // Iterate until fixed point
+  let mut changed = true
+  while changed {
+    changed = false
+    for block_id in rpo {
+      if block_id == 0 {
+        continue
+      }
+      // Find first processed predecessor
+      let mut new_idom = -1
+      for pred in self.predecessors[block_id] {
+        if idom[pred] != -1 {
+          if new_idom == -1 {
+            new_idom = pred
+          } else {
+            // Intersect dominators
+            new_idom = intersect_dominators(idom, new_idom, pred)
+          }
+        }
+      }
+      if new_idom != -1 && idom[block_id] != new_idom {
+        idom[block_id] = new_idom
+        changed = true
+      }
+    }
+  }
+  idom
+}
+
+///|
+/// Helper for dominator computation - find common dominator
+fn intersect_dominators(idom : Array[Int], b1_init : Int, b2_init : Int) -> Int {
+  let mut b1 = b1_init
+  let mut b2 = b2_init
+  while b1 != b2 {
+    while b1 > b2 {
+      b1 = idom[b1]
+    }
+    while b2 > b1 {
+      b2 = idom[b2]
+    }
+  }
+  b1
+}
+
+///|
+/// Check if block a dominates block b
+pub fn CFG::dominates(self : CFG, a : Int, b : Int) -> Bool {
+  let idom = self.compute_dominators()
+  if a == b {
+    return true
+  }
+  let mut current = b
+  while current != -1 && current != 0 {
+    current = idom[current]
+    if current == a {
+      return true
+    }
+  }
+  a == 0 && current == 0
+}
+
+///|
+/// Find all back edges (edges to dominators, indicating loops)
+pub fn CFG::find_back_edges(self : CFG) -> Array[(Int, Int)] {
+  let idom = self.compute_dominators()
+  let back_edges : Array[(Int, Int)] = []
+  for block_id = 0; block_id < self.num_blocks; block_id = block_id + 1 {
+    for succ in self.successors[block_id] {
+      // Check if succ dominates block_id (making this a back edge)
+      if dominates_with_idom(idom, succ, block_id) {
+        back_edges.push((block_id, succ))
+      }
+    }
+  }
+  back_edges
+}
+
+///|
+/// Helper to check domination with precomputed idom
+fn dominates_with_idom(idom : Array[Int], a : Int, b : Int) -> Bool {
+  if a == b {
+    return true
+  }
+  let mut current = b
+  while current != -1 && current != 0 {
+    current = idom[current]
+    if current == a {
+      return true
+    }
+  }
+  a == 0 && current == 0
+}
+
+///|
+/// Print CFG in DOT format for visualization
+pub fn CFG::to_dot(self : CFG, func_name : String) -> String {
+  let mut result = "digraph \{func_name} {\n"
+  result = result + "  node [shape=box];\n"
+  // Add edges
+  for block_id = 0; block_id < self.num_blocks; block_id = block_id + 1 {
+    for succ in self.successors[block_id] {
+      result = result + "  block\{block_id} -> block\{succ};\n"
+    }
+  }
+  result = result + "}\n"
+  result
+}

--- a/ir/ir_wbtest.mbt
+++ b/ir/ir_wbtest.mbt
@@ -361,3 +361,154 @@ test "validate translated function" {
   let result = validate_function(func)
   assert_true(result.valid)
 }
+
+// ============ CFG Tests ============
+
+///|
+test "cfg linear" {
+  // Simple linear CFG: block0 -> block1 -> return
+  let builder = IRBuilder::new("linear")
+  builder.add_result(Type::I32)
+  let b0 = builder.create_block()
+  let b1 = builder.create_block()
+  builder.switch_to_block(b0)
+  let c = builder.iconst_i32(42)
+  builder.jump(b1, [])
+  builder.switch_to_block(b1)
+  builder.return_([c])
+  let func = builder.get_function()
+  let cfg = CFG::build(func)
+  // Check successors
+  inspect(cfg.get_successors(0), content="[1]")
+  inspect(cfg.get_successors(1), content="[]")
+  // Check predecessors
+  inspect(cfg.get_predecessors(0), content="[]")
+  inspect(cfg.get_predecessors(1), content="[0]")
+}
+
+///|
+test "cfg branching" {
+  // Diamond CFG: block0 -> block1/block2 -> block3
+  let builder = IRBuilder::new("diamond")
+  let cond = builder.add_param(Type::I32)
+  builder.add_result(Type::I32)
+  let b0 = builder.create_block()
+  let b1 = builder.create_block()
+  let b2 = builder.create_block()
+  let b3 = builder.create_block()
+  builder.switch_to_block(b0)
+  builder.brnz(cond, b1, b2)
+  builder.switch_to_block(b1)
+  let c1 = builder.iconst_i32(1)
+  builder.jump(b3, [])
+  builder.switch_to_block(b2)
+  let c2 = builder.iconst_i32(2)
+  builder.jump(b3, [])
+  builder.switch_to_block(b3)
+  let result = builder.iconst_i32(0)
+  builder.return_([result])
+  let func = builder.get_function()
+  let cfg = CFG::build(func)
+  // Check successors
+  inspect(cfg.get_successors(0), content="[1, 2]")
+  inspect(cfg.get_successors(1), content="[3]")
+  inspect(cfg.get_successors(2), content="[3]")
+  inspect(cfg.get_successors(3), content="[]")
+  // Check predecessors
+  inspect(cfg.get_predecessors(0), content="[]")
+  inspect(cfg.get_predecessors(1), content="[0]")
+  inspect(cfg.get_predecessors(2), content="[0]")
+  inspect(cfg.get_predecessors(3), content="[1, 2]")
+  // Suppress unused variable warnings
+  ignore(c1)
+  ignore(c2)
+}
+
+///|
+test "cfg loop" {
+  // Loop CFG: block0 -> block1 -> block1/block2
+  let builder = IRBuilder::new("loop")
+  let n = builder.add_param(Type::I32)
+  builder.add_result(Type::I32)
+  let entry = builder.create_block()
+  let loop_header = builder.create_block()
+  let exit = builder.create_block()
+  builder.switch_to_block(entry)
+  let init = builder.iconst_i32(0)
+  builder.jump(loop_header, [])
+  let counter = builder.add_block_param(loop_header, Type::I32)
+  builder.switch_to_block(loop_header)
+  let cmp = builder.icmp_slt(counter, n)
+  builder.brnz(cmp, loop_header, exit)
+  builder.switch_to_block(exit)
+  builder.return_([counter])
+  let func = builder.get_function()
+  let cfg = CFG::build(func)
+  // Check back edge exists (loop_header -> loop_header)
+  let back_edges = cfg.find_back_edges()
+  inspect(back_edges, content="[(1, 1)]")
+  // Check postorder traversal
+  let po = cfg.postorder()
+  inspect(po, content="[2, 1, 0]")
+  // Suppress unused variable warnings
+  ignore(init)
+}
+
+///|
+test "cfg dominators" {
+  // Diamond CFG for dominator testing
+  let builder = IRBuilder::new("dom_test")
+  let cond = builder.add_param(Type::I32)
+  builder.add_result(Type::I32)
+  let b0 = builder.create_block()
+  let b1 = builder.create_block()
+  let b2 = builder.create_block()
+  let b3 = builder.create_block()
+  builder.switch_to_block(b0)
+  builder.brnz(cond, b1, b2)
+  builder.switch_to_block(b1)
+  builder.jump(b3, [])
+  builder.switch_to_block(b2)
+  builder.jump(b3, [])
+  builder.switch_to_block(b3)
+  let result = builder.iconst_i32(0)
+  builder.return_([result])
+  let func = builder.get_function()
+  let cfg = CFG::build(func)
+  // Compute dominators
+  let idom = cfg.compute_dominators()
+  // block0 is entry, dominates itself
+  inspect(idom[0], content="0")
+  // block1 is dominated by block0
+  inspect(idom[1], content="0")
+  // block2 is dominated by block0
+  inspect(idom[2], content="0")
+  // block3 is dominated by block0 (common dominator of b1 and b2)
+  inspect(idom[3], content="0")
+  // Check dominates function
+  assert_true(cfg.dominates(0, 3))
+  assert_false(cfg.dominates(1, 2))
+}
+
+///|
+test "cfg dot output" {
+  let builder = IRBuilder::new("dot_test")
+  builder.add_result(Type::I32)
+  let b0 = builder.create_block()
+  let b1 = builder.create_block()
+  builder.switch_to_block(b0)
+  let c = builder.iconst_i32(1)
+  builder.jump(b1, [])
+  builder.switch_to_block(b1)
+  builder.return_([c])
+  let func = builder.get_function()
+  let cfg = CFG::build(func)
+  let dot = cfg.to_dot("dot_test")
+  let expected =
+    #|digraph dot_test {
+    #|  node [shape=box];
+    #|  block0 -> block1;
+    #|}
+    #|
+  inspect(dot, content=expected)
+}

--- a/ir/pkg.generated.mbti
+++ b/ir/pkg.generated.mbti
@@ -26,6 +26,23 @@ type BlockFrame
 
 type BlockKind
 
+pub(all) struct CFG {
+  num_blocks : Int
+  successors : Array[Array[Int]]
+  predecessors : Array[Array[Int]]
+}
+fn CFG::build(Function) -> Self
+fn CFG::compute_dominators(Self) -> Array[Int]
+fn CFG::dominates(Self, Int, Int) -> Bool
+fn CFG::find_back_edges(Self) -> Array[(Int, Int)]
+fn CFG::get_predecessors(Self, Int) -> Array[Int]
+fn CFG::get_successors(Self, Int) -> Array[Int]
+fn CFG::is_entry_or_unreachable(Self, Int) -> Bool
+fn CFG::is_exit_block(Self, Int) -> Bool
+fn CFG::postorder(Self) -> Array[Int]
+fn CFG::reverse_postorder(Self) -> Array[Int]
+fn CFG::to_dot(Self, String) -> String
+
 pub enum FloatCC {
   Eq
   Ne


### PR DESCRIPTION
## Summary
- Add comprehensive CFG construction and analysis module (`ir/cfg.mbt`)
- Build CFG from IR function with predecessor/successor tracking
- Implement post-order and reverse post-order traversals for dataflow analysis
- Add dominator computation using iterative algorithm
- Implement back edge detection for loop analysis
- Generate DOT format output for visualization
- Add 5 new CFG tests covering linear, branching, loop, dominator, and DOT output

This completes Phase 6 of the roadmap (IR implementation).

## Test plan
- [x] All 118 tests pass
- [x] CFG tests cover linear, diamond (branching), and loop patterns
- [x] Dominator computation verified on diamond CFG
- [x] DOT output format validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)