### PR TITLE
feat(vcode): implement AArch64 instruction selection with pattern matching

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -555,4 +555,4 @@ _请在此处继续添加新的意见和建议_
 - [x] 所有 match 中出现类似 `_ => ()` 或者 `None => ()` 之类的分支，替换为 `if x is Some(subpattern)` 或者 `guard x is Some(subpattern) else { xxx }` (else 块可省略，相当于 panic) → 已添加到第14条并修复所有代码
 - [x] 目前为止，vcode 模块的测试全都是白盒测试，请给出理由，否则修改部分为黑盒测试 → vcode 是编译器内部组件，无公开 API，白盒测试合理
 - [x] bench 内容现在非常贫瘠，需要丰富 → 已实现：10 大类基准测试覆盖解释器、JIT、IR、优化、VCode、寄存器分配、代码生成、运行时等
-- [x] vcode/aarch64_patterns.mbt 中有非常多的 never constructed variant. 这是怎么导致的？以后会用到吗？还是永远不会用到？ → 这些是为 AArch64 后端设计的前瞻性 API，代表 ARM64 架构的完整指令集特性（shifted operands、multiply-accumulate、addressing modes、条件码等）。当前 lowering 和 emit 路径使用更底层的函数，这些高层 enum 会在未来优化指令选择时使用
+- [x] vcode/aarch64_patterns.mbt 中有非常多的 never constructed variant. 这是怎么导致的？以后会用到吗？还是永远不会用到？ → **设计决策**：当前采用统一 VCode 方案，AArch64 特定 opcode（Madd、AddShifted 等）直接放入 `VCodeOpcode` 枚举。`aarch64_patterns.mbt` 中的 `AArch64Opcode` 是早期设计残留，应当删除。理想架构是分层设计（VCode 目标无关 → AArch64Inst 目标特定），但考虑到项目只针对 AArch64 单一目标，统一方案更务实。如未来需支持多目标，再重构为分层架构

--- a/vcode/aarch64_patterns.mbt
+++ b/vcode/aarch64_patterns.mbt
@@ -3,177 +3,33 @@
 //
 // This module provides:
 // 1. AArch64-specific pattern matching rules
-// 2. Instruction forms optimized for ARM64 (e.g., shifted operands)
-// 3. Addressing mode selection
-// 4. AArch64-specific peephole optimizations
+// 2. Rewrite result types for AArch64 instruction selection
+// 3. Helper functions for immediate validation
+//
+// Note: AArch64-specific opcodes (Madd, Msub, Mneg, AddShifted, etc.) are
+// defined in vcode.mbt as part of VCodeOpcode. This design choice keeps
+// VCode self-contained for a single target (AArch64). If multi-target support
+// is needed in the future, a separate AArch64Inst type should be introduced.
 
-// ============ AArch64 Instruction Opcodes ============
-
-///|
-/// AArch64-specific VCode opcodes
-/// These represent actual ARM64 instructions more closely
-pub enum AArch64Opcode {
-  // Arithmetic with optional shifted operand
-  AddShifted(AArch64Shift, Int) // ADD Xd, Xn, Xm, shift #amount
-  SubShifted(AArch64Shift, Int) // SUB Xd, Xn, Xm, shift #amount
-  // Arithmetic with immediate
-  AddImm(Int64) // ADD Xd, Xn, #imm
-  SubImm(Int64) // SUB Xd, Xn, #imm
-  // Logical with shifted operand
-  AndShifted(AArch64Shift, Int)
-  OrrShifted(AArch64Shift, Int)
-  EorShifted(AArch64Shift, Int)
-  // Logical with immediate
-  AndImm(Int64)
-  OrrImm(Int64)
-  EorImm(Int64)
-  // Multiply-add/subtract
-  Madd // Xd = Xa + Xn * Xm
-  Msub // Xd = Xa - Xn * Xm
-  Mneg // Xd = -(Xn * Xm)
-  // Load with addressing modes
-  LdrOffset(Int) // LDR Xd, [Xn, #offset]
-  LdrPreIndex(Int) // LDR Xd, [Xn, #offset]!
-  LdrPostIndex(Int) // LDR Xd, [Xn], #offset
-  LdrRegister(AArch64Extend) // LDR Xd, [Xn, Xm, extend]
-  // Store with addressing modes
-  StrOffset(Int) // STR Xd, [Xn, #offset]
-  StrPreIndex(Int) // STR Xd, [Xn, #offset]!
-  StrPostIndex(Int) // STR Xd, [Xn], #offset
-  StrRegister(AArch64Extend) // STR Xd, [Xn, Xm, extend]
-  // Compare and branch
-  Cbz // CBZ Xn, label
-  Cbnz // CBNZ Xn, label
-  Tbz(Int) // TBZ Xn, #bit, label
-  Tbnz(Int) // TBNZ Xn, #bit, label
-  // Conditional operations
-  Csel(AArch64Cond) // CSEL Xd, Xn, Xm, cond
-  Csinc(AArch64Cond) // CSINC Xd, Xn, Xm, cond
-  Csneg(AArch64Cond) // CSNEG Xd, Xn, Xm, cond
-  Csinv(AArch64Cond) // CSINV Xd, Xn, Xm, cond
-  // Bit manipulation
-  Ubfx(Int, Int) // UBFX Xd, Xn, #lsb, #width
-  Sbfx(Int, Int) // SBFX Xd, Xn, #lsb, #width
-  Bfi(Int, Int) // BFI Xd, Xn, #lsb, #width
-  Bfxil(Int, Int) // BFXIL Xd, Xn, #lsb, #width
-  // Move with immediate (for constant generation)
-  Movz(Int) // MOVZ Xd, #imm, LSL #shift
-  Movn(Int) // MOVN Xd, #imm, LSL #shift
-  Movk(Int) // MOVK Xd, #imm, LSL #shift
-}
+// ============ AArch64 Rule Application Results ============
 
 ///|
-/// AArch64 shift types for shifted operand instructions
-pub enum AArch64Shift {
-  Lsl // Logical shift left
-  Lsr // Logical shift right
-  Asr // Arithmetic shift right
-  Ror // Rotate right
-}
-
-///|
-/// AArch64 extend types for register operand instructions
-pub enum AArch64Extend {
-  Uxtb // Unsigned extend byte
-  Uxth // Unsigned extend halfword
-  Uxtw // Unsigned extend word
-  Uxtx // Unsigned extend doubleword (no-op for 64-bit)
-  Sxtb // Signed extend byte
-  Sxth // Signed extend halfword
-  Sxtw // Signed extend word
-  Sxtx // Signed extend doubleword (no-op for 64-bit)
-}
-
-///|
-/// AArch64 condition codes
-pub enum AArch64Cond {
-  Eq // Equal
-  Ne // Not equal
-  Cs // Carry set (unsigned >=)
-  Cc // Carry clear (unsigned <)
-  Mi // Minus/negative
-  Pl // Plus/positive or zero
-  Vs // Overflow
-  Vc // No overflow
-  Hi // Unsigned higher (>)
-  Ls // Unsigned lower or same (<=)
-  Ge // Signed greater than or equal
-  Lt // Signed less than
-  Gt // Signed greater than
-  Le // Signed less than or equal
-  Al // Always (unconditional)
-  Nv // Never (unconditional, same as AL)
-}
-
-///|
-fn AArch64Shift::to_string(self : AArch64Shift) -> String {
-  match self {
-    Lsl => "lsl"
-    Lsr => "lsr"
-    Asr => "asr"
-    Ror => "ror"
-  }
-}
-
-///|
-fn AArch64Extend::to_string(self : AArch64Extend) -> String {
-  match self {
-    Uxtb => "uxtb"
-    Uxth => "uxth"
-    Uxtw => "uxtw"
-    Uxtx => "uxtx"
-    Sxtb => "sxtb"
-    Sxth => "sxth"
-    Sxtw => "sxtw"
-    Sxtx => "sxtx"
-  }
-}
-
-///|
-fn AArch64Cond::to_string(self : AArch64Cond) -> String {
-  match self {
-    Eq => "eq"
-    Ne => "ne"
-    Cs => "cs"
-    Cc => "cc"
-    Mi => "mi"
-    Pl => "pl"
-    Vs => "vs"
-    Vc => "vc"
-    Hi => "hi"
-    Ls => "ls"
-    Ge => "ge"
-    Lt => "lt"
-    Gt => "gt"
-    Le => "le"
-    Al => "al"
-    Nv => "nv"
-  }
-}
-
-// ============ AArch64 Pattern Matching ============
-
-///|
-/// AArch64-specific pattern for matching complex instruction forms
-pub enum AArch64Pattern {
-  // Match add with shifted operand: add(x, shl(y, n))
-  AddWithShift(Int) // shift amount
-  // Match add with extend: add(x, extend(y))
-  AddWithExtend(AArch64Extend)
-  // Match multiply-accumulate: add(a, mul(b, c))
-  MultiplyAdd
-  // Match multiply-subtract: sub(a, mul(b, c))
-  MultiplySub
-  // Match negated multiply: sub(0, mul(a, b))
-  MultiplyNeg
-  // Match conditional select based on compare: select(cmp(a,b), x, y)
-  ConditionalSelect(CmpKind)
-  // Match bit field extract: and(shr(x, lsb), mask)
-  BitFieldExtract(Int, Int) // lsb, width
-  // Match compare and branch zero: brz(x, target)
-  CompareAndBranchZero
-  // Match test bit and branch: brz(and(x, 1 << n), target)
-  TestBitAndBranch(Int)
+/// Result of applying an AArch64-specific rule
+pub enum AArch64RewriteResult {
+  // Emit add with shifted operand
+  AddShifted(Int, Int, Int) // src1_idx, src2_idx, shift_amount
+  // Emit sub with shifted operand
+  SubShifted(Int, Int, Int) // src1_idx, src2_idx, shift_amount
+  // Emit multiply-add
+  Madd(Int, Int, Int) // acc_idx, src1_idx, src2_idx
+  // Emit multiply-sub
+  Msub(Int, Int, Int) // acc_idx, src1_idx, src2_idx
+  // Emit negated multiply
+  Mneg(Int, Int) // src1_idx, src2_idx
+  // Emit and/or/xor with shifted operand
+  LogicalShifted(VCodeOpcode, Int, Int, Int) // op, src1_idx, src2_idx, shift
+  // No AArch64-specific optimization applies
+  NoMatch
 }
 
 // ============ AArch64 Lowering Rules ============
@@ -181,7 +37,7 @@ pub enum AArch64Pattern {
 ///|
 /// Check if an immediate can be encoded in AArch64 add/sub instruction
 /// AArch64 allows 12-bit immediates, optionally shifted left by 12
-fn is_valid_add_imm(val : Int64) -> Bool {
+pub fn is_valid_add_imm(val : Int64) -> Bool {
   // Check if value fits in 12 bits (0-4095)
   if val >= 0L && val <= 4095L {
     return true
@@ -196,7 +52,7 @@ fn is_valid_add_imm(val : Int64) -> Bool {
 ///|
 /// Check if an immediate can be encoded in AArch64 logical instructions
 /// Uses bitmask immediate encoding (complicated pattern)
-fn is_valid_logical_imm(val : Int64) -> Bool {
+pub fn is_valid_logical_imm(val : Int64) -> Bool {
   // Simplified check - in practice this is more complex
   // AArch64 uses a special encoding for bitmask immediates
   // For now, just allow simple cases
@@ -209,7 +65,7 @@ fn is_valid_logical_imm(val : Int64) -> Bool {
 
 ///|
 /// Check if a value has consecutive 1s in binary representation
-fn is_consecutive_ones(val : Int64) -> Bool {
+pub fn is_consecutive_ones(val : Int64) -> Bool {
   if val == 0L {
     return false
   }
@@ -289,25 +145,6 @@ pub fn get_aarch64_rules() -> Array[RewriteRule] {
 }
 
 // ============ AArch64 Rule Application ============
-
-///|
-/// Result of applying an AArch64-specific rule
-pub enum AArch64RewriteResult {
-  // Emit add with shifted operand
-  AddShifted(Int, Int, Int) // src1_idx, src2_idx, shift_amount
-  // Emit sub with shifted operand
-  SubShifted(Int, Int, Int) // src1_idx, src2_idx, shift_amount
-  // Emit multiply-add
-  Madd(Int, Int, Int) // acc_idx, src1_idx, src2_idx
-  // Emit multiply-sub
-  Msub(Int, Int, Int) // acc_idx, src1_idx, src2_idx
-  // Emit negated multiply
-  Mneg(Int, Int) // src1_idx, src2_idx
-  // Emit and/or/xor with shifted operand
-  LogicalShifted(VCodeOpcode, Int, Int, Int) // op, src1_idx, src2_idx, shift
-  // No AArch64-specific optimization applies
-  NoMatch
-}
 
 ///|
 /// Apply an AArch64-specific rule
@@ -407,5 +244,5 @@ pub fn apply_aarch64_rule(
 
 ///|
 fn logical_shift_right(val : Int64, shift : Int64) -> Int64 {
-  val.reinterpret_as_uint64().shr(shift.to_int()).reinterpret_as_int64()
+  (val.reinterpret_as_uint64() >> shift.to_int()).reinterpret_as_int64()
 }

--- a/vcode/emit.mbt
+++ b/vcode/emit.mbt
@@ -221,6 +221,167 @@ pub fn emit_add_reg(mc : MachineCode, rd : Int, rn : Int, rm : Int) -> Unit {
 }
 
 ///|
+/// Encode ADD (shifted register with shift amount): ADD Xd, Xn, Xm, shift #amount
+/// Opcode: 0x8B000000 (with shift bits)
+/// shift: 00=LSL, 01=LSR, 10=ASR
+pub fn emit_add_shifted(
+  mc : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+  shift : ShiftType,
+  amount : Int,
+) -> Unit {
+  let shift_bits = match shift {
+    Lsl => 0
+    Lsr => 1
+    Asr => 2
+  }
+  let imm6 = amount & 63
+  // Encoding: sf=1 | op=0 | S=0 | 01011 | shift[1:0] | 0 | Rm | imm6 | Rn | Rd
+  let b0 = (rd & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((imm6 & 7) << 3) | ((rm & 1) << 6)
+  let b2 = ((rm >> 1) & 15) | ((shift_bits & 3) << 6)
+  let b3 = 139 // 0x8B
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode SUB (shifted register with shift amount): SUB Xd, Xn, Xm, shift #amount
+pub fn emit_sub_shifted(
+  mc : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+  shift : ShiftType,
+  amount : Int,
+) -> Unit {
+  let shift_bits = match shift {
+    Lsl => 0
+    Lsr => 1
+    Asr => 2
+  }
+  let imm6 = amount & 63
+  let b0 = (rd & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((imm6 & 7) << 3) | ((rm & 1) << 6)
+  let b2 = ((rm >> 1) & 15) | ((shift_bits & 3) << 6)
+  let b3 = 203 // 0xCB
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode AND (shifted register with shift amount): AND Xd, Xn, Xm, shift #amount
+pub fn emit_and_shifted(
+  mc : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+  shift : ShiftType,
+  amount : Int,
+) -> Unit {
+  let shift_bits = match shift {
+    Lsl => 0
+    Lsr => 1
+    Asr => 2
+  }
+  let imm6 = amount & 63
+  let b0 = (rd & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((imm6 & 7) << 3) | ((rm & 1) << 6)
+  let b2 = ((rm >> 1) & 15) | ((shift_bits & 3) << 6)
+  let b3 = 138 // 0x8A
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode ORR (shifted register with shift amount): ORR Xd, Xn, Xm, shift #amount
+pub fn emit_orr_shifted(
+  mc : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+  shift : ShiftType,
+  amount : Int,
+) -> Unit {
+  let shift_bits = match shift {
+    Lsl => 0
+    Lsr => 1
+    Asr => 2
+  }
+  let imm6 = amount & 63
+  let b0 = (rd & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((imm6 & 7) << 3) | ((rm & 1) << 6)
+  let b2 = ((rm >> 1) & 15) | ((shift_bits & 3) << 6)
+  let b3 = 170 // 0xAA
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode EOR (shifted register with shift amount): EOR Xd, Xn, Xm, shift #amount
+pub fn emit_eor_shifted(
+  mc : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+  shift : ShiftType,
+  amount : Int,
+) -> Unit {
+  let shift_bits = match shift {
+    Lsl => 0
+    Lsr => 1
+    Asr => 2
+  }
+  let imm6 = amount & 63
+  let b0 = (rd & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((imm6 & 7) << 3) | ((rm & 1) << 6)
+  let b2 = ((rm >> 1) & 15) | ((shift_bits & 3) << 6)
+  let b3 = 202 // 0xCA
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode MADD: MADD Xd, Xn, Xm, Xa (Xd = Xa + Xn * Xm)
+/// Opcode: 0x9B000000
+pub fn emit_madd(
+  mc : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+  ra : Int,
+) -> Unit {
+  // Encoding: sf=1 | 00 | 11011 | 000 | Rm | o0=0 | Ra | Rn | Rd
+  let b0 = (rd & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((ra & 31) << 3)
+  let b2 = rm & 31
+  let b3 = 155 // 0x9B
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode MSUB: MSUB Xd, Xn, Xm, Xa (Xd = Xa - Xn * Xm)
+/// Opcode: 0x9B008000
+pub fn emit_msub(
+  mc : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+  ra : Int,
+) -> Unit {
+  // Encoding: sf=1 | 00 | 11011 | 000 | Rm | o0=1 | Ra | Rn | Rd
+  let b0 = (rd & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((ra & 31) << 3) | 128 // o0=1 (bit 7)
+  let b2 = rm & 31
+  let b3 = 155 // 0x9B
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode MNEG: MNEG Xd, Xn, Xm (Xd = -(Xn * Xm)) = MSUB Xd, Xn, Xm, XZR
+/// Opcode: 0x9B00FC00
+pub fn emit_mneg(mc : MachineCode, rd : Int, rn : Int, rm : Int) -> Unit {
+  emit_msub(mc, rd, rn, rm, 31) // XZR = register 31
+}
+
+///|
 /// Encode ADD (immediate): ADD Xd, Xn, #imm12
 /// Opcode: 0x91000000
 pub fn emit_add_imm(mc : MachineCode, rd : Int, rn : Int, imm12 : Int) -> Unit {
@@ -1000,6 +1161,61 @@ fn emit_instruction(mc : MachineCode, inst : VCodeInst) -> Unit {
     }
     Extend(_) | Truncate | IntToFloat | FloatToInt => emit_nop(mc)
     Nop => emit_nop(mc)
+    // AArch64-specific: shifted operand instructions
+    AddShifted(shift, amount) => {
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      emit_add_shifted(mc, rd, rn, rm, shift, amount)
+    }
+    SubShifted(shift, amount) => {
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      emit_sub_shifted(mc, rd, rn, rm, shift, amount)
+    }
+    AndShifted(shift, amount) => {
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      emit_and_shifted(mc, rd, rn, rm, shift, amount)
+    }
+    OrShifted(shift, amount) => {
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      emit_orr_shifted(mc, rd, rn, rm, shift, amount)
+    }
+    XorShifted(shift, amount) => {
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      emit_eor_shifted(mc, rd, rn, rm, shift, amount)
+    }
+    // AArch64-specific: multiply-accumulate instructions
+    Madd => {
+      // Xd = Xa + Xn * Xm, uses: [acc, src1, src2]
+      let rd = wreg_num(inst.defs[0])
+      let ra = reg_num(inst.uses[0]) // accumulator
+      let rn = reg_num(inst.uses[1]) // multiplicand
+      let rm = reg_num(inst.uses[2]) // multiplier
+      emit_madd(mc, rd, rn, rm, ra)
+    }
+    Msub => {
+      // Xd = Xa - Xn * Xm, uses: [acc, src1, src2]
+      let rd = wreg_num(inst.defs[0])
+      let ra = reg_num(inst.uses[0]) // accumulator
+      let rn = reg_num(inst.uses[1]) // multiplicand
+      let rm = reg_num(inst.uses[2]) // multiplier
+      emit_msub(mc, rd, rn, rm, ra)
+    }
+    Mneg => {
+      // Xd = -(Xn * Xm), uses: [src1, src2]
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      emit_mneg(mc, rd, rn, rm)
+    }
   }
 }
 

--- a/vcode/lower.mbt
+++ b/vcode/lower.mbt
@@ -5,6 +5,7 @@
 // 1. Maps IR values to virtual registers
 // 2. Converts IR opcodes to VCode opcodes
 // 3. Handles control flow translation
+// 4. Performs pattern matching for AArch64-specific instructions
 
 ///|
 /// Lowering context - tracks state during IR to VCode conversion
@@ -81,6 +82,63 @@ fn ir_type_to_mem_type(ty : @ir.Type) -> MemType {
   }
 }
 
+// ============ Pattern Matching Helpers for AArch64 Instruction Selection ============
+
+///|
+/// Check if a value is defined by a shift-left instruction with a constant
+/// Returns (shifted_value, shift_amount) if matched
+fn match_shl_const_value(
+  ctx : LoweringContext,
+  value : @ir.Value,
+) -> (@ir.Value, Int)? {
+  match find_defining_inst(ctx, value) {
+    Some(inst) =>
+      if inst.opcode is @ir.Opcode::Ishl {
+        // Check if shift amount is a constant
+        let shift_operand = inst.operands[1]
+        match find_defining_inst(ctx, shift_operand) {
+          Some(shift_inst) =>
+            if shift_inst.opcode is @ir.Opcode::Iconst(amount) {
+              let shift_val = amount.to_int()
+              if shift_val >= 0 && shift_val <= 63 {
+                return Some((inst.operands[0], shift_val))
+              }
+            }
+          None => ()
+        }
+      }
+    None => ()
+  }
+  None
+}
+
+///|
+/// Check if a value is defined by a multiply instruction
+/// Returns (lhs, rhs) if matched
+fn match_mul_value(
+  ctx : LoweringContext,
+  value : @ir.Value,
+) -> (@ir.Value, @ir.Value)? {
+  match find_defining_inst(ctx, value) {
+    Some(inst) =>
+      if inst.opcode is @ir.Opcode::Imul {
+        return Some((inst.operands[0], inst.operands[1]))
+      }
+    None => ()
+  }
+  None
+}
+
+///|
+/// Check if a value is the constant 0
+fn is_const_zero_value(ctx : LoweringContext, value : @ir.Value) -> Bool {
+  match find_defining_inst(ctx, value) {
+    Some(inst) => if inst.opcode is @ir.Opcode::Iconst(val) { return val == 0L }
+    None => ()
+  }
+  false
+}
+
 ///|
 /// Lower an entire IR function to VCode
 pub fn lower_function(ir_func : @ir.Function) -> VCodeFunction {
@@ -153,17 +211,17 @@ fn lower_inst(
     @ir.Opcode::Iconst(val) => lower_iconst(ctx, inst, block, val)
     @ir.Opcode::Fconst(val) => lower_fconst(ctx, inst, block, val)
 
-    // Integer arithmetic
-    @ir.Opcode::Iadd => lower_binary_int(ctx, inst, block, Add)
-    @ir.Opcode::Isub => lower_binary_int(ctx, inst, block, Sub)
+    // Integer arithmetic - with pattern matching for AArch64
+    @ir.Opcode::Iadd => lower_iadd(ctx, inst, block)
+    @ir.Opcode::Isub => lower_isub(ctx, inst, block)
     @ir.Opcode::Imul => lower_binary_int(ctx, inst, block, Mul)
     @ir.Opcode::Sdiv => lower_binary_int(ctx, inst, block, SDiv)
     @ir.Opcode::Udiv => lower_binary_int(ctx, inst, block, UDiv)
 
-    // Bitwise operations
-    @ir.Opcode::Band => lower_binary_int(ctx, inst, block, And)
-    @ir.Opcode::Bor => lower_binary_int(ctx, inst, block, Or)
-    @ir.Opcode::Bxor => lower_binary_int(ctx, inst, block, Xor)
+    // Bitwise operations - with pattern matching for shifted operands
+    @ir.Opcode::Band => lower_band(ctx, inst, block)
+    @ir.Opcode::Bor => lower_bor(ctx, inst, block)
+    @ir.Opcode::Bxor => lower_bxor(ctx, inst, block)
     @ir.Opcode::Ishl => lower_binary_int(ctx, inst, block, Shl)
     @ir.Opcode::Sshr => lower_binary_int(ctx, inst, block, AShr)
     @ir.Opcode::Ushr => lower_binary_int(ctx, inst, block, LShr)
@@ -261,6 +319,330 @@ fn lower_binary_int(
     }
     None => ()
   }
+}
+
+// ============ AArch64-Specific Lowering with Pattern Matching ============
+
+///|
+/// Lower integer add with pattern matching for MADD and shifted operands
+/// Patterns:
+/// - add(x, mul(y, z)) -> MADD: x + y * z
+/// - add(mul(x, y), z) -> MADD: z + x * y (commutative)
+/// - add(x, shl(y, n)) -> AddShifted: x + (y << n)
+/// - add(shl(x, n), y) -> AddShifted: y + (x << n) (commutative)
+fn lower_iadd(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : VCodeBlock,
+) -> Unit {
+  guard inst.result is Some(result) else { return }
+  let dst = ctx.get_vreg(result)
+  let lhs_val = inst.operands[0]
+  let rhs_val = inst.operands[1]
+
+  // Pattern: add(x, mul(y, z)) -> MADD
+  match match_mul_value(ctx, rhs_val) {
+    Some((mul_lhs, mul_rhs)) => {
+      let acc = ctx.get_vreg(lhs_val)
+      let src1 = ctx.get_vreg(mul_lhs)
+      let src2 = ctx.get_vreg(mul_rhs)
+      let vcode_inst = VCodeInst::new(Madd)
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(acc)) // accumulator
+      vcode_inst.add_use(Virtual(src1)) // multiplicand
+      vcode_inst.add_use(Virtual(src2)) // multiplier
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Pattern: add(mul(x, y), z) -> MADD (commutative)
+  match match_mul_value(ctx, lhs_val) {
+    Some((mul_lhs, mul_rhs)) => {
+      let acc = ctx.get_vreg(rhs_val)
+      let src1 = ctx.get_vreg(mul_lhs)
+      let src2 = ctx.get_vreg(mul_rhs)
+      let vcode_inst = VCodeInst::new(Madd)
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(acc))
+      vcode_inst.add_use(Virtual(src1))
+      vcode_inst.add_use(Virtual(src2))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Pattern: add(x, shl(y, n)) -> AddShifted
+  match match_shl_const_value(ctx, rhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(lhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(AddShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Pattern: add(shl(x, n), y) -> AddShifted (commutative)
+  match match_shl_const_value(ctx, lhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(rhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(AddShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Default: regular add
+  let lhs = ctx.get_vreg(lhs_val)
+  let rhs = ctx.get_vreg(rhs_val)
+  let vcode_inst = VCodeInst::new(Add)
+  vcode_inst.add_def({ reg: Virtual(dst) })
+  vcode_inst.add_use(Virtual(lhs))
+  vcode_inst.add_use(Virtual(rhs))
+  block.add_inst(vcode_inst)
+}
+
+///|
+/// Lower integer sub with pattern matching for MSUB, MNEG, and shifted operands
+/// Patterns:
+/// - sub(x, mul(y, z)) -> MSUB: x - y * z
+/// - sub(0, mul(x, y)) -> MNEG: -(x * y)
+/// - sub(x, shl(y, n)) -> SubShifted: x - (y << n)
+fn lower_isub(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : VCodeBlock,
+) -> Unit {
+  guard inst.result is Some(result) else { return }
+  let dst = ctx.get_vreg(result)
+  let lhs_val = inst.operands[0]
+  let rhs_val = inst.operands[1]
+
+  // Pattern: sub(0, mul(x, y)) -> MNEG
+  if is_const_zero_value(ctx, lhs_val) {
+    match match_mul_value(ctx, rhs_val) {
+      Some((mul_lhs, mul_rhs)) => {
+        let src1 = ctx.get_vreg(mul_lhs)
+        let src2 = ctx.get_vreg(mul_rhs)
+        let vcode_inst = VCodeInst::new(Mneg)
+        vcode_inst.add_def({ reg: Virtual(dst) })
+        vcode_inst.add_use(Virtual(src1))
+        vcode_inst.add_use(Virtual(src2))
+        block.add_inst(vcode_inst)
+        return
+      }
+      None => ()
+    }
+  }
+
+  // Pattern: sub(x, mul(y, z)) -> MSUB
+  match match_mul_value(ctx, rhs_val) {
+    Some((mul_lhs, mul_rhs)) => {
+      let acc = ctx.get_vreg(lhs_val)
+      let src1 = ctx.get_vreg(mul_lhs)
+      let src2 = ctx.get_vreg(mul_rhs)
+      let vcode_inst = VCodeInst::new(Msub)
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(acc))
+      vcode_inst.add_use(Virtual(src1))
+      vcode_inst.add_use(Virtual(src2))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Pattern: sub(x, shl(y, n)) -> SubShifted
+  match match_shl_const_value(ctx, rhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(lhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(SubShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Default: regular sub
+  let lhs = ctx.get_vreg(lhs_val)
+  let rhs = ctx.get_vreg(rhs_val)
+  let vcode_inst = VCodeInst::new(Sub)
+  vcode_inst.add_def({ reg: Virtual(dst) })
+  vcode_inst.add_use(Virtual(lhs))
+  vcode_inst.add_use(Virtual(rhs))
+  block.add_inst(vcode_inst)
+}
+
+///|
+/// Lower bitwise AND with pattern matching for shifted operands
+fn lower_band(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : VCodeBlock,
+) -> Unit {
+  guard inst.result is Some(result) else { return }
+  let dst = ctx.get_vreg(result)
+  let lhs_val = inst.operands[0]
+  let rhs_val = inst.operands[1]
+
+  // Pattern: and(x, shl(y, n)) -> AndShifted
+  match match_shl_const_value(ctx, rhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(lhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(AndShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Pattern: and(shl(x, n), y) -> AndShifted (commutative)
+  match match_shl_const_value(ctx, lhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(rhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(AndShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Default: regular and
+  let lhs = ctx.get_vreg(lhs_val)
+  let rhs = ctx.get_vreg(rhs_val)
+  let vcode_inst = VCodeInst::new(And)
+  vcode_inst.add_def({ reg: Virtual(dst) })
+  vcode_inst.add_use(Virtual(lhs))
+  vcode_inst.add_use(Virtual(rhs))
+  block.add_inst(vcode_inst)
+}
+
+///|
+/// Lower bitwise OR with pattern matching for shifted operands
+fn lower_bor(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : VCodeBlock,
+) -> Unit {
+  guard inst.result is Some(result) else { return }
+  let dst = ctx.get_vreg(result)
+  let lhs_val = inst.operands[0]
+  let rhs_val = inst.operands[1]
+
+  // Pattern: or(x, shl(y, n)) -> OrShifted
+  match match_shl_const_value(ctx, rhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(lhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(OrShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Pattern: or(shl(x, n), y) -> OrShifted (commutative)
+  match match_shl_const_value(ctx, lhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(rhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(OrShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Default: regular or
+  let lhs = ctx.get_vreg(lhs_val)
+  let rhs = ctx.get_vreg(rhs_val)
+  let vcode_inst = VCodeInst::new(Or)
+  vcode_inst.add_def({ reg: Virtual(dst) })
+  vcode_inst.add_use(Virtual(lhs))
+  vcode_inst.add_use(Virtual(rhs))
+  block.add_inst(vcode_inst)
+}
+
+///|
+/// Lower bitwise XOR with pattern matching for shifted operands
+fn lower_bxor(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : VCodeBlock,
+) -> Unit {
+  guard inst.result is Some(result) else { return }
+  let dst = ctx.get_vreg(result)
+  let lhs_val = inst.operands[0]
+  let rhs_val = inst.operands[1]
+
+  // Pattern: xor(x, shl(y, n)) -> XorShifted
+  match match_shl_const_value(ctx, rhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(lhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(XorShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Pattern: xor(shl(x, n), y) -> XorShifted (commutative)
+  match match_shl_const_value(ctx, lhs_val) {
+    Some((shifted, amount)) => {
+      let rn = ctx.get_vreg(rhs_val)
+      let rm = ctx.get_vreg(shifted)
+      let vcode_inst = VCodeInst::new(XorShifted(Lsl, amount))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(rn))
+      vcode_inst.add_use(Virtual(rm))
+      block.add_inst(vcode_inst)
+      return
+    }
+    None => ()
+  }
+
+  // Default: regular xor
+  let lhs = ctx.get_vreg(lhs_val)
+  let rhs = ctx.get_vreg(rhs_val)
+  let vcode_inst = VCodeInst::new(Xor)
+  vcode_inst.add_def({ reg: Virtual(dst) })
+  vcode_inst.add_use(Virtual(lhs))
+  vcode_inst.add_use(Virtual(rhs))
+  block.add_inst(vcode_inst)
 }
 
 ///|

--- a/vcode/lower_wbtest.mbt
+++ b/vcode/lower_wbtest.mbt
@@ -351,3 +351,285 @@ test "lower float constant" {
     #|
   inspect(output, content=expected)
 }
+
+// ============ AArch64-Specific Instruction Selection Tests ============
+// Note: Current implementation emits both the constituent instruction (mul/shl)
+// and the fused instruction (madd/add_shifted). A future optimization pass
+// could eliminate the dead constituent instructions via dead code elimination.
+
+///|
+test "lower add(x, mul(y, z)) to madd" {
+  // Pattern: add(x, mul(y, z)) -> MADD: x + y * z
+  let builder = @ir.IRBuilder::new("madd_test")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  let z = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let mul_yz = builder.imul(y, z)
+  let result = builder.iadd(x, mul_yz)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits both mul and madd (madd consumes mul pattern, mul becomes dead code)
+  let expected =
+    #|vcode madd_test(v0:int, v1:int, v2:int) -> int {
+    #|block0:
+    #|    v3 = mul v1, v2
+    #|    v4 = madd v0, v1, v2
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "lower sub(x, mul(y, z)) to msub" {
+  // Pattern: sub(x, mul(y, z)) -> MSUB: x - y * z
+  let builder = @ir.IRBuilder::new("msub_test")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  let z = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let mul_yz = builder.imul(y, z)
+  let result = builder.isub(x, mul_yz)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits both mul and msub (msub consumes mul pattern)
+  let expected =
+    #|vcode msub_test(v0:int, v1:int, v2:int) -> int {
+    #|block0:
+    #|    v3 = mul v1, v2
+    #|    v4 = msub v0, v1, v2
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "lower sub(0, mul(x, y)) to mneg" {
+  // Pattern: sub(0, mul(x, y)) -> MNEG: -(x * y)
+  let builder = @ir.IRBuilder::new("mneg_test")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let zero = builder.iconst_i64(0L)
+  let mul_xy = builder.imul(x, y)
+  let result = builder.isub(zero, mul_xy)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits both mul and mneg
+  let expected =
+    #|vcode mneg_test(v0:int, v1:int) -> int {
+    #|block0:
+    #|    v2 = ldi 0
+    #|    v3 = mul v0, v1
+    #|    v4 = mneg v0, v1
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "lower add(x, shl(y, n)) to add_shifted" {
+  // Pattern: add(x, shl(y, n)) -> AddShifted: x + (y << n)
+  let builder = @ir.IRBuilder::new("add_shifted_test")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let shift_amt = builder.iconst_i64(3L)
+  let shl_y = builder.ishl(y, shift_amt)
+  let result = builder.iadd(x, shl_y)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits shl and add_shifted (shl becomes dead code)
+  let expected =
+    #|vcode add_shifted_test(v0:int, v1:int) -> int {
+    #|block0:
+    #|    v2 = ldi 3
+    #|    v3 = shl v1, v2
+    #|    v4 = add.lsl #3 v0, v1
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "lower sub(x, shl(y, n)) to sub_shifted" {
+  // Pattern: sub(x, shl(y, n)) -> SubShifted: x - (y << n)
+  let builder = @ir.IRBuilder::new("sub_shifted_test")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let shift_amt = builder.iconst_i64(2L)
+  let shl_y = builder.ishl(y, shift_amt)
+  let result = builder.isub(x, shl_y)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits shl and sub_shifted
+  let expected =
+    #|vcode sub_shifted_test(v0:int, v1:int) -> int {
+    #|block0:
+    #|    v2 = ldi 2
+    #|    v3 = shl v1, v2
+    #|    v4 = sub.lsl #2 v0, v1
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "lower and(x, shl(y, n)) to and_shifted" {
+  // Pattern: and(x, shl(y, n)) -> AndShifted: x & (y << n)
+  let builder = @ir.IRBuilder::new("and_shifted_test")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let shift_amt = builder.iconst_i64(4L)
+  let shl_y = builder.ishl(y, shift_amt)
+  let result = builder.band(x, shl_y)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits shl and and_shifted
+  let expected =
+    #|vcode and_shifted_test(v0:int, v1:int) -> int {
+    #|block0:
+    #|    v2 = ldi 4
+    #|    v3 = shl v1, v2
+    #|    v4 = and.lsl #4 v0, v1
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "lower or(x, shl(y, n)) to or_shifted" {
+  // Pattern: or(x, shl(y, n)) -> OrShifted: x | (y << n)
+  let builder = @ir.IRBuilder::new("or_shifted_test")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let shift_amt = builder.iconst_i64(5L)
+  let shl_y = builder.ishl(y, shift_amt)
+  let result = builder.bor(x, shl_y)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits shl and or_shifted
+  let expected =
+    #|vcode or_shifted_test(v0:int, v1:int) -> int {
+    #|block0:
+    #|    v2 = ldi 5
+    #|    v3 = shl v1, v2
+    #|    v4 = or.lsl #5 v0, v1
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "lower xor(x, shl(y, n)) to xor_shifted" {
+  // Pattern: xor(x, shl(y, n)) -> XorShifted: x ^ (y << n)
+  let builder = @ir.IRBuilder::new("xor_shifted_test")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let shift_amt = builder.iconst_i64(1L)
+  let shl_y = builder.ishl(y, shift_amt)
+  let result = builder.bxor(x, shl_y)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits shl and xor_shifted
+  let expected =
+    #|vcode xor_shifted_test(v0:int, v1:int) -> int {
+    #|block0:
+    #|    v2 = ldi 1
+    #|    v3 = shl v1, v2
+    #|    v4 = xor.lsl #1 v0, v1
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "madd commutative: add(mul(x, y), z) to madd" {
+  // Pattern: add(mul(x, y), z) -> MADD: z + x * y (commutative)
+  let builder = @ir.IRBuilder::new("madd_commutative")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  let z = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let mul_xy = builder.imul(x, y)
+  let result = builder.iadd(mul_xy, z)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits both mul and madd (with z as accumulator)
+  let expected =
+    #|vcode madd_commutative(v0:int, v1:int, v2:int) -> int {
+    #|block0:
+    #|    v3 = mul v0, v1
+    #|    v4 = madd v2, v0, v1
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}
+
+///|
+test "add_shifted commutative: add(shl(x, n), y) to add_shifted" {
+  // Pattern: add(shl(x, n), y) -> AddShifted: y + (x << n)
+  let builder = @ir.IRBuilder::new("add_shifted_commutative")
+  let x = builder.add_param(@ir.Type::I64)
+  let y = builder.add_param(@ir.Type::I64)
+  builder.add_result(@ir.Type::I64)
+  let entry = builder.create_block()
+  builder.switch_to_block(entry)
+  let shift_amt = builder.iconst_i64(3L)
+  let shl_x = builder.ishl(x, shift_amt)
+  let result = builder.iadd(shl_x, y)
+  builder.return_([result])
+  let vcode_func = lower_function(builder.get_function())
+  let output = vcode_func.print()
+  // Emits shl and add_shifted with y as base (commutative)
+  let expected =
+    #|vcode add_shifted_commutative(v0:int, v1:int) -> int {
+    #|block0:
+    #|    v2 = ldi 3
+    #|    v3 = shl v0, v2
+    #|    v4 = add.lsl #3 v1, v0
+    #|    ret v4
+    #|}
+    #|
+  inspect(output, content=expected)
+}

--- a/vcode/pkg.generated.mbti
+++ b/vcode/pkg.generated.mbti
@@ -63,7 +63,11 @@ fn emit_add_imm(MachineCode, Int, Int, Int) -> Unit
 
 fn emit_add_reg(MachineCode, Int, Int, Int) -> Unit
 
+fn emit_add_shifted(MachineCode, Int, Int, Int, ShiftType, Int) -> Unit
+
 fn emit_and_reg(MachineCode, Int, Int, Int) -> Unit
+
+fn emit_and_shifted(MachineCode, Int, Int, Int, ShiftType, Int) -> Unit
 
 fn emit_asr_reg(MachineCode, Int, Int, Int) -> Unit
 
@@ -84,6 +88,8 @@ fn emit_cmp_reg(MachineCode, Int, Int) -> Unit
 fn emit_cset(MachineCode, Int, Int) -> Unit
 
 fn emit_eor_reg(MachineCode, Int, Int, Int) -> Unit
+
+fn emit_eor_shifted(MachineCode, Int, Int, Int, ShiftType, Int) -> Unit
 
 fn emit_fadd_d(MachineCode, Int, Int, Int) -> Unit
 
@@ -115,17 +121,25 @@ fn emit_lsl_reg(MachineCode, Int, Int, Int) -> Unit
 
 fn emit_lsr_reg(MachineCode, Int, Int, Int) -> Unit
 
+fn emit_madd(MachineCode, Int, Int, Int, Int) -> Unit
+
+fn emit_mneg(MachineCode, Int, Int, Int) -> Unit
+
 fn emit_mov_reg(MachineCode, Int, Int) -> Unit
 
 fn emit_movk(MachineCode, Int, Int, Int) -> Unit
 
 fn emit_movz(MachineCode, Int, Int, Int) -> Unit
 
+fn emit_msub(MachineCode, Int, Int, Int, Int) -> Unit
+
 fn emit_mul(MachineCode, Int, Int, Int) -> Unit
 
 fn emit_nop(MachineCode) -> Unit
 
 fn emit_orr_reg(MachineCode, Int, Int, Int) -> Unit
+
+fn emit_orr_shifted(MachineCode, Int, Int, Int, ShiftType, Int) -> Unit
 
 fn emit_ret(MachineCode, Int) -> Unit
 
@@ -145,11 +159,19 @@ fn emit_sub_imm(MachineCode, Int, Int, Int) -> Unit
 
 fn emit_sub_reg(MachineCode, Int, Int, Int) -> Unit
 
+fn emit_sub_shifted(MachineCode, Int, Int, Int, ShiftType, Int) -> Unit
+
 fn emit_udiv(MachineCode, Int, Int, Int) -> Unit
 
 fn get_aarch64_rules() -> Array[RewriteRule]
 
 fn get_optimization_rules() -> Array[RewriteRule]
+
+fn is_consecutive_ones(Int64) -> Bool
+
+fn is_valid_add_imm(Int64) -> Bool
+
+fn is_valid_logical_imm(Int64) -> Bool
 
 fn lower_function(@ir.Function) -> VCodeFunction
 
@@ -169,87 +191,6 @@ pub(all) struct AArch64 {
 }
 fn AArch64::new() -> Self
 impl TargetISA for AArch64
-
-pub enum AArch64Cond {
-  Eq
-  Ne
-  Cs
-  Cc
-  Mi
-  Pl
-  Vs
-  Vc
-  Hi
-  Ls
-  Ge
-  Lt
-  Gt
-  Le
-  Al
-  Nv
-}
-
-pub enum AArch64Extend {
-  Uxtb
-  Uxth
-  Uxtw
-  Uxtx
-  Sxtb
-  Sxth
-  Sxtw
-  Sxtx
-}
-
-pub enum AArch64Opcode {
-  AddShifted(AArch64Shift, Int)
-  SubShifted(AArch64Shift, Int)
-  AddImm(Int64)
-  SubImm(Int64)
-  AndShifted(AArch64Shift, Int)
-  OrrShifted(AArch64Shift, Int)
-  EorShifted(AArch64Shift, Int)
-  AndImm(Int64)
-  OrrImm(Int64)
-  EorImm(Int64)
-  Madd
-  Msub
-  Mneg
-  LdrOffset(Int)
-  LdrPreIndex(Int)
-  LdrPostIndex(Int)
-  LdrRegister(AArch64Extend)
-  StrOffset(Int)
-  StrPreIndex(Int)
-  StrPostIndex(Int)
-  StrRegister(AArch64Extend)
-  Cbz
-  Cbnz
-  Tbz(Int)
-  Tbnz(Int)
-  Csel(AArch64Cond)
-  Csinc(AArch64Cond)
-  Csneg(AArch64Cond)
-  Csinv(AArch64Cond)
-  Ubfx(Int, Int)
-  Sbfx(Int, Int)
-  Bfi(Int, Int)
-  Bfxil(Int, Int)
-  Movz(Int)
-  Movn(Int)
-  Movk(Int)
-}
-
-pub enum AArch64Pattern {
-  AddWithShift(Int)
-  AddWithExtend(AArch64Extend)
-  MultiplyAdd
-  MultiplySub
-  MultiplyNeg
-  ConditionalSelect(CmpKind)
-  BitFieldExtract(Int, Int)
-  CompareAndBranchZero
-  TestBitAndBranch(Int)
-}
 
 pub(all) struct AArch64Regs {
   placeholder : Int
@@ -282,13 +223,6 @@ pub enum AArch64RewriteResult {
   Mneg(Int, Int)
   LogicalShifted(VCodeOpcode, Int, Int, Int)
   NoMatch
-}
-
-pub enum AArch64Shift {
-  Lsl
-  Lsr
-  Asr
-  Ror
 }
 
 pub(all) struct AArch64StackFrame {
@@ -627,6 +561,13 @@ pub(all) struct RewriteRule {
   priority : Int
 }
 
+pub(all) enum ShiftType {
+  Lsl
+  Lsr
+  Asr
+}
+impl Show for ShiftType
+
 pub(all) struct SpillInfo {
   vreg : VReg
   slot : Int
@@ -785,6 +726,14 @@ pub enum VCodeOpcode {
   IntToFloat
   FloatToInt
   Nop
+  AddShifted(ShiftType, Int)
+  SubShifted(ShiftType, Int)
+  AndShifted(ShiftType, Int)
+  OrShifted(ShiftType, Int)
+  XorShifted(ShiftType, Int)
+  Madd
+  Msub
+  Mneg
 }
 impl Show for VCodeOpcode
 

--- a/vcode/vcode.mbt
+++ b/vcode/vcode.mbt
@@ -233,6 +233,28 @@ pub impl Show for VCodeInst with output(self, logger) {
 }
 
 ///|
+/// Shift type for shifted operand instructions
+pub(all) enum ShiftType {
+  Lsl // Logical shift left
+  Lsr // Logical shift right
+  Asr // Arithmetic shift right
+}
+
+///|
+fn ShiftType::to_string(self : ShiftType) -> String {
+  match self {
+    Lsl => "lsl"
+    Lsr => "lsr"
+    Asr => "asr"
+  }
+}
+
+///|
+pub impl Show for ShiftType with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+///|
 /// VCode opcode - machine-level operation (target-independent subset)
 pub enum VCodeOpcode {
   // Integer arithmetic
@@ -270,6 +292,17 @@ pub enum VCodeOpcode {
   FloatToInt
   // Special
   Nop
+  // AArch64-specific: shifted operand instructions
+  // These combine an arithmetic/logical op with a shift in one instruction
+  AddShifted(ShiftType, Int) // ADD Xd, Xn, Xm, shift #amount
+  SubShifted(ShiftType, Int) // SUB Xd, Xn, Xm, shift #amount
+  AndShifted(ShiftType, Int) // AND Xd, Xn, Xm, shift #amount
+  OrShifted(ShiftType, Int) // ORR Xd, Xn, Xm, shift #amount
+  XorShifted(ShiftType, Int) // EOR Xd, Xn, Xm, shift #amount
+  // AArch64-specific: multiply-accumulate instructions
+  Madd // Xd = Xa + Xn * Xm (3 uses: acc, src1, src2)
+  Msub // Xd = Xa - Xn * Xm (3 uses: acc, src1, src2)
+  Mneg // Xd = -(Xn * Xm) (2 uses: src1, src2)
 }
 
 ///|
@@ -302,6 +335,15 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     IntToFloat => "i2f"
     FloatToInt => "f2i"
     Nop => "nop"
+    // AArch64-specific
+    AddShifted(shift, amount) => "add.\{shift} #\{amount}"
+    SubShifted(shift, amount) => "sub.\{shift} #\{amount}"
+    AndShifted(shift, amount) => "and.\{shift} #\{amount}"
+    OrShifted(shift, amount) => "or.\{shift} #\{amount}"
+    XorShifted(shift, amount) => "xor.\{shift} #\{amount}"
+    Madd => "madd"
+    Msub => "msub"
+    Mneg => "mneg"
   }
 }
 


### PR DESCRIPTION
## Summary
- Add AArch64-specific VCode opcodes: Madd, Msub, Mneg, AddShifted, SubShifted, AndShifted, OrShifted, XorShifted
- Implement pattern matching in lowering phase to detect optimizable patterns and generate efficient fused instructions
- Clean up aarch64_patterns.mbt by removing unused enum definitions
- Add 10 whitebox tests for instruction selection patterns

## Test plan
- [x] All 412 tests pass
- [x] New instruction selection tests cover madd, msub, mneg, and shifted operand patterns
- [x] Commutative pattern matching verified (e.g., add(mul(x,y), z) and add(z, mul(x,y)))

🤖 Generated with [Claude Code](https://claude.com/claude-code)