### PR TITLE
feat(validator): add validation error context with function index and instruction offset

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,7 +185,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 - [x] **友好的错误信息** ✅
   - [x] WAT 解析错误显示行号、列号和相关代码片段 (`format_wat_error`)
   - [x] 运行时错误包含调用栈信息 (`RuntimeErrorContext`)
-  - [ ] WASM 验证错误指明具体位置 (函数索引、指令偏移) - 待实现
+  - [x] WASM 验证错误指明具体位置 (函数索引、指令偏移) (`ValidationErrorContext`, `validate_module_with_context`)
 
 ---
 
@@ -477,7 +477,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 | 任务 | 所属阶段 | 理由 |
 |------|----------|------|
 | ~~**友好的错误信息**~~ | ~~Phase 5~~ | ✅ 已完成 |
-| **WASM 验证错误位置** | Phase 5 | 验证错误缺少函数索引和指令偏移 |
+| ~~**WASM 验证错误位置**~~ | ~~Phase 5~~ | ✅ 已完成 |
 | **WASI 文件系统** | Phase 12 | 文件操作是常见需求 |
 | - `path_open`/`fd_close` | 12.1 | 文件读写必需 |
 | - `fd_seek`/`fd_tell` | 12.1 | 随机访问文件 |

--- a/validator/pkg.generated.mbti
+++ b/validator/pkg.generated.mbti
@@ -6,7 +6,11 @@ import(
 )
 
 // Values
+pub fn format_validation_error(ValidationError) -> String
+
 pub fn validate_module(@types.Module) -> Unit raise ValidationError
+
+pub fn validate_module_with_context(@types.Module) -> Unit raise ValidationError
 
 // Errors
 pub(all) suberror ValidationError {
@@ -24,10 +28,24 @@ pub(all) suberror ValidationError {
   MultipleMemories
   MultipleTables
   InvalidLimits(String)
+  WithContext(ValidationErrorContext)
 }
 pub impl Show for ValidationError
 
 // Types and methods
+pub(all) struct ValidationErrorContext {
+  error_msg : String
+  func_idx : Int?
+  instr_offset : Int?
+  instruction : String?
+}
+pub fn ValidationErrorContext::format(Self) -> String
+pub fn ValidationErrorContext::from_error(ValidationError) -> Self
+pub fn ValidationErrorContext::new(String) -> Self
+pub fn ValidationErrorContext::with_func_idx(Self, Int) -> Self
+pub fn ValidationErrorContext::with_instr_offset(Self, Int) -> Self
+pub fn ValidationErrorContext::with_instruction(Self, String) -> Self
+pub impl Show for ValidationErrorContext
 
 // Type aliases
 

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -17,7 +17,107 @@ pub(all) suberror ValidationError {
   MultipleMemories // More than one memory is not allowed in MVP
   MultipleTables // More than one table is not allowed in MVP
   InvalidLimits(String) // Invalid limits (e.g., min > max)
+  // Error with location context
+  WithContext(ValidationErrorContext)
 } derive(Show)
+
+///|
+/// Validation error with location context for debugging
+pub(all) struct ValidationErrorContext {
+  error_msg : String // The original error message
+  func_idx : Int? // The function index where validation failed
+  instr_offset : Int? // The instruction offset within the function body
+  instruction : String? // The instruction that caused the error
+}
+
+///|
+pub fn ValidationErrorContext::new(msg : String) -> ValidationErrorContext {
+  { error_msg: msg, func_idx: None, instr_offset: None, instruction: None }
+}
+
+///|
+pub fn ValidationErrorContext::from_error(
+  error : ValidationError,
+) -> ValidationErrorContext {
+  let msg = match error {
+    TypeMismatch(m) => "type mismatch: \{m}"
+    StackUnderflow(m) => "stack underflow: \{m}"
+    StackHeightMismatch(m) => "stack height mismatch: \{m}"
+    InvalidFunctionIndex(idx) => "invalid function index: \{idx}"
+    InvalidTypeIndex(idx) => "invalid type index: \{idx}"
+    InvalidLocalIndex(idx) => "invalid local index: \{idx}"
+    InvalidGlobalIndex(idx) => "invalid global index: \{idx}"
+    InvalidTableIndex(idx) => "invalid table index: \{idx}"
+    InvalidMemoryIndex(idx) => "invalid memory index: \{idx}"
+    InvalidLabelIndex(idx) => "invalid label index: \{idx}"
+    UnreachableCode => "unreachable code"
+    MultipleMemories => "multiple memories not allowed in MVP"
+    MultipleTables => "multiple tables not allowed in MVP"
+    InvalidLimits(m) => "invalid limits: \{m}"
+    WithContext(ctx) => ctx.error_msg
+  }
+  { error_msg: msg, func_idx: None, instr_offset: None, instruction: None }
+}
+
+///|
+pub fn ValidationErrorContext::with_func_idx(
+  self : ValidationErrorContext,
+  idx : Int,
+) -> ValidationErrorContext {
+  { ..self, func_idx: Some(idx) }
+}
+
+///|
+pub fn ValidationErrorContext::with_instr_offset(
+  self : ValidationErrorContext,
+  offset : Int,
+) -> ValidationErrorContext {
+  { ..self, instr_offset: Some(offset) }
+}
+
+///|
+pub fn ValidationErrorContext::with_instruction(
+  self : ValidationErrorContext,
+  instr : String,
+) -> ValidationErrorContext {
+  { ..self, instruction: Some(instr) }
+}
+
+///|
+/// Format the validation error with full context for display
+pub fn ValidationErrorContext::format(self : ValidationErrorContext) -> String {
+  let result = StringBuilder::new()
+  result.write_string("validation error: ")
+  result.write_string(self.error_msg)
+  result.write_string("\n")
+
+  // Show function index if available
+  if self.func_idx is Some(idx) {
+    result.write_string("  in function: func[\{idx}]\n")
+  }
+
+  // Show instruction offset if available
+  if self.instr_offset is Some(offset) {
+    result.write_string("  at instruction offset: \{offset}\n")
+  }
+
+  // Show instruction if available
+  if self.instruction is Some(instr) {
+    result.write_string("  instruction: \{instr}\n")
+  }
+  result.to_string()
+}
+
+///|
+pub impl Show for ValidationErrorContext with output(self, logger) {
+  logger.write_string(self.format())
+}
+
+///|
+/// Format a basic ValidationError without context
+pub fn format_validation_error(error : ValidationError) -> String {
+  ValidationErrorContext::from_error(error).format()
+}
 
 ///|
 /// Label information for control flow validation
@@ -215,6 +315,130 @@ pub fn validate_module(mod : @types.Module) -> Unit raise ValidationError {
     }
     let func_type = ctx.types[type_idx]
     validate_function(ctx, func_type, code)
+  }
+}
+
+///|
+/// Validate a complete module and return detailed error context on failure
+pub fn validate_module_with_context(
+  mod : @types.Module,
+) -> Unit raise ValidationError {
+  let ctx = ValidationContext::new(mod)
+
+  // Check for multiple memories (not allowed in MVP)
+  if ctx.mems.length() > 1 {
+    raise WithContext(ValidationErrorContext::from_error(MultipleMemories))
+  }
+
+  // Check for multiple tables (not allowed in MVP)
+  if ctx.tables.length() > 1 {
+    raise WithContext(ValidationErrorContext::from_error(MultipleTables))
+  }
+
+  // Validate memory limits
+  for mem in ctx.mems {
+    validate_memory_limits(mem.limits) catch {
+      e => raise WithContext(ValidationErrorContext::from_error(e))
+    }
+  }
+
+  // Validate data segments reference valid memory
+  for data in mod.datas {
+    if data.memory_idx >= ctx.mems.length() {
+      raise WithContext(
+        ValidationErrorContext::from_error(InvalidMemoryIndex(data.memory_idx)),
+      )
+    }
+  }
+
+  // Validate all function bodies with location tracking
+  let num_imports = count_func_imports(mod.imports)
+  for i, code in mod.codes {
+    let func_idx = num_imports + i
+    let type_idx = ctx.funcs[func_idx]
+    if type_idx >= ctx.types.length() {
+      raise WithContext(
+        ValidationErrorContext::from_error(InvalidTypeIndex(type_idx)).with_func_idx(
+          func_idx,
+        ),
+      )
+    }
+    let func_type = ctx.types[type_idx]
+    validate_function_with_offset(ctx, func_type, code, func_idx)
+  }
+}
+
+///|
+/// Validate a function body with instruction offset tracking
+fn validate_function_with_offset(
+  ctx : ValidationContext,
+  func_type : @types.FuncType,
+  code : @types.FunctionCode,
+  func_idx : Int,
+) -> Unit raise ValidationError {
+  // Set up locals: params + declared locals
+  let locals : Array[@types.ValueType] = []
+  for param in func_type.params {
+    locals.push(param)
+  }
+  for local_type in code.locals {
+    locals.push(local_type)
+  }
+
+  // Create validation context for this function
+  let func_ctx : ValidationContext = {
+    types: ctx.types,
+    funcs: ctx.funcs,
+    tables: ctx.tables,
+    mems: ctx.mems,
+    globals: ctx.globals,
+    locals,
+    labels: [],
+    returns: func_type.results,
+  }
+  let stack = OperandStack::new()
+
+  // Validate function body with offset tracking
+  validate_expr_with_offset(func_ctx, stack, code.body, func_idx)
+
+  // Check that final stack has exactly the return types
+  let expected_height = func_type.results.length()
+  stack.check_height(expected_height, "function return") catch {
+    e =>
+      raise WithContext(
+        ValidationErrorContext::from_error(e).with_func_idx(func_idx),
+      )
+  }
+
+  // Pop and verify return types
+  for i = func_type.results.length() - 1; i >= 0; i = i - 1 {
+    stack.pop(func_type.results[i]) catch {
+      e =>
+        raise WithContext(
+          ValidationErrorContext::from_error(e).with_func_idx(func_idx),
+        )
+    }
+  }
+}
+
+///|
+/// Validate an expression with instruction offset tracking
+fn validate_expr_with_offset(
+  ctx : ValidationContext,
+  stack : OperandStack,
+  instrs : Array[@types.Instruction],
+  func_idx : Int,
+) -> Unit raise ValidationError {
+  for i, instr in instrs {
+    validate_instr(ctx, stack, instr) catch {
+      e =>
+        raise WithContext(
+          ValidationErrorContext::from_error(e)
+          .with_func_idx(func_idx)
+          .with_instr_offset(i)
+          .with_instruction(instr.to_string()),
+        )
+    }
   }
 }
 

--- a/validator/validator_wbtest.mbt
+++ b/validator/validator_wbtest.mbt
@@ -586,3 +586,133 @@ test "validator: control flow - br_table basic" {
   }
   validate_module(mod) // Should pass
 }
+
+// ============================================================
+// Error Context Tests
+// ============================================================
+
+///|
+test "validator: format_validation_error provides descriptive message" {
+  let formatted = format_validation_error(InvalidLocalIndex(5))
+  assert_true(formatted.contains("invalid local index"))
+  assert_true(formatted.contains("5"))
+}
+
+///|
+test "validator: ValidationErrorContext formats with function index" {
+  let ctx = ValidationErrorContext::from_error(
+    TypeMismatch("Expected I32, got I64"),
+  ).with_func_idx(3)
+  let formatted = ctx.format()
+  assert_true(formatted.contains("type mismatch"))
+  assert_true(formatted.contains("func[3]"))
+}
+
+///|
+test "validator: ValidationErrorContext formats with instruction offset" {
+  let ctx = ValidationErrorContext::from_error(
+      StackUnderflow("Expected I32, but stack is empty"),
+    )
+    .with_func_idx(2)
+    .with_instr_offset(5)
+    .with_instruction("i32.add")
+  let formatted = ctx.format()
+  assert_true(formatted.contains("stack underflow"))
+  assert_true(formatted.contains("func[2]"))
+  assert_true(formatted.contains("offset: 5"))
+  assert_true(formatted.contains("i32.add"))
+}
+
+///|
+test "validator: validate_module_with_context provides location on error" {
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [I64Const(1L), I32Const(2), I32Add], // Type mismatch at index 2
+  }
+  let func_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let result = try? validate_module_with_context(mod)
+  // Should fail with context
+  match result {
+    Err(WithContext(ctx)) => {
+      assert_true(ctx.func_idx is Some(0))
+      assert_true(ctx.instr_offset is Some(2))
+      assert_true(ctx.instruction is Some(_))
+    }
+    _ => panic()
+  }
+}
+
+///|
+test "validator: validate_module_with_context reports correct function index" {
+  // First function is valid, second has error
+  let func0 : @types.FunctionCode = { locals: [], body: [I32Const(42)] }
+  let func1 : @types.FunctionCode = { locals: [], body: [LocalGet(99)] } // Invalid local index
+  let func_type : @types.FuncType = {
+    params: [],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0, 0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [],
+    start: None,
+    elems: [],
+    codes: [func0, func1],
+    datas: [],
+  }
+  let result = try? validate_module_with_context(mod)
+  match result {
+    Err(WithContext(ctx)) => {
+      // Should report error in function 1 (not 0)
+      assert_true(ctx.func_idx is Some(1))
+      assert_true(ctx.instr_offset is Some(0))
+    }
+    _ => panic()
+  }
+}
+
+///|
+test "validator: all ValidationError types have descriptive messages" {
+  // Verify each error type produces a non-empty message
+  let errors : Array[ValidationError] = [
+    TypeMismatch("test"),
+    StackUnderflow("test"),
+    StackHeightMismatch("test"),
+    InvalidFunctionIndex(0),
+    InvalidTypeIndex(0),
+    InvalidLocalIndex(0),
+    InvalidGlobalIndex(0),
+    InvalidTableIndex(0),
+    InvalidMemoryIndex(0),
+    InvalidLabelIndex(0),
+    UnreachableCode,
+    MultipleMemories,
+    MultipleTables,
+    InvalidLimits("test"),
+  ]
+  for err in errors {
+    let formatted = format_validation_error(err)
+    assert_true(formatted.length() > 20) // Should have meaningful content
+    assert_true(formatted.contains("validation error"))
+  }
+}


### PR DESCRIPTION
## Summary
- Add `ValidationErrorContext` struct with `func_idx`, `instr_offset`, and `instruction` fields for detailed error location tracking
- Add `WithContext(ValidationErrorContext)` variant to `ValidationError` suberror
- Add `validate_module_with_context()` function that validates modules and returns errors with full location context
- Add `format_validation_error()` convenience function for formatted error output

## Example Output
When validation fails, the error now includes:
```
validation error: type mismatch: Expected I32, got I64
  in function: func[0]
  at instruction offset: 2
  instruction: I32Add
```

## Test plan
- [x] All 444 tests pass
- [x] Added 6 new tests for validation error context formatting
- [x] Tests verify function index and instruction offset are correctly reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)