### PR TITLE
refactor: replace match with if-is pattern for Option handling

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -450,6 +450,37 @@
   ```
 - **说明**: `fields()` 必须放在 `FromJson()` 的括号内
 
+#### 14. 使用 `if-is` 替代含 `None => ()` 或 `_ => ()` 的 match
+- ❌ **错误做法**: 使用 match 然后用 `_ => ()` 或 `None => ()` 忽略另一个分支
+  ```moonbit
+  match optional_value {
+    Some(value) => do_something(value)
+    None => ()
+  }
+
+  match enum_value {
+    SomeVariant(data) => process(data)
+    _ => ()
+  }
+  ```
+- ✅ **正确做法**: 使用 `if x is Pattern` 语法
+  ```moonbit
+  if optional_value is Some(value) {
+    do_something(value)
+  }
+
+  if enum_value is SomeVariant(data) {
+    process(data)
+  }
+  ```
+- ⚠️ **注意**: 多模式匹配时需要加括号
+  ```moonbit
+  if char is (Some('-') | Some('+')) {
+    // 处理符号
+  }
+  ```
+- **说明**: `if-is` 语法更简洁，避免了无意义的空分支
+
 ---
 
 ## 2025-11-30
@@ -489,3 +520,4 @@ _请在此处继续添加新的意见和建议_
 - [x] 把 README.mbt.md 中的代码块改成正确的 MoonBit 代码，使用 test block 包裹 → 已完成
 - [x] 能使用 `for-in` 循环时，不要使用 `for i = 0; i < n; i++` → 已添加到第10条
 - [x] 忽略结果的语法，不要使用 `let _ = expr`，而要使用 `ignore(expr)` 或者最好是 `expr |> ignore` → 已更新第6条并修复所有代码
+- [x] 所有 match 中出现类似 `_ => ()` 或者 `None => ()` 之类的分支，替换为 `if x is Some(subpattern)` 或者 `guard x is Some(subpattern) else { xxx }` (else 块可省略，相当于 panic) → 已添加到第14条并修复所有代码 

--- a/cmd/main/main.mbt
+++ b/cmd/main/main.mbt
@@ -560,32 +560,25 @@ fn find_exported_func_type(
 ) -> @types.FuncType? {
   for exp in mod_.exports {
     if exp.name == func_name {
-      match exp.desc {
-        Func(idx) => {
-          // Get the type index for this function
-          // Account for imported functions
-          let num_imports = count_func_imports(mod_.imports)
-          let type_idx = if idx < num_imports {
-            // It's an imported function
-            get_import_func_type_idx(mod_.imports, idx)
+      if exp.desc is Func(idx) {
+        // Get the type index for this function
+        // Account for imported functions
+        let num_imports = count_func_imports(mod_.imports)
+        let type_idx = if idx < num_imports {
+          // It's an imported function
+          get_import_func_type_idx(mod_.imports, idx)
+        } else {
+          // It's a defined function
+          let func_idx = idx - num_imports
+          if func_idx < mod_.funcs.length() {
+            Some(mod_.funcs[func_idx])
           } else {
-            // It's a defined function
-            let func_idx = idx - num_imports
-            if func_idx < mod_.funcs.length() {
-              Some(mod_.funcs[func_idx])
-            } else {
-              None
-            }
-          }
-          match type_idx {
-            Some(tidx) =>
-              if tidx < mod_.types.length() {
-                return Some(mod_.types[tidx])
-              }
-            None => ()
+            None
           }
         }
-        _ => ()
+        if type_idx is Some(tidx) && tidx < mod_.types.length() {
+          return Some(mod_.types[tidx])
+        }
       }
     }
   }
@@ -597,9 +590,8 @@ fn find_exported_func_type(
 fn count_func_imports(imports : Array[@types.Import]) -> Int {
   let mut count = 0
   for imp in imports {
-    match imp.desc {
-      Func(_) => count = count + 1
-      _ => ()
+    if imp.desc is Func(_) {
+      count = count + 1
     }
   }
   count

--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -514,32 +514,28 @@ pub fn instantiate_module_with_init(
   }
 
   // Execute start function if present
-  match mod.start {
-    Some(start_func_idx) => {
-      let ctx = ExecContext::new(store, instance)
-      (ctx.call_func(start_func_idx, []) catch {
-        BranchWith(_, _) | Return => raise @runtime.Unreachable
-        @runtime.StackUnderflow => raise @runtime.StackUnderflow
-        @runtime.StackOverflow => raise @runtime.StackOverflow
-        @runtime.TypeMismatch => raise @runtime.TypeMismatch
-        @runtime.OutOfBoundsMemoryAccess =>
-          raise @runtime.OutOfBoundsMemoryAccess
-        @runtime.OutOfBoundsTableAccess => raise @runtime.OutOfBoundsTableAccess
-        @runtime.UndefinedElement => raise @runtime.UndefinedElement
-        @runtime.UninitializedElement => raise @runtime.UninitializedElement
-        @runtime.IndirectCallTypeMismatch =>
-          raise @runtime.IndirectCallTypeMismatch
-        @runtime.DivisionByZero => raise @runtime.DivisionByZero
-        @runtime.IntegerOverflow => raise @runtime.IntegerOverflow
-        @runtime.InvalidConversion => raise @runtime.InvalidConversion
-        @runtime.Unreachable => raise @runtime.Unreachable
-        @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
-        @runtime.UnknownImport => raise @runtime.UnknownImport
-        _ => raise @runtime.Unreachable
-      })
-      |> ignore
-    }
-    None => ()
+  if mod.start is Some(start_func_idx) {
+    let ctx = ExecContext::new(store, instance)
+    (ctx.call_func(start_func_idx, []) catch {
+      BranchWith(_, _) | Return => raise @runtime.Unreachable
+      @runtime.StackUnderflow => raise @runtime.StackUnderflow
+      @runtime.StackOverflow => raise @runtime.StackOverflow
+      @runtime.TypeMismatch => raise @runtime.TypeMismatch
+      @runtime.OutOfBoundsMemoryAccess => raise @runtime.OutOfBoundsMemoryAccess
+      @runtime.OutOfBoundsTableAccess => raise @runtime.OutOfBoundsTableAccess
+      @runtime.UndefinedElement => raise @runtime.UndefinedElement
+      @runtime.UninitializedElement => raise @runtime.UninitializedElement
+      @runtime.IndirectCallTypeMismatch =>
+        raise @runtime.IndirectCallTypeMismatch
+      @runtime.DivisionByZero => raise @runtime.DivisionByZero
+      @runtime.IntegerOverflow => raise @runtime.IntegerOverflow
+      @runtime.InvalidConversion => raise @runtime.InvalidConversion
+      @runtime.Unreachable => raise @runtime.Unreachable
+      @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
+      @runtime.UnknownImport => raise @runtime.UnknownImport
+      _ => raise @runtime.Unreachable
+    })
+    |> ignore
   }
   (store, instance)
 }
@@ -792,32 +788,28 @@ pub fn instantiate_with_linker(
   }
 
   // Execute start function if present
-  match mod.start {
-    Some(start_func_idx) => {
-      let ctx = ExecContext::new(store, instance)
-      (ctx.call_func(start_func_idx, []) catch {
-        BranchWith(_, _) | Return => raise @runtime.Unreachable
-        @runtime.StackUnderflow => raise @runtime.StackUnderflow
-        @runtime.StackOverflow => raise @runtime.StackOverflow
-        @runtime.TypeMismatch => raise @runtime.TypeMismatch
-        @runtime.OutOfBoundsMemoryAccess =>
-          raise @runtime.OutOfBoundsMemoryAccess
-        @runtime.OutOfBoundsTableAccess => raise @runtime.OutOfBoundsTableAccess
-        @runtime.UndefinedElement => raise @runtime.UndefinedElement
-        @runtime.UninitializedElement => raise @runtime.UninitializedElement
-        @runtime.IndirectCallTypeMismatch =>
-          raise @runtime.IndirectCallTypeMismatch
-        @runtime.DivisionByZero => raise @runtime.DivisionByZero
-        @runtime.IntegerOverflow => raise @runtime.IntegerOverflow
-        @runtime.InvalidConversion => raise @runtime.InvalidConversion
-        @runtime.Unreachable => raise @runtime.Unreachable
-        @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
-        @runtime.UnknownImport => raise @runtime.UnknownImport
-        _ => raise @runtime.Unreachable
-      })
-      |> ignore
-    }
-    None => ()
+  if mod.start is Some(start_func_idx) {
+    let ctx = ExecContext::new(store, instance)
+    (ctx.call_func(start_func_idx, []) catch {
+      BranchWith(_, _) | Return => raise @runtime.Unreachable
+      @runtime.StackUnderflow => raise @runtime.StackUnderflow
+      @runtime.StackOverflow => raise @runtime.StackOverflow
+      @runtime.TypeMismatch => raise @runtime.TypeMismatch
+      @runtime.OutOfBoundsMemoryAccess => raise @runtime.OutOfBoundsMemoryAccess
+      @runtime.OutOfBoundsTableAccess => raise @runtime.OutOfBoundsTableAccess
+      @runtime.UndefinedElement => raise @runtime.UndefinedElement
+      @runtime.UninitializedElement => raise @runtime.UninitializedElement
+      @runtime.IndirectCallTypeMismatch =>
+        raise @runtime.IndirectCallTypeMismatch
+      @runtime.DivisionByZero => raise @runtime.DivisionByZero
+      @runtime.IntegerOverflow => raise @runtime.IntegerOverflow
+      @runtime.InvalidConversion => raise @runtime.InvalidConversion
+      @runtime.Unreachable => raise @runtime.Unreachable
+      @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
+      @runtime.UnknownImport => raise @runtime.UnknownImport
+      _ => raise @runtime.Unreachable
+    })
+    |> ignore
   }
   linker.register(name, instance)
   instance

--- a/ir/validator.mbt
+++ b/ir/validator.mbt
@@ -41,9 +41,8 @@ pub fn validate_function(func : Function) -> ValidationResult {
     for inst in block.instructions {
       validate_instruction(inst, defined_values, result)
       // Add result to defined values
-      match inst.result {
-        Some(v) => defined_values.set(v.id, v.ty)
-        None => ()
+      if inst.result is Some(v) {
+        defined_values.set(v.id, v.ty)
       }
     }
     // Validate terminator

--- a/runtime/memory.mbt
+++ b/runtime/memory.mbt
@@ -335,9 +335,8 @@ pub fn Memory::grow(self : Memory, delta : Int) -> Int {
   let new_size = old_size + delta
 
   // Check max limit
-  match self.max {
-    Some(max) => if new_size > max { return -1 }
-    None => ()
+  if self.max is Some(max) && new_size > max {
+    return -1
   }
 
   // Check absolute limit (65536 pages = 4GB)

--- a/runtime/table.mbt
+++ b/runtime/table.mbt
@@ -63,9 +63,8 @@ pub fn Table::grow(self : Table, delta : Int, init : @types.Value) -> Int {
   let new_size = old_size + delta
 
   // Check max limit
-  match self.max {
-    Some(max) => if new_size > max { return -1 }
-    None => ()
+  if self.max is Some(max) && new_size > max {
+    return -1
   }
 
   // Grow the table

--- a/testsuite/runner.mbt
+++ b/testsuite/runner.mbt
@@ -538,9 +538,8 @@ fn run_test_command_internal(
       match ctx.get_current_module() {
         Some(inst) => {
           ctx.named_modules.set(as_, inst)
-          match name {
-            Some(n) => ctx.named_modules.set(n, inst)
-            None => ()
+          if name is Some(n) {
+            ctx.named_modules.set(n, inst)
           }
         }
         None =>

--- a/wat/wat.mbt
+++ b/wat/wat.mbt
@@ -236,9 +236,8 @@ fn hex_digit_value(c : Char) -> Int? {
 fn Lexer::read_number(self : Lexer) -> String {
   let buf = StringBuilder::new()
   // Handle optional sign
-  match self.peek_char() {
-    Some('-') | Some('+') => buf.write_char(self.next_char().unwrap())
-    _ => ()
+  if self.peek_char() is (Some('-') | Some('+')) {
+    buf.write_char(self.next_char().unwrap())
   }
   // Handle 0x prefix for hex
   if self.pos + 1 < self.input.length() {
@@ -605,39 +604,33 @@ fn Parser::parse_module(self : Parser) -> @types.Module raise WatError {
             let func_idx = mod_.funcs.length()
             mod_.funcs.push(type_idx)
             mod_.codes.push(code)
-            match export_name {
-              Some(name) =>
-                mod_.exports.push({
-                  name,
-                  desc: @types.ExportDesc::Func(func_idx),
-                })
-              None => ()
+            if export_name is Some(name) {
+              mod_.exports.push({
+                name,
+                desc: @types.ExportDesc::Func(func_idx),
+              })
             }
           }
           Keyword("memory") => {
             let (mem, export_name) = self.parse_memory_def()
             let mem_idx = mod_.memories.length()
             mod_.memories.push(mem)
-            match export_name {
-              Some(name) =>
-                mod_.exports.push({
-                  name,
-                  desc: @types.ExportDesc::Memory(mem_idx),
-                })
-              None => ()
+            if export_name is Some(name) {
+              mod_.exports.push({
+                name,
+                desc: @types.ExportDesc::Memory(mem_idx),
+              })
             }
           }
           Keyword("global") => {
             let (global, export_name) = self.parse_global_def()
             let global_idx = mod_.globals.length()
             mod_.globals.push(global)
-            match export_name {
-              Some(name) =>
-                mod_.exports.push({
-                  name,
-                  desc: @types.ExportDesc::Global(global_idx),
-                })
-              None => ()
+            if export_name is Some(name) {
+              mod_.exports.push({
+                name,
+                desc: @types.ExportDesc::Global(global_idx),
+              })
             }
           }
           Keyword("export") => {
@@ -652,13 +645,11 @@ fn Parser::parse_module(self : Parser) -> @types.Module raise WatError {
             let (table, export_name) = self.parse_table_def()
             let table_idx = mod_.tables.length()
             mod_.tables.push(table)
-            match export_name {
-              Some(name) =>
-                mod_.exports.push({
-                  name,
-                  desc: @types.ExportDesc::Table(table_idx),
-                })
-              None => ()
+            if export_name is Some(name) {
+              mod_.exports.push({
+                name,
+                desc: @types.ExportDesc::Table(table_idx),
+              })
             }
           }
           Keyword("start") => {


### PR DESCRIPTION
## Summary
- Replace verbose `match` expressions containing `None => ()` or `_ => ()` with the cleaner `if x is Pattern` syntax
- Update ERRATA.md with new best practice (section 14)
- Improves code readability and follows MoonBit idioms

## Files Changed
- `executor/executor.mbt` - 2 locations (start function handling)
- `cmd/main/main.mbt` - 3 locations (export function type lookup)
- `wat/wat.mbt` - 5 locations (lexer and parser)
- `runtime/memory.mbt` - 1 location (grow max check)
- `runtime/table.mbt` - 1 location (grow max check)
- `testsuite/runner.mbt` - 1 location (register command)
- `ir/validator.mbt` - 1 location (instruction result)
- `ERRATA.md` - Added section 14 documenting the best practice

## Test plan
- [x] All 196 tests pass
- [x] `moon check` passes
- [x] Code formatted with `moon fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)