### PR TITLE
fix(ir): correctly resolve import function types in translator

### DIFF
--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -341,6 +341,7 @@ test "bench_ir_translate_simple" (b : @bench.T) {
         [func_type],
         [0],
         0,
+        [],
       )
       translator.translate(instructions) |> ignore
     },
@@ -379,6 +380,7 @@ test "bench_ir_translate_complex" (b : @bench.T) {
         [func_type],
         [0],
         0,
+        [],
       )
       translator.translate(instructions) |> ignore
     },
@@ -430,6 +432,7 @@ test "bench_ir_translate_with_control_flow" (b : @bench.T) {
         [func_type],
         [0],
         0,
+        [],
       )
       translator.translate(instructions) |> ignore
     },
@@ -783,6 +786,7 @@ test "bench_pipeline_translate_only" (b : @bench.T) {
         [func_type],
         [0],
         0,
+        [],
       )
       translator.translate(instructions) |> ignore
     },
@@ -814,6 +818,7 @@ test "bench_pipeline_translate_and_optimize" (b : @bench.T) {
         [func_type],
         [0],
         0,
+        [],
       )
       let ir_func = translator.translate(instructions)
       @ir.optimize(ir_func) |> ignore
@@ -846,6 +851,7 @@ test "bench_pipeline_translate_optimize_lower" (b : @bench.T) {
         [func_type],
         [0],
         0,
+        [],
       )
       let ir_func = translator.translate(instructions)
       @ir.optimize(ir_func) |> ignore
@@ -879,6 +885,7 @@ test "bench_pipeline_full" (b : @bench.T) {
         [func_type],
         [0],
         0,
+        [],
       )
       let ir_func = translator.translate(instructions)
       @ir.optimize(ir_func) |> ignore
@@ -957,6 +964,7 @@ test "bench_compare_compilation_overhead" (b : @bench.T) {
         [func_type],
         [0],
         0,
+        [],
       )
       let ir_func = translator.translate(instructions)
       @ir.optimize(ir_func) |> ignore

--- a/ir/ir_wbtest.mbt
+++ b/ir/ir_wbtest.mbt
@@ -188,7 +188,7 @@ test "translate simple add function" {
     @types.Instruction::LocalGet(1),
     @types.Instruction::I32Add,
   ]
-  let translator = Translator::new("add", func_type, [], [func_type], [0], 0)
+  let translator = Translator::new("add", func_type, [], [func_type], [0], 0, [])
   let func = translator.translate(instrs)
   let output = func.print()
   let expected =
@@ -222,6 +222,7 @@ test "translate multiply and add" {
     [func_type],
     [0],
     0,
+    [],
   )
   let func = translator.translate(instrs)
   let output = func.print()
@@ -264,6 +265,7 @@ test "translate with local variable" {
     [func_type],
     [0],
     0,
+    [],
   )
   let func = translator.translate(instrs)
   let output = func.print()
@@ -297,7 +299,7 @@ test "translate comparison" {
     @types.Instruction::I32GtS,
     @types.Instruction::Select,
   ]
-  let translator = Translator::new("max", func_type, [], [func_type], [0], 0)
+  let translator = Translator::new("max", func_type, [], [func_type], [0], 0, [])
   let func = translator.translate(instrs)
   let output = func.print()
   let expected =
@@ -356,7 +358,7 @@ test "validate translated function" {
     @types.Instruction::LocalGet(1),
     @types.Instruction::I32Add,
   ]
-  let translator = Translator::new("add", func_type, [], [func_type], [0], 0)
+  let translator = Translator::new("add", func_type, [], [func_type], [0], 0, [])
   let func = translator.translate(instrs)
   let result = validate_function(func)
   assert_true(result.valid)

--- a/ir/pkg.generated.mbti
+++ b/ir/pkg.generated.mbti
@@ -309,8 +309,9 @@ pub(all) struct Translator {
   func_types : Array[@types.FuncType]
   func_type_indices : Array[Int]
   num_imports : Int
+  import_func_type_indices : Array[Int]
 }
-pub fn Translator::new(String, @types.FuncType, Array[@types.ValueType], Array[@types.FuncType], Array[Int], Int) -> Self
+pub fn Translator::new(String, @types.FuncType, Array[@types.ValueType], Array[@types.FuncType], Array[Int], Int, Array[Int]) -> Self
 pub fn Translator::translate(Self, Array[@types.Instruction]) -> Function
 
 pub(all) enum Type {

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -17,6 +17,8 @@ pub(all) struct Translator {
   func_type_indices : Array[Int]
   // Number of imported functions
   num_imports : Int
+  // Type indices for imported functions
+  import_func_type_indices : Array[Int]
 }
 
 ///|
@@ -49,6 +51,7 @@ pub fn Translator::new(
   func_types : Array[@types.FuncType],
   func_type_indices : Array[Int],
   num_imports : Int,
+  import_func_type_indices : Array[Int],
 ) -> Translator {
   let builder = IRBuilder::new(name)
   // Add function parameters
@@ -80,6 +83,7 @@ pub fn Translator::new(
     func_types,
     func_type_indices,
     num_imports,
+    import_func_type_indices,
   }
 }
 
@@ -975,8 +979,12 @@ fn Translator::translate_br_table(
 fn Translator::translate_call(self : Translator, func_idx : Int) -> Unit {
   // Get function type
   let type_idx = if func_idx < self.num_imports {
-    // This would need to look up import types
-    0 // Placeholder
+    // Look up import function type
+    if func_idx < self.import_func_type_indices.length() {
+      self.import_func_type_indices[func_idx]
+    } else {
+      0 // Fallback
+    }
   } else {
     let local_idx = func_idx - self.num_imports
     if local_idx < self.func_type_indices.length() {

--- a/main/compile.mbt
+++ b/main/compile.mbt
@@ -29,6 +29,14 @@ fn run_compile(
   let precompiled = @cwasm.PrecompiledModule::new(@cwasm.AArch64)
   let num_imports = count_func_imports(mod_.imports)
 
+  // Build import function type indices
+  let import_func_type_indices : Array[Int] = []
+  for imp in mod_.imports {
+    if imp.desc is Func(type_idx) {
+      import_func_type_indices.push(type_idx)
+    }
+  }
+
   // IR output buffer (if requested)
   let ir_output = match emit_ir {
     Some(_) => Some(StringBuilder::new())
@@ -59,6 +67,7 @@ fn run_compile(
       mod_.types,
       mod_.funcs,
       num_imports,
+      import_func_type_indices,
     )
     let ir_func = translator.translate(code.body)
 

--- a/main/explore.mbt
+++ b/main/explore.mbt
@@ -46,6 +46,14 @@ fn run_explore(
 
   // Get function info
   let num_imports = count_func_imports(mod_.imports)
+
+  // Build import function type indices
+  let import_func_type_indices : Array[Int] = []
+  for imp in mod_.imports {
+    if imp.desc is Func(type_idx) {
+      import_func_type_indices.push(type_idx)
+    }
+  }
   let type_idx = mod_.funcs[func_idx]
   let func_type = mod_.types[type_idx]
   let code = mod_.codes[func_idx]
@@ -72,6 +80,7 @@ fn run_explore(
     mod_.types,
     mod_.funcs,
     num_imports,
+    import_func_type_indices,
   )
   let ir_func = translator.translate(code.body)
   let ir_text = ir_func.print()


### PR DESCRIPTION
## Summary
The IR translator was using a placeholder type index (0) for imported functions, causing stack underflow when compiling modules with imports (like WASI functions).

**Root cause:** `translate_call` had this code:
```moonbit
let type_idx = if func_idx < self.num_imports {
  0 // Placeholder  <-- BUG: wrong type!
} else { ... }
```

**Fix:**
- Add `import_func_type_indices` parameter to `Translator::new`
- Build this array from module imports (extracting type index from `ImportDesc::Func(type_idx)`)
- Look up correct type index for imported functions in `translate_call`

## Test plan
- [x] `moon check` passes
- [x] `./wasmoon compile examples/benchmark.wat` now succeeds (was crashing with "Stack underflow")

🤖 Generated with [Claude Code](https://claude.com/claude-code)