### PR TITLE
feat(cli): add objdump command for inspecting .cwasm files

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,9 +153,9 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 - [x] `explore` - 探索 WASM 编译过程
   - [x] 显示编译各阶段输出 (WASM → IR → VCode → 寄存器分配)
   - [ ] 输出 HTML 报告 (可选，未来增强)
-- [ ] `objdump` - 检查预编译的 `.cwasm` 文件
-  - [ ] 显示元数据
-  - [ ] 显示段信息
+- [x] `objdump` - 检查预编译的 `.cwasm` 文件
+  - [x] 显示元数据
+  - [x] 显示段信息
 
 #### 配置与调试选项
 - [ ] `-O, --optimize <KEY=VAL>` 优化选项

--- a/cwasm/cwasm.mbt
+++ b/cwasm/cwasm.mbt
@@ -258,6 +258,13 @@ fn string_to_bytes(s : String) -> Array[Int] {
 pub suberror DeserializeError String
 
 ///|
+pub impl Show for DeserializeError with output(self, logger) {
+  match self {
+    DeserializeError(msg) => logger.write_string(msg)
+  }
+}
+
+///|
 /// Deserialize a precompiled module from bytes
 pub fn deserialize(
   bytes : Array[Int],

--- a/cwasm/pkg.generated.mbti
+++ b/cwasm/pkg.generated.mbti
@@ -14,6 +14,7 @@ fn x86_64_target() -> TargetArch
 
 // Errors
 pub suberror DeserializeError String
+impl Show for DeserializeError
 
 // Types and methods
 type ByteReader

--- a/main/main.mbt
+++ b/main/main.mbt
@@ -914,6 +914,100 @@ fn format_func_type(ft : @types.FuncType) -> String {
 }
 
 ///|
+/// Inspect a precompiled .cwasm file
+async fn run_objdump(cwasm_path : String) -> Unit {
+  println("Inspecting: \{cwasm_path}")
+  println("=".repeat(60))
+
+  // Read the file
+  let data = @fs.read_file(cwasm_path) catch {
+    e => {
+      println("Error reading file: \{e}")
+      return
+    }
+  }
+  let bytes_raw = data.binary()
+
+  // Convert Bytes to Array[Int]
+  let bytes : Array[Int] = []
+  for i in 0..<bytes_raw.length() {
+    bytes.push(bytes_raw[i].to_int())
+  }
+
+  // Deserialize the precompiled module
+  let precompiled = @cwasm.deserialize(bytes) catch {
+    e => {
+      println("Error parsing cwasm: \{e}")
+      return
+    }
+  }
+
+  // Display metadata
+  println("")
+  println("== Metadata ==")
+  println("  Format:       cwasm")
+  println("  Version:      \{precompiled.version}")
+  println("  Target:       \{precompiled.target}")
+  println("  Functions:    \{precompiled.functions.length()}")
+  println("")
+
+  // Calculate total code size
+  let mut total_code_size = 0
+  for func in precompiled.functions {
+    total_code_size = total_code_size + func.code.length()
+  }
+  println("  Total code:   \{total_code_size} bytes")
+  println("")
+
+  // Display section info
+  println("== Functions ==")
+  if precompiled.functions.length() == 0 {
+    println("  (no compiled functions)")
+  } else {
+    for func in precompiled.functions {
+      println("")
+      println("  Function \{func.func_idx}:")
+      println("    Name:         \{func.name}")
+      println("    Code size:    \{func.code.length()} bytes")
+      println("    Frame size:   \{func.frame_size} bytes")
+      println("    Entry offset: \{func.entry_offset}")
+
+      // Show first few bytes of code as hex
+      if func.code.length() > 0 {
+        let hex_preview = StringBuilder::new()
+        let preview_len = if func.code.length() > 16 {
+          16
+        } else {
+          func.code.length()
+        }
+        for i in 0..<preview_len {
+          if i > 0 {
+            hex_preview.write_string(" ")
+          }
+          let b = func.code[i]
+          hex_preview.write_string(to_hex_byte(b))
+        }
+        if func.code.length() > 16 {
+          hex_preview.write_string(" ...")
+        }
+        println("    Code preview: \{hex_preview.to_string()}")
+      }
+    }
+  }
+  println("")
+  println("=".repeat(60))
+}
+
+///|
+fn to_hex_byte(b : Int) -> String {
+  let hex_chars = "0123456789abcdef"
+  let high = (b >> 4) & 0xF
+  let low = b & 0xF
+  String::make(1, hex_chars[high].unsafe_to_char()) +
+  String::make(1, hex_chars[low].unsafe_to_char())
+}
+
+///|
 /// Run a WAST test script
 async fn run_wast(wast_path : String) -> Unit {
   println("Running WAST script: \{wast_path}")
@@ -1347,6 +1441,9 @@ async fn main {
           ),
         },
       ),
+      "objdump": @clap.SubCommand::new(help="Inspect precompiled .cwasm file", args={
+        "file": @clap.Arg::positional(help="Path to .cwasm file"),
+      }),
     },
   )
   let help_msg = parser.gen_help_message(["wasmoon"], {})
@@ -1474,6 +1571,14 @@ async fn main {
                   None => None
                 }
                 run_explore(positional[0], func_idx)
+              } else {
+                println("Error: missing file argument")
+              }
+            }
+            "objdump" => {
+              let positional = sub.positional_args
+              if positional.length() > 0 {
+                run_objdump(positional[0])
               } else {
                 println("Error: missing file argument")
               }


### PR DESCRIPTION
## Summary
- Add `objdump` subcommand to inspect precompiled `.cwasm` files
- Display format metadata (version, target architecture)
- Show function count and total code size
- List each compiled function with details (name, code size, frame size, entry offset)
- Show hex preview of machine code

## Example
```
$ wasmoon objdump test.cwasm
Inspecting: test.cwasm
============================================================

== Metadata ==
  Format:       cwasm
  Version:      1
  Target:       aarch64
  Functions:    0

  Total code:   0 bytes

== Functions ==
  (no compiled functions)

============================================================
```

## Test plan
- [x] All 418 tests pass
- [x] `moon check` passes
- [x] Manual testing with compiled .cwasm files

🤖 Generated with [Claude Code](https://claude.com/claude-code)