### PR TITLE
test: add black-box tests for core modules

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -556,4 +556,5 @@ _请在此处继续添加新的意见和建议_
 - [x] 目前为止，vcode 模块的测试全都是白盒测试，请给出理由，否则修改部分为黑盒测试 → vcode 是编译器内部组件，无公开 API，白盒测试合理
 - [x] bench 内容现在非常贫瘠，需要丰富 → 已实现：10 大类基准测试覆盖解释器、JIT、IR、优化、VCode、寄存器分配、代码生成、运行时等
 - [x] vcode/aarch64_patterns.mbt 中有非常多的 never constructed variant. 这是怎么导致的？以后会用到吗？还是永远不会用到？ → **设计决策**：当前采用统一 VCode 方案，AArch64 特定 opcode（Madd、AddShifted 等）直接放入 `VCodeOpcode` 枚举。`aarch64_patterns.mbt` 中的 `AArch64Opcode` 是早期设计残留，应当删除。理想架构是分层设计（VCode 目标无关 → AArch64Inst 目标特定），但考虑到项目只针对 AArch64 单一目标，统一方案更务实。如未来需支持多目标，再重构为分层架构
-- [ ] 现在缺乏很多黑盒测试
+- [x] 现在缺乏很多黑盒测试 → 已为 types、runtime、cwasm 模块添加黑盒测试（35 个新测试）
+- [ ] main.mbt 现在太大了，适当进行拆分 → 建议拆分为：demo.mbt, testsuite.mbt, completion.mbt, settings.mbt, config.mbt, wast.mbt, utils.mbt

--- a/cwasm/cwasm_test.mbt
+++ b/cwasm/cwasm_test.mbt
@@ -1,0 +1,68 @@
+// Black-box tests for cwasm module
+
+///|
+test "TargetArch from helper functions" {
+  let arch64 = @cwasm.aarch64_target()
+  let x86 = @cwasm.x86_64_target()
+  inspect(arch64, content="aarch64")
+  inspect(x86, content="x86_64")
+}
+
+///|
+test "PrecompiledModule::new" {
+  let pcm = @cwasm.PrecompiledModule::new(@cwasm.aarch64_target())
+  inspect(pcm.version, content="1")
+  inspect(pcm.target, content="aarch64")
+  inspect(pcm.function_count(), content="0")
+}
+
+///|
+test "CompiledEntry::new" {
+  let entry = @cwasm.CompiledEntry::new(0, "test_func", [1, 2, 3], 16, 0)
+  inspect(entry.func_idx, content="0")
+  inspect(entry.name, content="test_func")
+  inspect(entry.code.length(), content="3")
+  inspect(entry.frame_size, content="16")
+  inspect(entry.entry_offset, content="0")
+}
+
+///|
+test "PrecompiledModule serialize and deserialize roundtrip" {
+  let pcm = @cwasm.PrecompiledModule::new(@cwasm.aarch64_target())
+  // Create a CompiledFunction mock via CompiledEntry
+  let entry = @cwasm.CompiledEntry::new(0, "add", [0xD503201F], 32, 0)
+  let cf = entry.to_compiled_function()
+  pcm.add_function(0, "add", cf)
+  inspect(pcm.function_count(), content="1")
+  // Serialize
+  let serialized = pcm.serialize()
+  inspect(serialized.length() > 0, content="true")
+  // Deserialize
+  let pcm2 = @cwasm.deserialize(serialized)
+  inspect(pcm2.version, content="1")
+  inspect(pcm2.target, content="aarch64")
+  inspect(pcm2.function_count(), content="1")
+}
+
+///|
+test "deserialize invalid data raises error" {
+  let invalid_data = [0, 0, 0, 0] // Invalid magic
+  let result : Result[@cwasm.PrecompiledModule, _] = Ok(
+    @cwasm.deserialize(invalid_data),
+  ) catch {
+    e => Err(e)
+  }
+  inspect(result is Err(_), content="true")
+}
+
+///|
+test "PrecompiledModule with multiple functions" {
+  let pcm = @cwasm.PrecompiledModule::new(@cwasm.aarch64_target())
+  let entry1 = @cwasm.CompiledEntry::new(0, "func0", [1, 2], 16, 0)
+  let entry2 = @cwasm.CompiledEntry::new(1, "func1", [3, 4, 5], 32, 0)
+  pcm.add_function(0, "func0", entry1.to_compiled_function())
+  pcm.add_function(1, "func1", entry2.to_compiled_function())
+  inspect(pcm.function_count(), content="2")
+  inspect(pcm.functions[0].name, content="func0")
+  inspect(pcm.functions[1].name, content="func1")
+}

--- a/cwasm/moon.pkg.json
+++ b/cwasm/moon.pkg.json
@@ -1,5 +1,8 @@
 {
   "import": [
     "Milky2018/wasmoon/vcode"
+  ],
+  "test-import": [
+    { "path": "Milky2018/wasmoon/cwasm", "alias": "cwasm" }
   ]
 }

--- a/runtime/moon.pkg.json
+++ b/runtime/moon.pkg.json
@@ -1,5 +1,9 @@
 {
   "import": [
     "Milky2018/wasmoon/types"
+  ],
+  "test-import": [
+    { "path": "Milky2018/wasmoon/runtime", "alias": "runtime" },
+    { "path": "Milky2018/wasmoon/types", "alias": "types" }
   ]
 }

--- a/runtime/runtime_test.mbt
+++ b/runtime/runtime_test.mbt
@@ -1,0 +1,171 @@
+// Black-box tests for runtime module
+
+///|
+test "Stack basic operations" {
+  let stack = @runtime.Stack::new()
+  inspect(stack.size(), content="0")
+  stack.push(@types.Value::I32(42))
+  inspect(stack.size(), content="1")
+  inspect(stack.peek(), content="I32(42)")
+  inspect(stack.pop(), content="I32(42)")
+  inspect(stack.size(), content="0")
+}
+
+///|
+test "Stack typed pop operations" {
+  let stack = @runtime.Stack::new()
+  stack.push(@types.Value::I32(100))
+  inspect(stack.pop_i32(), content="100")
+  stack.push(@types.Value::I64(200L))
+  inspect(stack.pop_i64(), content="200")
+  stack.push(@types.Value::F32(3.14))
+  let f32_val = stack.pop_f32()
+  inspect(f32_val > 3.13 && f32_val < 3.15, content="true")
+  stack.push(@types.Value::F64(2.718))
+  inspect(stack.pop_f64(), content="2.718")
+}
+
+///|
+test "Stack clear" {
+  let stack = @runtime.Stack::new()
+  stack.push(@types.Value::I32(1))
+  stack.push(@types.Value::I32(2))
+  stack.push(@types.Value::I32(3))
+  inspect(stack.size(), content="3")
+  stack.clear()
+  inspect(stack.size(), content="0")
+}
+
+///|
+test "Memory basic operations" {
+  let mem = @runtime.Memory::new(1, None) // 1 page = 64KB
+  inspect(mem.size_pages(), content="1")
+  mem.store_i32(0, 42)
+  inspect(mem.load_i32(0), content="42")
+  mem.store_byte(100, b'\x7F')
+  inspect(mem.load_byte(100), content="b'\\x7F'")
+}
+
+///|
+test "Memory grow" {
+  let mem = @runtime.Memory::new(1, Some(3))
+  inspect(mem.size_pages(), content="1")
+  let result = mem.grow(1)
+  inspect(result, content="1") // Returns old size
+  inspect(mem.size_pages(), content="2")
+}
+
+///|
+test "Memory i64 operations" {
+  let mem = @runtime.Memory::new(1, None)
+  mem.store_i64(0, 0x123456789ABCDEF0L)
+  inspect(mem.load_i64(0), content="1311768467463790320")
+}
+
+///|
+test "Memory float operations" {
+  let mem = @runtime.Memory::new(1, None)
+  mem.store_f32(0, 3.14)
+  let loaded = mem.load_f32(0)
+  inspect(loaded > 3.13 && loaded < 3.15, content="true")
+  mem.store_f64(8, 2.718281828)
+  let loaded64 = mem.load_f64(8)
+  inspect(loaded64 > 2.71 && loaded64 < 2.72, content="true")
+}
+
+///|
+test "Memory fill" {
+  let mem = @runtime.Memory::new(1, None)
+  mem.fill(0, b'\xFF', 10)
+  inspect(mem.load_byte(0), content="b'\\xFF'")
+  inspect(mem.load_byte(9), content="b'\\xFF'")
+}
+
+///|
+test "Table basic operations" {
+  let table = @runtime.Table::new(@types.ValueType::FuncRef, 10, Some(100))
+  inspect(table.size(), content="10")
+  table.set(0, @types.Value::FuncRef(42))
+  inspect(table.get(0), content="FuncRef(42)")
+}
+
+///|
+test "Table grow" {
+  let table = @runtime.Table::new(@types.ValueType::FuncRef, 5, Some(20))
+  inspect(table.size(), content="5")
+  let old_size = table.grow(5, @types.Value::Null)
+  inspect(old_size, content="5")
+  inspect(table.size(), content="10")
+}
+
+///|
+test "GlobalInstance operations" {
+  let gt : @types.GlobalType = {
+    value_type: @types.ValueType::I32,
+    mutable: true,
+  }
+  let g = @runtime.GlobalInstance::new(gt, @types.Value::I32(100))
+  inspect(g.get(), content="I32(100)")
+  g.set(@types.Value::I32(200))
+  inspect(g.get(), content="I32(200)")
+}
+
+///|
+test "Store basic operations" {
+  let store = @runtime.Store::new()
+  let mem = @runtime.Memory::new(1, None)
+  let mem_idx = store.alloc_mem(mem)
+  inspect(mem_idx, content="0")
+  let retrieved_mem = store.get_mem(0)
+  inspect(retrieved_mem.size_pages(), content="1")
+}
+
+///|
+test "Frame local variables" {
+  let frame = @runtime.Frame::new(
+    0,
+    [@types.Value::I32(10), @types.Value::I64(20L)],
+    0,
+  )
+  inspect(frame.get_local(0), content="I32(10)")
+  inspect(frame.get_local(1), content="I64(20)")
+  frame.set_local(0, @types.Value::I32(100))
+  inspect(frame.get_local(0), content="I32(100)")
+}
+
+///|
+test "Linker basic operations" {
+  let linker = @runtime.Linker::new()
+  let store = linker.get_store()
+  inspect(store.funcs.length(), content="0")
+}
+
+///|
+test "Imports resolution" {
+  let imports = @runtime.Imports::new()
+  imports.add_func("env", "print", 0)
+  imports.add_memory("env", "memory", 0)
+  inspect(imports.resolve("env", "print") is Some(_), content="true")
+  inspect(imports.resolve("env", "unknown") is Some(_), content="false")
+}
+
+///|
+test "ModuleInstance::new" {
+  let inst = @runtime.ModuleInstance::new()
+  inspect(inst.types.length(), content="0")
+  inspect(inst.func_addrs.length(), content="0")
+  inspect(inst.exports.length(), content="0")
+}
+
+///|
+test "ExternVal variants" {
+  let func_val = @runtime.ExternVal::Func(0)
+  let table_val = @runtime.ExternVal::Table(1)
+  let mem_val = @runtime.ExternVal::Memory(2)
+  let global_val = @runtime.ExternVal::Global(3)
+  // Test pattern matching
+  inspect(func_val is @runtime.ExternVal::Func(_), content="true")
+  inspect(table_val is @runtime.ExternVal::Table(_), content="true")
+  inspect(mem_val is @runtime.ExternVal::Memory(_), content="true")
+  inspect(global_val is @runtime.ExternVal::Global(_), content="true")
+}

--- a/types/moon.pkg.json
+++ b/types/moon.pkg.json
@@ -1,2 +1,5 @@
 {
+  "test-import": [
+    { "path": "Milky2018/wasmoon/types", "alias": "types" }
+  ]
 }

--- a/types/types_test.mbt
+++ b/types/types_test.mbt
@@ -1,0 +1,126 @@
+// Black-box tests for types module
+
+///|
+test "ValueType equality" {
+  inspect(@types.ValueType::I32 == @types.ValueType::I32, content="true")
+  inspect(@types.ValueType::I32 == @types.ValueType::I64, content="false")
+  inspect(@types.ValueType::F32 == @types.ValueType::F64, content="false")
+}
+
+///|
+test "ValueType to_string" {
+  inspect(@types.ValueType::I32, content="I32")
+  inspect(@types.ValueType::I64, content="I64")
+  inspect(@types.ValueType::F32, content="F32")
+  inspect(@types.ValueType::F64, content="F64")
+  inspect(@types.ValueType::FuncRef, content="FuncRef")
+  inspect(@types.ValueType::ExternRef, content="ExternRef")
+}
+
+///|
+test "Value equality" {
+  inspect(@types.Value::I32(42) == @types.Value::I32(42), content="true")
+  inspect(@types.Value::I32(42) == @types.Value::I32(0), content="false")
+  inspect(@types.Value::I64(100L) == @types.Value::I64(100L), content="true")
+  inspect(@types.Value::Null == @types.Value::Null, content="true")
+}
+
+///|
+test "Value to_string" {
+  inspect(@types.Value::I32(42), content="I32(42)")
+  inspect(@types.Value::I64(100L), content="I64(100)")
+  inspect(@types.Value::F32(3.14), content="F32(3.140000104904175)")
+  inspect(@types.Value::F64(2.718), content="F64(2.718)")
+  inspect(@types.Value::Null, content="Null")
+}
+
+///|
+test "FuncType equality" {
+  let ft1 : @types.FuncType = {
+    params: [@types.ValueType::I32, @types.ValueType::I32],
+    results: [@types.ValueType::I32],
+  }
+  let ft2 : @types.FuncType = {
+    params: [@types.ValueType::I32, @types.ValueType::I32],
+    results: [@types.ValueType::I32],
+  }
+  let ft3 : @types.FuncType = {
+    params: [@types.ValueType::I64],
+    results: [@types.ValueType::I64],
+  }
+  inspect(ft1 == ft2, content="true")
+  inspect(ft1 == ft3, content="false")
+}
+
+///|
+test "Limits equality" {
+  let l1 : @types.Limits = { min: 1, max: Some(10) }
+  let l2 : @types.Limits = { min: 1, max: Some(10) }
+  let l3 : @types.Limits = { min: 1, max: None }
+  inspect(l1 == l2, content="true")
+  inspect(l1 == l3, content="false")
+}
+
+///|
+test "BlockType variants" {
+  inspect(@types.BlockType::Empty, content="Empty")
+  inspect(@types.BlockType::Value(@types.ValueType::I32), content="Value(I32)")
+  inspect(@types.BlockType::TypeIndex(0), content="TypeIndex(0)")
+}
+
+///|
+test "Instruction equality" {
+  inspect(
+    @types.Instruction::I32Const(42) == @types.Instruction::I32Const(42),
+    content="true",
+  )
+  inspect(
+    @types.Instruction::I32Const(42) == @types.Instruction::I32Const(0),
+    content="false",
+  )
+  inspect(@types.Instruction::Nop == @types.Instruction::Nop, content="true")
+  inspect(
+    @types.Instruction::Nop == @types.Instruction::Unreachable,
+    content="false",
+  )
+}
+
+///|
+test "Module::new creates empty module" {
+  let m = @types.Module::new()
+  inspect(m.types.length(), content="0")
+  inspect(m.imports.length(), content="0")
+  inspect(m.funcs.length(), content="0")
+  inspect(m.exports.length(), content="0")
+  inspect(m.codes.length(), content="0")
+  inspect(m.start, content="None")
+}
+
+///|
+test "Export and ExportDesc" {
+  let exp : @types.Export = { name: "add", desc: @types.ExportDesc::Func(0) }
+  inspect(exp.name, content="add")
+  inspect(exp.desc, content="Func(0)")
+}
+
+///|
+test "Import and ImportDesc" {
+  let imp : @types.Import = {
+    mod_name: "env",
+    name: "print",
+    desc: @types.ImportDesc::Func(0),
+  }
+  inspect(imp.mod_name, content="env")
+  inspect(imp.name, content="print")
+  inspect(imp.desc, content="Func(0)")
+}
+
+///|
+test "GlobalType" {
+  let gt : @types.GlobalType = {
+    value_type: @types.ValueType::I32,
+    mutable: true,
+  }
+  inspect(gt.value_type, content="I32")
+  inspect(gt.mutable, content="true")
+}


### PR DESCRIPTION
## Summary
Add comprehensive black-box tests for core modules to improve test coverage:

### types module (13 tests)
- ValueType equality and to_string
- Value equality and to_string
- FuncType equality
- Limits equality
- BlockType variants
- Instruction equality
- Module::new
- Export and ExportDesc
- Import and ImportDesc
- GlobalType

### runtime module (17 tests)
- Stack basic operations and typed pop
- Memory basic, grow, i64, float, fill operations
- Table basic operations and grow
- GlobalInstance operations
- Store basic operations
- Frame local variables
- Linker basic operations
- Imports resolution
- ModuleInstance::new
- ExternVal variants

### cwasm module (6 tests)
- TargetArch from helper functions
- PrecompiledModule::new
- CompiledEntry::new
- serialize/deserialize roundtrip
- deserialize invalid data
- PrecompiledModule with multiple functions

## Test Results
Total tests increased from 418 to 453 (35 new tests), all passing.

## Test plan
- [x] All 453 tests pass (`moon test`)
- [x] Check works (`moon check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)