### PR TITLE
feat(cli): add settings command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -174,7 +174,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 #### 辅助命令
 - [ ] `config` - 配置管理
   - [ ] `--config <FILE>` 使用 TOML 配置文件
-- [ ] `settings` - 显示可用的编译器设置
+- [x] `settings` - 显示可用的编译器设置
 - [ ] `completion` - 生成 shell 补全脚本
   - [ ] 支持 bash, zsh, fish
 

--- a/main/main.mbt
+++ b/main/main.mbt
@@ -1013,6 +1013,49 @@ fn to_hex_byte(b : Int) -> String {
 }
 
 ///|
+/// Display available compiler settings
+fn run_settings() -> Unit {
+  println("Wasmoon Compiler Settings")
+  println("=".repeat(60))
+  println("")
+  println("== Optimization Levels (-O) ==")
+  println("  0  No optimization")
+  println("     - Fastest compilation, easiest debugging")
+  println("     - IR is not modified after translation")
+  println("")
+  println("  1  Basic optimizations")
+  println("     - Constant folding")
+  println("     - Copy propagation")
+  println("     - Common subexpression elimination (CSE)")
+  println("     - Dead code elimination (DCE)")
+  println("")
+  println("  2  Default optimizations (default)")
+  println("     - All O1 optimizations, plus:")
+  println("     - Branch simplification")
+  println("     - Unreachable code elimination")
+  println("     - Basic block merging")
+  println("     - Jump threading")
+  println("")
+  println("  3  Aggressive optimizations")
+  println("     - All O2 optimizations, plus:")
+  println("     - Loop invariant code motion (LICM)")
+  println("     - Loop unrolling (factor 2)")
+  println("     - Strength reduction (mul/div by power of 2)")
+  println("")
+  println("== Target Architectures ==")
+  println("  aarch64  ARM 64-bit (default)")
+  println("  x86_64   Intel/AMD 64-bit (planned)")
+  println("")
+  println("== File Formats ==")
+  println("  .wasm   WebAssembly binary format")
+  println("  .wat    WebAssembly text format")
+  println("  .wast   WebAssembly test script format")
+  println("  .cwasm  Precompiled WebAssembly module")
+  println("")
+  println("=".repeat(60))
+}
+
+///|
 /// Run a WAST test script
 async fn run_wast(wast_path : String) -> Unit {
   println("Running WAST script: \{wast_path}")
@@ -1450,6 +1493,9 @@ async fn main {
       "objdump": @clap.SubCommand::new(help="Inspect precompiled .cwasm file", args={
         "file": @clap.Arg::positional(help="Path to .cwasm file"),
       }),
+      "settings": @clap.SubCommand::new(
+        help="Display available compiler settings",
+      ),
     },
   )
   let help_msg = parser.gen_help_message(["wasmoon"], {})
@@ -1600,6 +1646,7 @@ async fn main {
                 println("Error: missing file argument")
               }
             }
+            "settings" => run_settings()
             name => println("Unknown command: \{name}")
           }
         None => println("Error: no command")


### PR DESCRIPTION
## Summary
Add `settings` subcommand that displays available compiler options:
- Optimization levels (O0-O3) with detailed descriptions of what each level enables
- Target architectures (aarch64, x86_64)
- Supported file formats (.wasm, .wat, .wast, .cwasm)

## Usage
```
$ wasmoon settings
Wasmoon Compiler Settings
============================================================

== Optimization Levels (-O) ==
  0  No optimization
     - Fastest compilation, easiest debugging
     - IR is not modified after translation

  1  Basic optimizations
     - Constant folding
     - Copy propagation
     - Common subexpression elimination (CSE)
     - Dead code elimination (DCE)
...
```

## Test plan
- [x] All 418 tests pass
- [x] `moon check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)