### PR TITLE
refactor: simplify try-catch patterns with try? syntax

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -481,6 +481,24 @@
   ```
 - **说明**: `if-is` 语法更简洁，避免了无意义的空分支
 
+#### 15. 测试中检查错误的写法
+- ❌ **错误做法**: 使用复杂的 try-catch 模式检查是否抛出错误
+  ```moonbit
+  let result = try {
+    f() |> ignore
+    false // Should not reach here
+  } catch {
+    SomeErr => true // Expected
+    _ => false
+  }
+  inspect(result, content="true")
+  ```
+- ✅ **正确做法**: 使用 `try?` 配合 `inspect`
+  ```moonbit
+  inspect(try? f(), content="Err(SomeErr)")
+  ```
+- **说明**: `try?` 将结果转换为 `Result` 类型，可直接用 `inspect` 检查错误类型
+
 ---
 
 ## 2025-11-30
@@ -560,3 +578,4 @@ _请在此处继续添加新的意见和建议_
 - [x] main.mbt 现在太大了，适当进行拆分 → 已拆分为：demo.mbt, wast.mbt, settings.mbt, config.mbt, html_report.mbt
 - [x] 我完全不理解 `{ "path": "Milky2018/wasmoon/cwasm", "alias": "cwasm" }` 这是在做什么 → 当路径最后一段与 alias 相同时，alias 是多余的。当前项目已移除所有不必要的 alias
 - [x] completion 和项目主要功能无关，可以先删掉 → 已删除 completion.mbt
+- [x] 有非常多如下形式的测试：应使用 `inspect(try? f(), content="Err(...)")` → 已修复所有测试文件（cwasm_wbtest.mbt, i32_wbtest.mbt, i64_wbtest.mbt, executor_wbtest.mbt, validator_wbtest.mbt）

--- a/cwasm/cwasm_wbtest.mbt
+++ b/cwasm/cwasm_wbtest.mbt
@@ -91,14 +91,7 @@ test "serialize and deserialize: multiple functions" {
 ///|
 test "deserialize: invalid magic" {
   let bytes : Array[Int] = [0x00, 0x00, 0x00, 0x00]
-  let result = try {
-    deserialize(bytes) |> ignore
-    false
-  } catch {
-    DeserializeError(_) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(try? deserialize(bytes), content="Err(Invalid magic number)")
 }
 
 ///|
@@ -108,14 +101,7 @@ test "deserialize: unsupported version" {
     0x63, 0x77, 0x61, 0x73, // magic
      0xFF, 0x00, 0x00, 0x00,
   ] // version 255
-  let result = try {
-    deserialize(bytes) |> ignore
-    false
-  } catch {
-    DeserializeError(_) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(try? deserialize(bytes), content="Err(Unsupported version: 255)")
 }
 
 ///|

--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -1366,14 +1366,10 @@ test "import validation: missing import raises error" {
   let imports = @runtime.Imports::new()
 
   // Should raise UnknownImport
-  let result = try {
-    instantiate_module_with_imports(store, mod, imports) |> ignore
-    false // Should not reach here
-  } catch {
-    @runtime.UnknownImport => true // Expected
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(
+    try? instantiate_module_with_imports(store, mod, imports),
+    content="Err(UnknownImport)",
+  )
 }
 
 ///|
@@ -2242,14 +2238,10 @@ test "bulk memory: data.drop" {
   }
 
   // After drop: init_nonzero should fail
-  let trapped = try {
-    call_exported_func(store, instance, "init_nonzero", []) |> ignore
-    false
-  } catch {
-    @runtime.OutOfBoundsMemoryAccess => true
-    _ => false
-  }
-  inspect(trapped, content="true")
+  inspect(
+    try? call_exported_func(store, instance, "init_nonzero", []),
+    content="Err(OutOfBoundsMemoryAccess)",
+  )
 }
 
 ///|

--- a/main/main.mbt
+++ b/main/main.mbt
@@ -101,14 +101,14 @@ async fn run_test_command_async(
       let bytes = read_wasm_file(base_dir, filename)
       match bytes {
         Some(b) =>
-          try {
-            let instance = ctx.load_module(b, None)
-            ctx.set_current_module(instance)
-          } catch {
-            e =>
-              result.add_failed(
-                "\{line_prefix}Failed to load module \{filename}: \{e}",
-              )
+          if (try? {
+              let instance = ctx.load_module(b, None)
+              ctx.set_current_module(instance)
+            })
+            is Err(e) {
+            result.add_failed(
+              "\{line_prefix}Failed to load module \{filename}: \{e}",
+            )
           }
         None => {
           result.add_skipped()
@@ -155,64 +155,46 @@ async fn run_test_command_async(
     AssertInvalid(filename, _msg) => {
       let bytes = read_wasm_file(base_dir, filename)
       match bytes {
-        Some(b) => {
-          let valid = try {
-            let mod = @parser.parse_module(b)
-            @validator.validate_module(mod)
-            true
-          } catch {
-            _ => false
-          }
-          if valid {
+        Some(b) =>
+          if (try? {
+              let mod = @parser.parse_module(b)
+              @validator.validate_module(mod)
+            })
+            is Ok(_) {
             result.add_failed(
               "\{line_prefix}assert_invalid should have failed: \{filename}",
             )
           } else {
             result.add_passed()
           }
-        }
         None => result.add_skipped()
       }
     }
     AssertMalformed(filename, _msg) => {
       let bytes = read_wasm_file(base_dir, filename)
       match bytes {
-        Some(b) => {
-          let parsed = try {
-            @parser.parse_module(b) |> ignore
-            true
-          } catch {
-            _ => false
-          }
-          if parsed {
+        Some(b) =>
+          if (try? @parser.parse_module(b)) is Ok(_) {
             result.add_failed(
               "\{line_prefix}assert_malformed should have failed: \{filename}",
             )
           } else {
             result.add_passed()
           }
-        }
         None => result.add_skipped()
       }
     }
     AssertUninstantiable(filename, _msg) => {
       let bytes = read_wasm_file(base_dir, filename)
       match bytes {
-        Some(b) => {
-          let instantiated = try {
-            ctx.load_module(b, None) |> ignore
-            true
-          } catch {
-            _ => false
-          }
-          if instantiated {
+        Some(b) =>
+          if (try? ctx.load_module(b, None)) is Ok(_) {
             result.add_failed(
               "\{line_prefix}assert_uninstantiable should have failed: \{filename}",
             )
           } else {
             result.add_passed()
           }
-        }
         None => result.add_skipped()
       }
     }

--- a/main/wast.mbt
+++ b/main/wast.mbt
@@ -132,12 +132,11 @@ fn run_wast_command(
     }
     AssertExhaustion(action, _msg) =>
       // Just try to invoke - should cause stack exhaustion
-      try {
-        invoke_action(ctx, action) |> ignore
+      if (try? invoke_action(ctx, action)) is Err(_) {
+        result.passed = result.passed + 1
+      } else {
         result.failed = result.failed + 1
         result.failures.push("assert_exhaustion: expected exhaustion")
-      } catch {
-        _ => result.passed = result.passed + 1
       }
     AssertInvalid(source, _msg) => {
       let valid = validate_module_source(source)
@@ -222,12 +221,7 @@ fn run_assert_trap(
   _expected_msg : String,
 ) -> Bool {
   // Should trap
-  try {
-    invoke_action(ctx, action) |> ignore
-    false // Should have trapped
-  } catch {
-    _ => true // Trapped as expected
-  }
+  (try? invoke_action(ctx, action)) is Err(_)
 }
 
 ///|
@@ -311,34 +305,20 @@ fn values_match(actual : @types.Value, expected : @wast.WastValue) -> Bool {
 fn validate_module_source(source : @wast.WastModuleSource) -> Bool {
   match source {
     Binary(bytes) =>
-      try {
+      (try? {
         let mod_ = @parser.parse_module(bytes)
         @validator.validate_module(mod_)
-        true
-      } catch {
-        _ => false
-      }
+      })
+      is Ok(_)
     Quote(_) => true // Can't easily validate quoted source
-    Inline(mod_) =>
-      try {
-        @validator.validate_module(mod_)
-        true
-      } catch {
-        _ => false
-      }
+    Inline(mod_) => (try? @validator.validate_module(mod_)) is Ok(_)
   }
 }
 
 ///|
 fn parse_module_source(source : @wast.WastModuleSource) -> Bool {
   match source {
-    Binary(bytes) =>
-      try {
-        @parser.parse_module(bytes) |> ignore
-        true
-      } catch {
-        _ => false
-      }
+    Binary(bytes) => (try? @parser.parse_module(bytes)) is Ok(_)
     Quote(_) => false // Quoted source is assumed to fail parsing
     Inline(_) => true // Already parsed successfully
   }
@@ -351,15 +331,13 @@ fn try_instantiate_source(
 ) -> Bool {
   match source {
     Binary(bytes) =>
-      try {
+      (try? {
         let mod_ = @parser.parse_module(bytes)
         let (store, instance) = @executor.instantiate_module(mod_)
         ctx.store = store
         ctx.current_module = Some(instance)
-        true
-      } catch {
-        _ => false
-      }
+      })
+      is Ok(_)
     Inline(mod_) => {
       let (store, instance) = @executor.instantiate_module(mod_)
       ctx.store = store

--- a/testsuite/executor.mbt
+++ b/testsuite/executor.mbt
@@ -130,13 +130,7 @@ pub fn run_assert_trap(
 ) -> Bool {
   let runtime_args = args.map(parse_test_value)
   // Should trap
-  let trapped = try {
-    ctx.invoke(module_name, func_name, runtime_args) |> ignore
-    false
-  } catch {
-    _ => true
-  }
-  trapped
+  (try? ctx.invoke(module_name, func_name, runtime_args)) is Err(_)
 }
 
 ///|

--- a/testsuite/i32_wbtest.mbt
+++ b/testsuite/i32_wbtest.mbt
@@ -189,15 +189,10 @@ test "wasm-testsuite: i32.div_s trap on zero" {
   let mod = create_i32_arithmetic_module()
   let (store, instance) = @executor.instantiate_module(mod)
   // (assert_trap (invoke "div_s" (i32.const 1) (i32.const 0)) "integer divide by zero")
-  let trapped = try {
-    @executor.call_exported_func(store, instance, "div_s", [I32(1), I32(0)])
-    |> ignore
-    false
-  } catch {
-    @runtime.DivisionByZero => true
-    _ => false
-  }
-  inspect(trapped, content="true")
+  inspect(
+    try? @executor.call_exported_func(store, instance, "div_s", [I32(1), I32(0)]),
+    content="Err(DivisionByZero)",
+  )
 }
 
 ///|
@@ -206,18 +201,13 @@ test "wasm-testsuite: i32.div_s trap on overflow" {
   let (store, instance) = @executor.instantiate_module(mod)
   // (assert_trap (invoke "div_s" (i32.const 0x80000000) (i32.const -1)) "integer overflow")
   // -2147483648 / -1 overflows because result would be 2147483648 which doesn't fit in i32
-  let trapped = try {
-    @executor.call_exported_func(store, instance, "div_s", [
+  inspect(
+    try? @executor.call_exported_func(store, instance, "div_s", [
       I32(-2147483648),
       I32(-1),
-    ])
-    |> ignore
-    false
-  } catch {
-    @runtime.IntegerOverflow => true
-    _ => false
-  }
-  inspect(trapped, content="true")
+    ]),
+    content="Err(IntegerOverflow)",
+  )
 }
 
 ///|
@@ -975,11 +965,10 @@ test "wasm-testsuite: i32.1.wasm should fail validation" {
   ]
   let bytes_data = Bytes::from_array(bytes)
   let mod = @parser.parse_module(bytes_data)
-  let validation_failed = try {
-    @validator.validate_module(mod)
-    false
-  } catch {
-    _ => true
-  }
-  inspect(validation_failed, content="true")
+  inspect(
+    try? @validator.validate_module(mod),
+    content=(
+      #|Err(StackUnderflow("Expected I32, but stack is empty"))
+    ),
+  )
 }

--- a/testsuite/i64_wbtest.mbt
+++ b/testsuite/i64_wbtest.mbt
@@ -144,15 +144,13 @@ test "wasm-testsuite: i64.div_s trap on zero" {
   let mod = create_i64_arithmetic_module()
   let (store, instance) = @executor.instantiate_module(mod)
   // (assert_trap (invoke "div_s" (i64.const 1) (i64.const 0)) "integer divide by zero")
-  let trapped = try {
-    @executor.call_exported_func(store, instance, "div_s", [I64(1L), I64(0L)])
-    |> ignore
-    false
-  } catch {
-    @runtime.DivisionByZero => true
-    _ => false
-  }
-  inspect(trapped, content="true")
+  inspect(
+    try? @executor.call_exported_func(store, instance, "div_s", [
+      I64(1L),
+      I64(0L),
+    ]),
+    content="Err(DivisionByZero)",
+  )
 }
 
 ///|
@@ -161,18 +159,13 @@ test "wasm-testsuite: i64.div_s trap on overflow" {
   let (store, instance) = @executor.instantiate_module(mod)
   // (assert_trap (invoke "div_s" (i64.const 0x8000000000000000) (i64.const -1)) "integer overflow")
   // INT64_MIN / -1 overflows
-  let trapped = try {
-    @executor.call_exported_func(store, instance, "div_s", [
+  inspect(
+    try? @executor.call_exported_func(store, instance, "div_s", [
       I64(-9223372036854775808L),
       I64(-1L),
-    ])
-    |> ignore
-    false
-  } catch {
-    @runtime.IntegerOverflow => true
-    _ => false
-  }
-  inspect(trapped, content="true")
+    ]),
+    content="Err(IntegerOverflow)",
+  )
 }
 
 ///|

--- a/testsuite/runner.mbt
+++ b/testsuite/runner.mbt
@@ -467,15 +467,11 @@ fn run_test_command_internal(
           return
         }
       }
-      let invalid = try {
-        let mod = @parser.parse_module(bytes)
-        // Run validator
-        @validator.validate_module(mod)
-        false // validation passed - not expected
-      } catch {
-        _ => true // parsing or validation failed - expected
-      }
-      if invalid {
+      if (try? {
+          let mod = @parser.parse_module(bytes)
+          @validator.validate_module(mod)
+        })
+        is Err(_) {
         result.passed += 1
       } else {
         result.failed += 1
@@ -494,19 +490,13 @@ fn run_test_command_internal(
           return
         }
       }
-      let parsed = try {
-        @parser.parse_module(bytes) |> ignore
-        true
-      } catch {
-        _ => false
-      }
-      if parsed {
+      if (try? @parser.parse_module(bytes)) is Err(_) {
+        result.passed += 1
+      } else {
         result.failed += 1
         result.failures.push(
           "\{line_prefix}assert_malformed should have failed: \{filename}",
         )
-      } else {
-        result.passed += 1
       }
     }
     AssertUninstantiable(filename, _msg) => {
@@ -518,13 +508,7 @@ fn run_test_command_internal(
           return
         }
       }
-      let instantiated = try {
-        ctx.load_module(bytes, None) |> ignore
-        true
-      } catch {
-        _ => false
-      }
-      if instantiated {
+      if (try? ctx.load_module(bytes, None)) is Ok(_) {
         result.failed += 1
         result.failures.push(
           "\{line_prefix}assert_uninstantiable should have failed: \{filename}",

--- a/validator/validator_wbtest.mbt
+++ b/validator/validator_wbtest.mbt
@@ -74,14 +74,12 @@ test "validator: type mismatch - wrong operand type" {
     codes: [func],
     datas: [],
   }
-  let result = try {
-    validate_module(mod)
-    false
-  } catch {
-    TypeMismatch(_) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(
+    try? validate_module(mod),
+    content=(
+      #|Err(TypeMismatch("Expected I32, got I64"))
+    ),
+  )
 }
 
 ///|
@@ -104,14 +102,12 @@ test "validator: stack underflow" {
     codes: [func],
     datas: [],
   }
-  let result = try {
-    validate_module(mod)
-    false
-  } catch {
-    StackUnderflow(_) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(
+    try? validate_module(mod),
+    content=(
+      #|Err(StackUnderflow("Expected I32, but stack is empty"))
+    ),
+  )
 }
 
 ///|
@@ -131,14 +127,7 @@ test "validator: invalid local index" {
     codes: [func],
     datas: [],
   }
-  let result = try {
-    validate_module(mod)
-    false
-  } catch {
-    InvalidLocalIndex(5) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(try? validate_module(mod), content="Err(InvalidLocalIndex(5))")
 }
 
 ///|
@@ -221,14 +210,12 @@ test "validator: stack height - function returns too many values" {
     codes: [func],
     datas: [],
   }
-  let result = try {
-    validate_module(mod)
-    false
-  } catch {
-    StackHeightMismatch(_) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(
+    try? validate_module(mod),
+    content=(
+      #|Err(StackHeightMismatch("function return: expected stack height 1, got 2"))
+    ),
+  )
 }
 
 ///|
@@ -252,14 +239,10 @@ test "validator: stack height - function returns too few values" {
     codes: [func],
     datas: [],
   }
-  let result = try {
-    validate_module(mod)
-    false
-  } catch {
-    StackHeightMismatch(_) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(
+    (try? validate_module(mod)) is Err(StackHeightMismatch(_)),
+    content="true",
+  )
 }
 
 ///|
@@ -328,14 +311,10 @@ test "validator: stack height - block leaves wrong number of values" {
     codes: [func],
     datas: [],
   }
-  let result = try {
-    validate_module(mod)
-    false
-  } catch {
-    StackHeightMismatch(_) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(
+    (try? validate_module(mod)) is Err(StackHeightMismatch(_)),
+    content="true",
+  )
 }
 
 ///|
@@ -389,14 +368,10 @@ test "validator: stack height - void function with leftover values" {
     codes: [func],
     datas: [],
   }
-  let result = try {
-    validate_module(mod)
-    false
-  } catch {
-    StackHeightMismatch(_) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(
+    (try? validate_module(mod)) is Err(StackHeightMismatch(_)),
+    content="true",
+  )
 }
 
 ///|
@@ -449,14 +424,10 @@ test "validator: control flow - invalid label index" {
     codes: [func],
     datas: [],
   }
-  let result = try {
-    validate_module(mod)
-    false
-  } catch {
-    InvalidLabelIndex(0) => true
-    _ => false
-  }
-  inspect(result, content="true")
+  inspect(
+    (try? validate_module(mod)) is Err(InvalidLabelIndex(0)),
+    content="true",
+  )
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Replace complex try-catch patterns with concise `try?` syntax throughout the codebase
- Use `(try? expr) is Err(_)` for conditional error checks
- Use `(try? expr) is Ok(_)` for success checks
- Use `inspect(try? f(), content="Err(...)")` in tests for error checking

## Files Changed
- `cwasm/cwasm_wbtest.mbt`
- `executor/executor_wbtest.mbt`
- `main/main.mbt`
- `main/wast.mbt`
- `testsuite/executor.mbt`
- `testsuite/i32_wbtest.mbt`
- `testsuite/i64_wbtest.mbt`
- `testsuite/runner.mbt`
- `validator/validator_wbtest.mbt`
- `ERRATA.md` (marked todo as complete)

## Test plan
- [x] All 414 tests pass
- [x] `moon fmt` and `moon info` run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)