### PR TITLE
feat(jit): add 8/16-bit narrow memory operations support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,7 +316,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
   - [x] 64位整数运算 (ADD, SUB, MUL, SDIV, UDIV)
   - [x] 64位浮点运算 (FADD, FSUB, FMUL, FDIV)
   - [x] 64位/32位内存操作 (LDR, STR)
-  - [ ] 8位/16位内存操作 (`MemType::I8/I16` 已定义但未使用)
+  - [x] 8位/16位内存操作 (LDRB, LDRH, LDRSB, LDRSH, STRB, STRH)
 - [x] 寄存器使用
 - [x] 条件执行
 - [x] AArch64 特有指令选择
@@ -427,7 +427,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 | Phase 7 | IR 优化 | ✅ 已完成 (7.4 可选跳过) |
 | Phase 8 | 指令选择 | ✅ 核心完成 (约束系统/多调用约定定义但未使用) |
 | Phase 9 | 寄存器分配 | ✅ 核心完成 (合并优化待实现) |
-| Phase 10 | 代码生成 | ✅ 核心完成 (8/16位内存操作、扩展指令待实现) |
+| Phase 10 | 代码生成 | ✅ 核心完成 (扩展指令待实现) |
 | Phase 11 | JIT 集成 | 🔨 进行中 (OSR、完整调试命令待实现) |
 | Phase 12 | WASI 支持 | 📋 未来计划 |
 | Phase 13 | WASM 扩展 | 📋 未来计划 |
@@ -453,7 +453,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 
 ---
 
-**当前状态**: Phase 8-11 核心功能已完成，部分高级功能（操作数约束、多调用约定、8/16位内存操作、扩展指令、调试步进命令）已定义接口但未实现
+**当前状态**: Phase 8-11 核心功能已完成，部分高级功能（操作数约束、多调用约定、扩展指令、调试步进命令）已定义接口但未实现
 **下一步**: 见下方优先级排序
 
 ---
@@ -481,7 +481,7 @@ Wasmoon 是一个用 MoonBit 编写的 WebAssembly 运行时，目标是实现�
 | **WASI 文件系统** | Phase 12 | 文件操作是常见需求 |
 | - `path_open`/`fd_close` | 12.1 | 文件读写必需 |
 | - `fd_seek`/`fd_tell` | 12.1 | 随机访问文件 |
-| **8/16位内存操作** | Phase 10 | 某些 WASM 程序可能使用 |
+| ~~**8/16位内存操作**~~ | ~~Phase 10~~ | ✅ 已完成 |
 | **扩展指令 (ExtendKind)** | Phase 10 | 类型转换完整性 |
 | **寄存器合并 (Coalescing)** | Phase 9 | 提升 JIT 代码质量 |
 
@@ -529,7 +529,6 @@ Phase 12 WASI 文件系统 (P1)
          ▼
 Phase 10 完善 (P1)
     │
-    ├─► 8/16位内存操作
     └─► ExtendKind 指令
          │
          ▼

--- a/ir/builder.mbt
+++ b/ir/builder.mbt
@@ -477,6 +477,70 @@ pub fn IRBuilder::load(
 }
 
 ///|
+/// Load 8-bit signed value and extend to target type
+pub fn IRBuilder::load8_s(
+  self : IRBuilder,
+  ty : Type,
+  addr : Value,
+  offset : Int,
+) -> Value {
+  self.emit_inst(ty, Opcode::Load8S(ty, offset), [addr])
+}
+
+///|
+/// Load 8-bit unsigned value and extend to target type
+pub fn IRBuilder::load8_u(
+  self : IRBuilder,
+  ty : Type,
+  addr : Value,
+  offset : Int,
+) -> Value {
+  self.emit_inst(ty, Opcode::Load8U(ty, offset), [addr])
+}
+
+///|
+/// Load 16-bit signed value and extend to target type
+pub fn IRBuilder::load16_s(
+  self : IRBuilder,
+  ty : Type,
+  addr : Value,
+  offset : Int,
+) -> Value {
+  self.emit_inst(ty, Opcode::Load16S(ty, offset), [addr])
+}
+
+///|
+/// Load 16-bit unsigned value and extend to target type
+pub fn IRBuilder::load16_u(
+  self : IRBuilder,
+  ty : Type,
+  addr : Value,
+  offset : Int,
+) -> Value {
+  self.emit_inst(ty, Opcode::Load16U(ty, offset), [addr])
+}
+
+///|
+/// Load 32-bit signed value and extend to i64
+pub fn IRBuilder::load32_s(
+  self : IRBuilder,
+  addr : Value,
+  offset : Int,
+) -> Value {
+  self.emit_inst(Type::I64, Opcode::Load32S(offset), [addr])
+}
+
+///|
+/// Load 32-bit unsigned value and extend to i64
+pub fn IRBuilder::load32_u(
+  self : IRBuilder,
+  addr : Value,
+  offset : Int,
+) -> Value {
+  self.emit_inst(Type::I64, Opcode::Load32U(offset), [addr])
+}
+
+///|
 /// Store to memory
 pub fn IRBuilder::store(
   self : IRBuilder,
@@ -486,6 +550,39 @@ pub fn IRBuilder::store(
   offset : Int,
 ) -> Unit {
   self.emit_void_inst(Opcode::Store(ty, offset), [addr, value])
+}
+
+///|
+/// Store low 8 bits of value
+pub fn IRBuilder::store8(
+  self : IRBuilder,
+  addr : Value,
+  value : Value,
+  offset : Int,
+) -> Unit {
+  self.emit_void_inst(Opcode::Store8(offset), [addr, value])
+}
+
+///|
+/// Store low 16 bits of value
+pub fn IRBuilder::store16(
+  self : IRBuilder,
+  addr : Value,
+  value : Value,
+  offset : Int,
+) -> Unit {
+  self.emit_void_inst(Opcode::Store16(offset), [addr, value])
+}
+
+///|
+/// Store low 32 bits of i64 value
+pub fn IRBuilder::store32(
+  self : IRBuilder,
+  addr : Value,
+  value : Value,
+  offset : Int,
+) -> Unit {
+  self.emit_void_inst(Opcode::Store32(offset), [addr, value])
 }
 
 // ============ Misc Operations ============

--- a/ir/ir.mbt
+++ b/ir/ir.mbt
@@ -153,6 +153,17 @@ pub enum Opcode {
   Load(Type, Int) // Load from memory (type, offset)
   Store(Type, Int) // Store to memory (type, offset)
 
+  // Narrow memory operations (8/16-bit with sign/zero extension)
+  Load8S(Type, Int) // Load 8-bit signed and extend to Type (offset)
+  Load8U(Type, Int) // Load 8-bit unsigned and extend to Type (offset)
+  Load16S(Type, Int) // Load 16-bit signed and extend to Type (offset)
+  Load16U(Type, Int) // Load 16-bit unsigned and extend to Type (offset)
+  Load32S(Int) // Load 32-bit signed and extend to i64 (offset)
+  Load32U(Int) // Load 32-bit unsigned and extend to i64 (offset)
+  Store8(Int) // Store low 8 bits (offset)
+  Store16(Int) // Store low 16 bits (offset)
+  Store32(Int) // Store low 32 bits of i64 (offset)
+
   // Misc
   Select // Conditional select (cond ? a : b)
   Copy // Copy value (for register allocation)

--- a/ir/pkg.generated.mbti
+++ b/ir/pkg.generated.mbti
@@ -160,6 +160,12 @@ pub fn IRBuilder::ishl(Self, Value, Value) -> Value
 pub fn IRBuilder::isub(Self, Value, Value) -> Value
 pub fn IRBuilder::jump(Self, Block, Array[Value]) -> Unit
 pub fn IRBuilder::load(Self, Type, Value, Int) -> Value
+pub fn IRBuilder::load16_s(Self, Type, Value, Int) -> Value
+pub fn IRBuilder::load16_u(Self, Type, Value, Int) -> Value
+pub fn IRBuilder::load32_s(Self, Value, Int) -> Value
+pub fn IRBuilder::load32_u(Self, Value, Int) -> Value
+pub fn IRBuilder::load8_s(Self, Type, Value, Int) -> Value
+pub fn IRBuilder::load8_u(Self, Type, Value, Int) -> Value
 pub fn IRBuilder::new(String) -> Self
 pub fn IRBuilder::print(Self) -> String
 pub fn IRBuilder::return_(Self, Array[Value]) -> Unit
@@ -172,6 +178,9 @@ pub fn IRBuilder::sint_to_fcvt(Self, Type, Value) -> Value
 pub fn IRBuilder::srem(Self, Value, Value) -> Value
 pub fn IRBuilder::sshr(Self, Value, Value) -> Value
 pub fn IRBuilder::store(Self, Type, Value, Value, Int) -> Unit
+pub fn IRBuilder::store16(Self, Value, Value, Int) -> Unit
+pub fn IRBuilder::store32(Self, Value, Value, Int) -> Unit
+pub fn IRBuilder::store8(Self, Value, Value, Int) -> Unit
 pub fn IRBuilder::switch_to_block(Self, Block) -> Unit
 pub fn IRBuilder::trap(Self, String) -> Unit
 pub fn IRBuilder::udiv(Self, Value, Value) -> Value
@@ -254,6 +263,15 @@ pub enum Opcode {
   Bitcast
   Load(Type, Int)
   Store(Type, Int)
+  Load8S(Type, Int)
+  Load8U(Type, Int)
+  Load16S(Type, Int)
+  Load16U(Type, Int)
+  Load32S(Int)
+  Load32U(Int)
+  Store8(Int)
+  Store16(Int)
+  Store32(Int)
   Select
   Copy
   Call(Int)

--- a/ir/printer.mbt
+++ b/ir/printer.mbt
@@ -117,6 +117,17 @@ fn format_opcode(opcode : Opcode, operands : Array[Value]) -> String {
     // Memory operations
     Load(ty, offset) => "load.\{format_type(ty)} \{ops} +\{offset}"
     Store(ty, offset) => "store.\{format_type(ty)} \{ops} +\{offset}"
+    // Narrow load operations (8/16/32-bit with sign/zero extension)
+    Load8S(ty, offset) => "load8_s.\{format_type(ty)} \{ops} +\{offset}"
+    Load8U(ty, offset) => "load8_u.\{format_type(ty)} \{ops} +\{offset}"
+    Load16S(ty, offset) => "load16_s.\{format_type(ty)} \{ops} +\{offset}"
+    Load16U(ty, offset) => "load16_u.\{format_type(ty)} \{ops} +\{offset}"
+    Load32S(offset) => "load32_s \{ops} +\{offset}"
+    Load32U(offset) => "load32_u \{ops} +\{offset}"
+    // Narrow store operations (8/16/32-bit)
+    Store8(offset) => "store8 \{ops} +\{offset}"
+    Store16(offset) => "store16 \{ops} +\{offset}"
+    Store32(offset) => "store32 \{ops} +\{offset}"
 
     // Misc
     Select => "select \{ops}"

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -464,6 +464,58 @@ fn Translator::translate_instruction(
       let result = self.builder.load(Type::F64, addr, offset)
       self.push(result)
     }
+
+    // Narrow load operations (8/16/32-bit with sign/zero extension)
+    I32Load8S(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load8_s(Type::I32, addr, offset)
+      self.push(result)
+    }
+    I32Load8U(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load8_u(Type::I32, addr, offset)
+      self.push(result)
+    }
+    I32Load16S(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load16_s(Type::I32, addr, offset)
+      self.push(result)
+    }
+    I32Load16U(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load16_u(Type::I32, addr, offset)
+      self.push(result)
+    }
+    I64Load8S(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load8_s(Type::I64, addr, offset)
+      self.push(result)
+    }
+    I64Load8U(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load8_u(Type::I64, addr, offset)
+      self.push(result)
+    }
+    I64Load16S(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load16_s(Type::I64, addr, offset)
+      self.push(result)
+    }
+    I64Load16U(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load16_u(Type::I64, addr, offset)
+      self.push(result)
+    }
+    I64Load32S(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load32_s(addr, offset)
+      self.push(result)
+    }
+    I64Load32U(_, offset) => {
+      let addr = self.pop()
+      let result = self.builder.load32_u(addr, offset)
+      self.push(result)
+    }
     I32Store(_, offset) => {
       let value = self.pop()
       let addr = self.pop()
@@ -483,6 +535,33 @@ fn Translator::translate_instruction(
       let value = self.pop()
       let addr = self.pop()
       self.builder.store(Type::F64, addr, value, offset)
+    }
+
+    // Narrow store operations (8/16/32-bit)
+    I32Store8(_, offset) => {
+      let value = self.pop()
+      let addr = self.pop()
+      self.builder.store8(addr, value, offset)
+    }
+    I32Store16(_, offset) => {
+      let value = self.pop()
+      let addr = self.pop()
+      self.builder.store16(addr, value, offset)
+    }
+    I64Store8(_, offset) => {
+      let value = self.pop()
+      let addr = self.pop()
+      self.builder.store8(addr, value, offset)
+    }
+    I64Store16(_, offset) => {
+      let value = self.pop()
+      let addr = self.pop()
+      self.builder.store16(addr, value, offset)
+    }
+    I64Store32(_, offset) => {
+      let value = self.pop()
+      let addr = self.pop()
+      self.builder.store32(addr, value, offset)
     }
 
     // Control flow

--- a/ir/validator.mbt
+++ b/ir/validator.mbt
@@ -210,6 +210,27 @@ fn validate_instruction(
         )
       }
 
+    // Narrow load operations need 1 operand (address)
+    Load8S(_, _)
+    | Load8U(_, _)
+    | Load16S(_, _)
+    | Load16U(_, _)
+    | Load32S(_)
+    | Load32U(_) =>
+      if inst.operands.length() != 1 {
+        result.add_error(
+          "Narrow load expects 1 operand (address), got \{inst.operands.length()}",
+        )
+      }
+
+    // Narrow store operations need 2 operands (address, value)
+    Store8(_) | Store16(_) | Store32(_) =>
+      if inst.operands.length() != 2 {
+        result.add_error(
+          "Narrow store expects 2 operands (address, value), got \{inst.operands.length()}",
+        )
+      }
+
     // Conversions need 1 operand
     Ireduce
     | Sextend

--- a/vcode/emit.mbt
+++ b/vcode/emit.mbt
@@ -711,6 +711,93 @@ pub fn emit_str_w_imm(
   mc.emit_inst(b0, b1, b2, b3)
 }
 
+// ============ Sign-Extending Load Instructions ============
+
+///|
+/// Encode LDRSB (64-bit result, unsigned offset): LDRSB Xt, [Xn, #imm]
+/// Opcode: 0x39800000
+pub fn emit_ldrsb_x_imm(
+  mc : MachineCode,
+  rt : Int,
+  rn : Int,
+  imm12 : Int,
+) -> Unit {
+  let imm = imm12 & 0xFFF
+  let b0 = (rt & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((imm & 31) << 3)
+  let b2 = ((imm >> 5) & 127) | 128 // bit 7 = 1 for signed + 64-bit
+  let b3 = 57 // 0x39
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode LDRSB (32-bit result, unsigned offset): LDRSB Wt, [Xn, #imm]
+/// Opcode: 0x39C00000
+pub fn emit_ldrsb_w_imm(
+  mc : MachineCode,
+  rt : Int,
+  rn : Int,
+  imm12 : Int,
+) -> Unit {
+  let imm = imm12 & 0xFFF
+  let b0 = (rt & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((imm & 31) << 3)
+  let b2 = ((imm >> 5) & 127) | 192 // bit 7,6 = 11 for signed + 32-bit
+  let b3 = 57 // 0x39
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode LDRSH (64-bit result, unsigned offset): LDRSH Xt, [Xn, #imm]
+/// Opcode: 0x79800000
+pub fn emit_ldrsh_x_imm(
+  mc : MachineCode,
+  rt : Int,
+  rn : Int,
+  imm12 : Int,
+) -> Unit {
+  let scaled = (imm12 / 2) & 0xFFF
+  let b0 = (rt & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((scaled & 31) << 3)
+  let b2 = ((scaled >> 5) & 127) | 128 // bit 7 = 1 for signed + 64-bit
+  let b3 = 121 // 0x79
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode LDRSH (32-bit result, unsigned offset): LDRSH Wt, [Xn, #imm]
+/// Opcode: 0x79C00000
+pub fn emit_ldrsh_w_imm(
+  mc : MachineCode,
+  rt : Int,
+  rn : Int,
+  imm12 : Int,
+) -> Unit {
+  let scaled = (imm12 / 2) & 0xFFF
+  let b0 = (rt & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((scaled & 31) << 3)
+  let b2 = ((scaled >> 5) & 127) | 192 // bit 7,6 = 11 for signed + 32-bit
+  let b3 = 121 // 0x79
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
+///|
+/// Encode LDRSW (unsigned offset): LDRSW Xt, [Xn, #imm]
+/// Opcode: 0xB9800000
+pub fn emit_ldrsw_imm(
+  mc : MachineCode,
+  rt : Int,
+  rn : Int,
+  imm12 : Int,
+) -> Unit {
+  let scaled = (imm12 / 4) & 0xFFF
+  let b0 = (rt & 31) | ((rn & 3) << 5)
+  let b1 = ((rn >> 2) & 7) | ((scaled & 31) << 3)
+  let b2 = ((scaled >> 5) & 127) | 128 // bit 7 = 1 for signed
+  let b3 = 185 // 0xB9
+  mc.emit_inst(b0, b1, b2, b3)
+}
+
 // ============ Branch Instructions ============
 
 ///|
@@ -1098,6 +1185,43 @@ fn emit_instruction(mc : MachineCode, inst : VCodeInst) -> Unit {
       let rt = reg_num(inst.uses[0])
       let rn = reg_num(inst.uses[1])
       emit_store(mc, ty, rt, rn, offset)
+    }
+    // Narrow load operations (8/16/32-bit with sign/zero extension)
+    Load8S(offset) => {
+      let rt = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      // Sign-extend to 64-bit (use LDRSB Xt form)
+      emit_ldrsb_x_imm(mc, rt, rn, offset)
+    }
+    Load8U(offset) => {
+      let rt = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      // Zero-extend (LDRB already zero-extends)
+      emit_ldrb_imm(mc, rt, rn, offset)
+    }
+    Load16S(offset) => {
+      let rt = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      // Sign-extend to 64-bit (use LDRSH Xt form)
+      emit_ldrsh_x_imm(mc, rt, rn, offset)
+    }
+    Load16U(offset) => {
+      let rt = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      // Zero-extend (LDRH already zero-extends)
+      emit_ldrh_imm(mc, rt, rn, offset)
+    }
+    Load32S(offset) => {
+      let rt = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      // Sign-extend 32-bit to 64-bit
+      emit_ldrsw_imm(mc, rt, rn, offset)
+    }
+    Load32U(offset) => {
+      let rt = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      // Zero-extend (LDR W already zero-extends to 64-bit)
+      emit_ldr_w_imm(mc, rt, rn, offset)
     }
     Move => {
       let rd = wreg_num(inst.defs[0])

--- a/vcode/lower.mbt
+++ b/vcode/lower.mbt
@@ -242,6 +242,26 @@ fn lower_inst(
     @ir.Opcode::Load(ty, offset) => lower_load(ctx, inst, block, ty, offset)
     @ir.Opcode::Store(ty, offset) => lower_store(ctx, inst, block, ty, offset)
 
+    // Narrow memory operations (8/16/32-bit with sign/zero extension)
+    @ir.Opcode::Load8S(_ty, offset) =>
+      lower_load_narrow(ctx, inst, block, offset, fn(o) { Load8S(o) })
+    @ir.Opcode::Load8U(_ty, offset) =>
+      lower_load_narrow(ctx, inst, block, offset, fn(o) { Load8U(o) })
+    @ir.Opcode::Load16S(_ty, offset) =>
+      lower_load_narrow(ctx, inst, block, offset, fn(o) { Load16S(o) })
+    @ir.Opcode::Load16U(_ty, offset) =>
+      lower_load_narrow(ctx, inst, block, offset, fn(o) { Load16U(o) })
+    @ir.Opcode::Load32S(offset) =>
+      lower_load_narrow(ctx, inst, block, offset, fn(o) { Load32S(o) })
+    @ir.Opcode::Load32U(offset) =>
+      lower_load_narrow(ctx, inst, block, offset, fn(o) { Load32U(o) })
+    @ir.Opcode::Store8(offset) =>
+      lower_store_narrow(ctx, inst, block, offset, I8)
+    @ir.Opcode::Store16(offset) =>
+      lower_store_narrow(ctx, inst, block, offset, I16)
+    @ir.Opcode::Store32(offset) =>
+      lower_store_narrow(ctx, inst, block, offset, I32)
+
     // Conversions
     @ir.Opcode::Sextend => lower_extend(ctx, inst, block, signed=true)
     @ir.Opcode::Uextend => lower_extend(ctx, inst, block, signed=false)
@@ -782,6 +802,46 @@ fn lower_store(
   let addr = ctx.get_vreg(inst.operands[0])
   let value = ctx.get_vreg(inst.operands[1])
   let mem_ty = ir_type_to_mem_type(ty)
+  let vcode_inst = VCodeInst::new(Store(mem_ty, offset))
+  vcode_inst.add_use(Virtual(addr))
+  vcode_inst.add_use(Virtual(value))
+  block.add_inst(vcode_inst)
+}
+
+///|
+/// Lower narrow load instruction (8/16/32-bit with sign/zero extension)
+fn lower_load_narrow(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : VCodeBlock,
+  offset : Int,
+  opcode_fn : (Int) -> VCodeOpcode,
+) -> Unit {
+  match inst.result {
+    Some(result) => {
+      let dst = ctx.get_vreg(result)
+      let addr = ctx.get_vreg(inst.operands[0])
+      let vcode_inst = VCodeInst::new(opcode_fn(offset))
+      vcode_inst.add_def({ reg: Virtual(dst) })
+      vcode_inst.add_use(Virtual(addr))
+      block.add_inst(vcode_inst)
+    }
+    None => ()
+  }
+}
+
+///|
+/// Lower narrow store instruction (8/16/32-bit)
+fn lower_store_narrow(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : VCodeBlock,
+  offset : Int,
+  mem_ty : MemType,
+) -> Unit {
+  // Store has no result, just uses: addr, value
+  let addr = ctx.get_vreg(inst.operands[0])
+  let value = ctx.get_vreg(inst.operands[1])
   let vcode_inst = VCodeInst::new(Store(mem_ty, offset))
   vcode_inst.add_use(Virtual(addr))
   vcode_inst.add_use(Virtual(value))

--- a/vcode/pkg.generated.mbti
+++ b/vcode/pkg.generated.mbti
@@ -85,6 +85,16 @@ pub fn emit_ldrb_imm(MachineCode, Int, Int, Int) -> Unit
 
 pub fn emit_ldrh_imm(MachineCode, Int, Int, Int) -> Unit
 
+pub fn emit_ldrsb_w_imm(MachineCode, Int, Int, Int) -> Unit
+
+pub fn emit_ldrsb_x_imm(MachineCode, Int, Int, Int) -> Unit
+
+pub fn emit_ldrsh_w_imm(MachineCode, Int, Int, Int) -> Unit
+
+pub fn emit_ldrsh_x_imm(MachineCode, Int, Int, Int) -> Unit
+
+pub fn emit_ldrsw_imm(MachineCode, Int, Int, Int) -> Unit
+
 pub fn emit_load_imm64(MachineCode, Int, Int64) -> Unit
 
 pub fn emit_lsl_reg(MachineCode, Int, Int, Int) -> Unit
@@ -705,6 +715,12 @@ pub enum VCodeOpcode {
   FDiv
   Load(MemType, Int)
   Store(MemType, Int)
+  Load8S(Int)
+  Load8U(Int)
+  Load16S(Int)
+  Load16U(Int)
+  Load32S(Int)
+  Load32U(Int)
   Move
   LoadConst(Int64)
   LoadConstF(Double)

--- a/vcode/vcode.mbt
+++ b/vcode/vcode.mbt
@@ -278,6 +278,13 @@ pub enum VCodeOpcode {
   // Memory operations
   Load(MemType, Int) // type, offset
   Store(MemType, Int) // type, offset
+  // Narrow load operations (8/16-bit with sign/zero extension)
+  Load8S(Int) // Load 8-bit signed, sign-extend to 32/64-bit (offset)
+  Load8U(Int) // Load 8-bit unsigned, zero-extend to 32/64-bit (offset)
+  Load16S(Int) // Load 16-bit signed, sign-extend to 32/64-bit (offset)
+  Load16U(Int) // Load 16-bit unsigned, zero-extend to 32/64-bit (offset)
+  Load32S(Int) // Load 32-bit signed, sign-extend to 64-bit (offset)
+  Load32U(Int) // Load 32-bit unsigned, zero-extend to 64-bit (offset)
   // Moves
   Move
   LoadConst(Int64) // Load immediate
@@ -325,6 +332,12 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     FDiv => "fdiv"
     Load(ty, offset) => "load.\{ty} +\{offset}"
     Store(ty, offset) => "store.\{ty} +\{offset}"
+    Load8S(offset) => "load8s +\{offset}"
+    Load8U(offset) => "load8u +\{offset}"
+    Load16S(offset) => "load16s +\{offset}"
+    Load16U(offset) => "load16u +\{offset}"
+    Load32S(offset) => "load32s +\{offset}"
+    Load32U(offset) => "load32u +\{offset}"
     Move => "mov"
     LoadConst(v) => "ldi \{v}"
     LoadConstF(v) => "ldf \{v}"


### PR DESCRIPTION
## Summary

- Add full JIT pipeline support for WASM 8/16/32-bit narrow memory load/store instructions
- Implement IR opcodes for narrow loads with sign/zero extension (Load8S/U, Load16S/U, Load32S/U, Store8/16/32)
- Add AArch64 instruction encoders for signed-extending loads (LDRSB, LDRSH, LDRSW)
- Update ROADMAP.md to mark this task as complete

## Test plan

- [x] All 444 existing tests pass
- [x] `moon check` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)