### PR TITLE
feat(wat): support multi-value blocks with params and results

### DIFF
--- a/disasm/disasm.mbt
+++ b/disasm/disasm.mbt
@@ -383,6 +383,32 @@ fn write_block_type(buf : StringBuilder, bt : @types.BlockType) -> Unit {
       write_value_type(buf, vt)
       buf.write_string(")")
     }
+    MultiValue(vts) => {
+      buf.write_string(" (result")
+      for vt in vts {
+        buf.write_string(" ")
+        write_value_type(buf, vt)
+      }
+      buf.write_string(")")
+    }
+    InlineType(params, results) => {
+      if params.length() > 0 {
+        buf.write_string(" (param")
+        for vt in params {
+          buf.write_string(" ")
+          write_value_type(buf, vt)
+        }
+        buf.write_string(")")
+      }
+      if results.length() > 0 {
+        buf.write_string(" (result")
+        for vt in results {
+          buf.write_string(" ")
+          write_value_type(buf, vt)
+        }
+        buf.write_string(")")
+      }
+    }
     TypeIndex(idx) => {
       buf.write_string(" (type ")
       buf.write_string(idx.to_string())

--- a/executor/instr_control.mbt
+++ b/executor/instr_control.mbt
@@ -6,6 +6,8 @@ fn ExecContext::block_arity(self : ExecContext, bt : @types.BlockType) -> Int {
   match bt {
     Empty => 0
     Value(_) => 1
+    MultiValue(types) => types.length()
+    InlineType(_, results) => results.length()
     TypeIndex(idx) => self.instance.types[idx].results.length()
   }
 }
@@ -19,6 +21,8 @@ fn ExecContext::block_param_arity(
   match bt {
     Empty => 0
     Value(_) => 0 // Single value blocks have no params
+    MultiValue(_) => 0 // MultiValue blocks have no params (result-only)
+    InlineType(params, _) => params.length()
     TypeIndex(idx) => self.instance.types[idx].params.length()
   }
 }

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -116,6 +116,8 @@ fn get_block_result_types(
   match block_type {
     Empty => []
     Value(vt) => [Type::from_wasm(vt)]
+    MultiValue(vts) => vts.map(Type::from_wasm)
+    InlineType(_, results) => results.map(Type::from_wasm)
     TypeIndex(idx) =>
       if idx < func_types.length() {
         func_types[idx].results.map(Type::from_wasm)
@@ -134,6 +136,8 @@ fn get_block_param_types(
   match block_type {
     Empty => []
     Value(_) => [] // Simple block types have no params
+    MultiValue(_) => [] // MultiValue blocks have no params (result-only)
+    InlineType(params, _) => params.map(Type::from_wasm)
     TypeIndex(idx) =>
       if idx < func_types.length() {
         func_types[idx].params.map(Type::from_wasm)

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -9,6 +9,8 @@ package "Milky2018/wasmoon/types"
 pub(all) enum BlockType {
   Empty
   Value(ValueType)
+  MultiValue(Array[ValueType])
+  InlineType(Array[ValueType], Array[ValueType])
   TypeIndex(Int)
 }
 pub impl Eq for BlockType

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -267,6 +267,8 @@ pub(all) enum Instruction {
 pub(all) enum BlockType {
   Empty
   Value(ValueType)
+  MultiValue(Array[ValueType]) // Multi-value results only (e.g., result i32 i64)
+  InlineType(Array[ValueType], Array[ValueType]) // (params, results) for blocks with params
   TypeIndex(Int)
 } derive(Eq, Show)
 

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -1176,6 +1176,8 @@ fn get_block_results(
   match bt {
     Empty => []
     Value(t) => [t]
+    MultiValue(types) => types
+    InlineType(_, results) => results
     TypeIndex(idx) =>
       if idx < ctx.types.length() {
         ctx.types[idx].results
@@ -1193,6 +1195,8 @@ fn get_block_params(
   match bt {
     Empty => []
     Value(_) => [] // Single value blocks have no params
+    MultiValue(_) => [] // MultiValue blocks have no params (result-only)
+    InlineType(params, _) => params
     TypeIndex(idx) =>
       if idx < ctx.types.length() {
         ctx.types[idx].params

--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -1424,24 +1424,72 @@ fn log2(n : Int) -> Int {
 
 ///|
 fn Parser::parse_block_type(self : Parser) -> @types.BlockType raise WatError {
-  // Check for (result type)
-  if self.current == LParen {
+  let params : Array[@types.ValueType] = []
+  let results : Array[@types.ValueType] = []
+  let mut type_idx : Int? = None
+
+  // Parse optional (type $idx) and/or (param ...) (result ...)
+  while self.current == LParen {
     let saved = self.lexer.pos
+    let saved_line = self.lexer.line
+    let saved_column = self.lexer.column
+    let saved_token_start_line = self.lexer.token_start_line
+    let saved_token_start_column = self.lexer.token_start_column
     self.advance()
     match self.current {
+      Keyword("type") => {
+        // (type $idx) - explicit type reference
+        self.advance()
+        type_idx = Some(self.parse_type_idx())
+        self.expect_rparen()
+        // Continue to parse any inline param/result annotations (they are optional redundant info)
+      }
+      Keyword("param") => {
+        self.advance()
+        // Skip optional name
+        if self.current is Id(_) {
+          self.advance()
+        }
+        while self.current != RParen {
+          params.push(self.parse_value_type())
+        }
+        self.expect_rparen()
+      }
       Keyword("result") => {
         self.advance()
-        let vt = self.parse_value_type()
+        while self.current != RParen {
+          results.push(self.parse_value_type())
+        }
         self.expect_rparen()
-        return @types.BlockType::Value(vt)
       }
       _ => {
+        // Not a block type annotation, restore state
         self.lexer.pos = saved
+        self.lexer.line = saved_line
+        self.lexer.column = saved_column
+        self.lexer.token_start_line = saved_token_start_line
+        self.lexer.token_start_column = saved_token_start_column
         self.current = LParen
+        break
       }
     }
   }
-  @types.BlockType::Empty
+
+  // Determine the block type variant
+  // If we have explicit type index, use it (param/result are just annotations)
+  if type_idx is Some(idx) {
+    return @types.BlockType::TypeIndex(idx)
+  }
+  if params.length() > 0 {
+    // Has parameters - use InlineType
+    @types.BlockType::InlineType(params, results)
+  } else if results.length() == 0 {
+    @types.BlockType::Empty
+  } else if results.length() == 1 {
+    @types.BlockType::Value(results[0])
+  } else {
+    @types.BlockType::MultiValue(results)
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Add `BlockType::MultiValue` for blocks with multiple result types (e.g., `(block (result i32 i64) ...)`)
- Add `BlockType::InlineType` for blocks with params (e.g., `(block (param i32) (result i32) ...)`)
- Support explicit type annotations with `(type $idx)` combined with inline param/result annotations
- Support multiple `(param)` and `(result)` clauses in block type definitions

## Test plan
- [x] All existing tests pass (509/509)
- [x] block.wast now parses successfully (219/222 tests pass, 3 failures are runtime issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)