### PR TITLE
feat(cli): add --opt flag for specific optimization toggles

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -160,7 +160,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 #### 配置与调试选项
 - [x] `-O, --optimize` 优化选项
   - [x] 优化级别 (0-3)
-  - [ ] 特定优化开关
+  - [x] 特定优化开关 (`--opt +name/-name`)
 - [x] `-D, --debug` 调试选项
   - [x] 详细日志输出 (verbose)
   - [x] IR 打印 (ir)

--- a/ir/optimize.mbt
+++ b/ir/optimize.mbt
@@ -601,6 +601,324 @@ pub fn OptLevel::from_int(n : Int) -> OptLevel {
 }
 
 ///|
+/// Optimization toggles for fine-grained control
+pub(all) struct OptToggles {
+  // Basic optimizations (O1)
+  mut const_fold : Bool // Constant folding
+  mut copy_prop : Bool // Copy propagation
+  mut cse : Bool // Common subexpression elimination
+  mut dce : Bool // Dead code elimination
+  // Control flow optimizations (O2)
+  mut branch_simp : Bool // Branch simplification
+  mut uce : Bool // Unreachable code elimination
+  mut block_merge : Bool // Block merging
+  mut jump_thread : Bool // Jump threading
+  // Loop optimizations (O3)
+  mut licm : Bool // Loop invariant code motion
+  mut loop_unroll : Bool // Loop unrolling
+  mut strength_red : Bool // Strength reduction
+}
+
+///|
+/// Create default toggles (all disabled)
+pub fn OptToggles::none() -> OptToggles {
+  OptToggles::{
+    const_fold: false,
+    copy_prop: false,
+    cse: false,
+    dce: false,
+    branch_simp: false,
+    uce: false,
+    block_merge: false,
+    jump_thread: false,
+    licm: false,
+    loop_unroll: false,
+    strength_red: false,
+  }
+}
+
+///|
+/// Create toggles from optimization level
+pub fn OptToggles::from_level(level : OptLevel) -> OptToggles {
+  match level {
+    O0 => OptToggles::none()
+    O1 =>
+      OptToggles::{
+        const_fold: true,
+        copy_prop: true,
+        cse: true,
+        dce: true,
+        branch_simp: false,
+        uce: false,
+        block_merge: false,
+        jump_thread: false,
+        licm: false,
+        loop_unroll: false,
+        strength_red: false,
+      }
+    O2 =>
+      OptToggles::{
+        const_fold: true,
+        copy_prop: true,
+        cse: true,
+        dce: true,
+        branch_simp: true,
+        uce: true,
+        block_merge: true,
+        jump_thread: true,
+        licm: false,
+        loop_unroll: false,
+        strength_red: false,
+      }
+    O3 =>
+      OptToggles::{
+        const_fold: true,
+        copy_prop: true,
+        cse: true,
+        dce: true,
+        branch_simp: true,
+        uce: true,
+        block_merge: true,
+        jump_thread: true,
+        licm: true,
+        loop_unroll: true,
+        strength_red: true,
+      }
+  }
+}
+
+///|
+/// Parse toggle string and enable the specified optimization
+/// Returns true if the toggle was recognized
+pub fn OptToggles::enable(self : OptToggles, name : String) -> Bool {
+  match name {
+    "cf" | "const-fold" | "constant-folding" => {
+      self.const_fold = true
+      true
+    }
+    "cp" | "copy-prop" | "copy-propagation" => {
+      self.copy_prop = true
+      true
+    }
+    "cse" | "common-subexpr" => {
+      self.cse = true
+      true
+    }
+    "dce" | "dead-code" => {
+      self.dce = true
+      true
+    }
+    "bs" | "branch-simp" | "branch-simplification" => {
+      self.branch_simp = true
+      true
+    }
+    "uce" | "unreachable" => {
+      self.uce = true
+      true
+    }
+    "bm" | "block-merge" => {
+      self.block_merge = true
+      true
+    }
+    "jt" | "jump-thread" | "jump-threading" => {
+      self.jump_thread = true
+      true
+    }
+    "licm" | "loop-invariant" => {
+      self.licm = true
+      true
+    }
+    "lu" | "loop-unroll" | "unroll" => {
+      self.loop_unroll = true
+      true
+    }
+    "sr" | "strength-red" | "strength-reduction" => {
+      self.strength_red = true
+      true
+    }
+    "all" => {
+      self.const_fold = true
+      self.copy_prop = true
+      self.cse = true
+      self.dce = true
+      self.branch_simp = true
+      self.uce = true
+      self.block_merge = true
+      self.jump_thread = true
+      self.licm = true
+      self.loop_unroll = true
+      self.strength_red = true
+      true
+    }
+    _ => false
+  }
+}
+
+///|
+/// Parse toggle string and disable the specified optimization
+/// Returns true if the toggle was recognized
+pub fn OptToggles::disable(self : OptToggles, name : String) -> Bool {
+  match name {
+    "cf" | "const-fold" | "constant-folding" => {
+      self.const_fold = false
+      true
+    }
+    "cp" | "copy-prop" | "copy-propagation" => {
+      self.copy_prop = false
+      true
+    }
+    "cse" | "common-subexpr" => {
+      self.cse = false
+      true
+    }
+    "dce" | "dead-code" => {
+      self.dce = false
+      true
+    }
+    "bs" | "branch-simp" | "branch-simplification" => {
+      self.branch_simp = false
+      true
+    }
+    "uce" | "unreachable" => {
+      self.uce = false
+      true
+    }
+    "bm" | "block-merge" => {
+      self.block_merge = false
+      true
+    }
+    "jt" | "jump-thread" | "jump-threading" => {
+      self.jump_thread = false
+      true
+    }
+    "licm" | "loop-invariant" => {
+      self.licm = false
+      true
+    }
+    "lu" | "loop-unroll" | "unroll" => {
+      self.loop_unroll = false
+      true
+    }
+    "sr" | "strength-red" | "strength-reduction" => {
+      self.strength_red = false
+      true
+    }
+    "all" => {
+      self.const_fold = false
+      self.copy_prop = false
+      self.cse = false
+      self.dce = false
+      self.branch_simp = false
+      self.uce = false
+      self.block_merge = false
+      self.jump_thread = false
+      self.licm = false
+      self.loop_unroll = false
+      self.strength_red = false
+      true
+    }
+    _ => false
+  }
+}
+
+///|
+/// Run optimizations with specific toggles
+pub fn optimize_with_toggles(
+  func : Function,
+  toggles : OptToggles,
+) -> OptResult {
+  let result = OptResult::new()
+  let mut changed = true
+  let mut iterations = 0
+  let max_iterations = 100
+  while changed && iterations < max_iterations {
+    changed = false
+    iterations = iterations + 1
+
+    // Basic optimizations
+    if toggles.const_fold {
+      let cf_result = fold_constants(func)
+      if cf_result.changed {
+        changed = true
+        result.mark_changed()
+      }
+    }
+    if toggles.copy_prop {
+      let cp_result = propagate_copies(func)
+      if cp_result.changed {
+        changed = true
+        result.mark_changed()
+      }
+    }
+    if toggles.cse {
+      let cse_result = eliminate_common_subexpressions(func)
+      if cse_result.changed {
+        changed = true
+        result.mark_changed()
+      }
+    }
+    if toggles.dce {
+      let dce_result = eliminate_dead_code(func)
+      if dce_result.changed {
+        changed = true
+        result.mark_changed()
+      }
+    }
+
+    // Control flow optimizations
+    if toggles.branch_simp {
+      let bs_result = simplify_branches(func)
+      if bs_result.changed {
+        changed = true
+        result.mark_changed()
+      }
+    }
+    if toggles.uce {
+      let uce_result = eliminate_unreachable_code(func)
+      if uce_result.changed {
+        changed = true
+        result.mark_changed()
+      }
+    }
+    if toggles.block_merge {
+      let bm_result = merge_blocks(func)
+      if bm_result.changed {
+        changed = true
+        result.mark_changed()
+      }
+    }
+    if toggles.jump_thread {
+      let jt_result = thread_jumps(func)
+      if jt_result.changed {
+        changed = true
+        result.mark_changed()
+      }
+    }
+  }
+
+  // Loop optimizations (run once after fixpoint)
+  if toggles.licm {
+    let licm_result = hoist_loop_invariants(func)
+    if licm_result.changed {
+      result.mark_changed()
+    }
+  }
+  if toggles.loop_unroll {
+    let lu_result = unroll_loops(func, 2)
+    if lu_result.changed {
+      result.mark_changed()
+    }
+  }
+  if toggles.strength_red {
+    let sr_result = reduce_strength(func)
+    if sr_result.changed {
+      result.mark_changed()
+    }
+  }
+  result
+}
+
+///|
 /// Run optimizations based on level
 pub fn optimize_with_level(func : Function, level : OptLevel) -> OptResult {
   match level {

--- a/ir/pkg.generated.mbti
+++ b/ir/pkg.generated.mbti
@@ -22,6 +22,8 @@ fn optimize(Function) -> OptResult
 
 fn optimize_with_level(Function, OptLevel) -> OptResult
 
+fn optimize_with_toggles(Function, OptToggles) -> OptResult
+
 fn propagate_copies(Function) -> OptResult
 
 fn reduce_strength(Function) -> OptResult
@@ -274,6 +276,24 @@ pub(all) struct OptResult {
 }
 fn OptResult::mark_changed(Self) -> Unit
 fn OptResult::new() -> Self
+
+pub(all) struct OptToggles {
+  mut const_fold : Bool
+  mut copy_prop : Bool
+  mut cse : Bool
+  mut dce : Bool
+  mut branch_simp : Bool
+  mut uce : Bool
+  mut block_merge : Bool
+  mut jump_thread : Bool
+  mut licm : Bool
+  mut loop_unroll : Bool
+  mut strength_red : Bool
+}
+fn OptToggles::disable(Self, String) -> Bool
+fn OptToggles::enable(Self, String) -> Bool
+fn OptToggles::from_level(OptLevel) -> Self
+fn OptToggles::none() -> Self
 
 pub enum Terminator {
   Jump(Int, Array[Value])

--- a/main/main.mbt
+++ b/main/main.mbt
@@ -852,11 +852,43 @@ fn DebugOptions::parse(opts : Array[String]) -> DebugOptions {
 }
 
 ///|
+/// Parse optimization toggles from CLI args
+/// Format: "+name" to enable, "-name" to disable
+fn parse_opt_toggles(
+  opt_level : Int,
+  toggles : Array[String],
+) -> @ir.OptToggles {
+  let level = @ir.OptLevel::from_int(opt_level)
+  let opts = @ir.OptToggles::from_level(level)
+  for toggle in toggles {
+    if toggle.length() > 1 {
+      let prefix = toggle[0]
+      // Build the name without the prefix
+      let name_builder = StringBuilder::new()
+      for i = 1; i < toggle.length(); i = i + 1 {
+        name_builder.write_char(toggle[i].unsafe_to_char())
+      }
+      let name = name_builder.to_string()
+      if prefix == '+' {
+        opts.enable(name) |> ignore
+      } else if prefix == '-' {
+        opts.disable(name) |> ignore
+      } else {
+        // No prefix, assume enable
+        opts.enable(toggle) |> ignore
+      }
+    }
+  }
+  opts
+}
+
+///|
 /// Explore WASM compilation process
 async fn run_explore(
   wasm_path : String,
   func_index : Int?,
   opt_level : Int,
+  opt_toggles : Array[String],
   debug_opts : DebugOptions,
 ) -> Unit {
   println("Exploring compilation: \{wasm_path}")
@@ -938,9 +970,9 @@ async fn run_explore(
   println("")
 
   // Stage 3: Optimized IR
-  let level = @ir.OptLevel::from_int(opt_level)
+  let toggles = parse_opt_toggles(opt_level, opt_toggles)
   println("== Stage 3: Optimized IR (O\{opt_level}) ==")
-  @ir.optimize_with_level(ir_func, level) |> ignore
+  @ir.optimize_with_toggles(ir_func, toggles) |> ignore
   println(ir_func.print())
   println("")
 
@@ -1480,6 +1512,31 @@ fn run_settings() -> Unit {
   println("     - Loop unrolling (factor 2)")
   println("     - Strength reduction (mul/div by power of 2)")
   println("")
+  println("== Optimization Toggles (--opt) ==")
+  println("  Use --opt to enable/disable specific optimizations:")
+  println("    +name  Enable optimization")
+  println("    -name  Disable optimization")
+  println("")
+  println("  Basic optimizations (O1):")
+  println("    cf     Constant folding")
+  println("    cp     Copy propagation")
+  println("    cse    Common subexpression elimination")
+  println("    dce    Dead code elimination")
+  println("")
+  println("  Control flow optimizations (O2):")
+  println("    bs     Branch simplification")
+  println("    uce    Unreachable code elimination")
+  println("    bm     Block merging")
+  println("    jt     Jump threading")
+  println("")
+  println("  Loop optimizations (O3):")
+  println("    licm   Loop invariant code motion")
+  println("    lu     Loop unrolling")
+  println("    sr     Strength reduction")
+  println("")
+  println("  Example: wasmoon explore test.wasm -O2 --opt -cse --opt +licm")
+  println("           (O2 without CSE, but with LICM)")
+  println("")
   println("== Target Architectures ==")
   println("  aarch64  ARM 64-bit (default)")
   println("  x86_64   Intel/AMD 64-bit (planned)")
@@ -1934,6 +1991,10 @@ async fn main {
             help="Function index to explore (default: 0)",
           ),
           "O": @clap.Arg::named(help="Optimization level (0-3, default: 2)"),
+          "opt": @clap.Arg::named(
+            nargs=@clap.Nargs::Any,
+            help="Optimization toggles: +name to enable, -name to disable (cf, cp, cse, dce, bs, uce, bm, jt, licm, lu, sr)",
+          ),
           "D": @clap.Arg::named(
             nargs=@clap.Nargs::Any,
             help="Debug options: verbose, ir, timing, all",
@@ -2096,7 +2157,17 @@ async fn main {
                   Some(arr) => DebugOptions::parse(arr)
                   None => DebugOptions::new()
                 }
-                run_explore(positional[0], func_idx, opt_level, debug_opts)
+                let opt_toggles : Array[String] = match sub.args.get("opt") {
+                  Some(arr) => arr
+                  None => []
+                }
+                run_explore(
+                  positional[0],
+                  func_idx,
+                  opt_level,
+                  opt_toggles,
+                  debug_opts,
+                )
               } else {
                 println("Error: missing file argument")
               }


### PR DESCRIPTION
## Summary
- Add `--opt` flag to the `explore` command for fine-grained control over individual optimizations
- Support +name to enable, -name to disable specific optimizations
- Add `OptToggles` struct in `ir/optimize.mbt` with methods for parsing and applying toggles
- Update `settings` command to document the new option

## Available Toggles

**Basic optimizations (O1):**
- `cf` - Constant folding
- `cp` - Copy propagation
- `cse` - Common subexpression elimination
- `dce` - Dead code elimination

**Control flow optimizations (O2):**
- `bs` - Branch simplification
- `uce` - Unreachable code elimination
- `bm` - Block merging
- `jt` - Jump threading

**Loop optimizations (O3):**
- `licm` - Loop invariant code motion
- `lu` - Loop unrolling
- `sr` - Strength reduction

## Usage
```bash
# Use O2 but disable CSE and enable LICM
wasmoon explore test.wasm -O2 --opt -cse --opt +licm

# Start from O0 and enable only specific optimizations
wasmoon explore test.wasm -O0 --opt +cf --opt +dce
```

## Test plan
- [x] Tests pass (`moon test`)
- [x] Check works (`moon check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)