### PR TITLE
feat(wat): support folded form syntax for if expressions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -122,6 +122,8 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 ### 5.2 工具链
 - [x] WASM 反汇编器
 - [x] WAT 文本格式支持
+  - [x] 基本 WAT 解析 (flat form)
+  - [x] WAT folded form 语法支持 (then/else keywords in if expressions)
 
 ### 5.3 命令行工具 (对齐 wasmtime CLI)
 

--- a/wat/wat.mbt
+++ b/wat/wat.mbt
@@ -901,10 +901,11 @@ fn Parser::parse_instructions(
   while self.current != RParen && self.current != Eof {
     match self.current {
       LParen => {
-        // Folded instruction
+        // Folded instruction - may produce multiple instructions
         self.advance()
-        let instr = self.parse_folded_instruction()
-        instrs.push(instr)
+        for instr in self.parse_folded_instructions() {
+          instrs.push(instr)
+        }
       }
       Keyword(kw) => {
         // Stop on control flow terminators (they are handled by the caller)
@@ -921,24 +922,92 @@ fn Parser::parse_instructions(
 }
 
 ///|
-fn Parser::parse_folded_instruction(
+/// Parse a folded instruction and return all resulting instructions.
+/// For most instructions, returns a single instruction.
+/// For folded `if`, returns condition instructions followed by the if instruction.
+fn Parser::parse_folded_instructions(
   self : Parser,
-) -> @types.Instruction raise WatError {
+) -> Array[@types.Instruction] raise WatError {
   match self.current {
     Keyword(kw) => {
+      // Special handling for "if" in folded form
+      if kw == "if" {
+        self.advance() // skip "if"
+        let bt = self.parse_block_type()
+        let result : Array[@types.Instruction] = []
+        // In folded form, condition operands come first as nested S-expressions
+        while self.current == LParen {
+          // Peek ahead to see if this is (then ...) or (else ...)
+          let saved = self.lexer.pos
+          self.advance()
+          match self.current {
+            Keyword("then") | Keyword("else") => {
+              // Restore and break to handle then/else
+              self.lexer.pos = saved
+              self.current = LParen
+              break
+            }
+            _ => {
+              // Restore to parse as folded operand (condition)
+              self.lexer.pos = saved
+              self.current = LParen
+              self.advance()
+              for instr in self.parse_folded_instructions() {
+                result.push(instr)
+              }
+            }
+          }
+        }
+        // Now parse (then ...) and optionally (else ...)
+        let mut then_body : Array[@types.Instruction] = []
+        let mut else_body : Array[@types.Instruction] = []
+        if self.current == LParen {
+          self.advance()
+          match self.current {
+            Keyword("then") => {
+              self.advance()
+              then_body = self.parse_instructions()
+              self.expect_rparen()
+            }
+            _ => raise UnexpectedToken("expected 'then' in folded if")
+          }
+        }
+        if self.current == LParen {
+          let saved = self.lexer.pos
+          self.advance()
+          match self.current {
+            Keyword("else") => {
+              self.advance()
+              else_body = self.parse_instructions()
+              self.expect_rparen()
+            }
+            _ => {
+              self.lexer.pos = saved
+              self.current = LParen
+            }
+          }
+        }
+        self.expect_rparen() // close if
+        result.push(@types.Instruction::If(bt, then_body, else_body))
+        return result
+      }
       let instr = self.parse_plain_instruction(kw)
       // For control instructions, we've already handled them
       // For other instructions, parse folded operands
       match instr {
-        Block(_, _) | Loop(_, _) | If(_, _, _) => instr
+        Block(_, _) | Loop(_, _) | If(_, _, _) => [instr]
         _ => {
-          // Parse nested folded instructions
+          // Parse nested folded instructions (operands)
+          let result : Array[@types.Instruction] = []
           while self.current == LParen {
             self.advance()
-            self.parse_folded_instruction() |> ignore
+            for i in self.parse_folded_instructions() {
+              result.push(i)
+            }
           }
           self.expect_rparen()
-          instr
+          result.push(instr)
+          result
         }
       }
     }
@@ -970,6 +1039,7 @@ fn Parser::parse_plain_instruction(
     }
     "if" => {
       let bt = self.parse_block_type()
+      // Flat form: if (result type) ... else ... end
       let then_body = self.parse_instructions()
       let else_body : Array[@types.Instruction] = if self.current ==
         Keyword("else") {


### PR DESCRIPTION
## Summary
- Add support for WAT folded form if-then-else syntax
- Parser now handles `(if (result type) (condition) (then ...) (else ...))` format
- Condition operands are correctly extracted as instructions preceding the if statement

## Example
```wat
;; Folded form (now supported)
(if (result i32)
    (i32.gt_s (local.get 0) (local.get 1))
    (then (local.get 0))
    (else (local.get 1)))

;; Automatically converted to flat form internally
local.get 0
local.get 1
i32.gt_s
if (result i32)
  local.get 0
else
  local.get 1
end
```

## Test plan
- [x] All 418 existing tests pass
- [x] Runtime execution verified with max/abs functions
- [x] `moon check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)