### PR TITLE
chore: fix unused value warnings

### DIFF
--- a/jit/ffi_jit.mbt
+++ b/jit/ffi_jit.mbt
@@ -30,6 +30,7 @@ extern "c" fn c_jit_ctx_set_memory(
 
 ///|
 /// Get memory base from context
+#warnings("-unused_value")
 extern "c" fn c_jit_ctx_get_memory(ctx_ptr : Int64) -> Int64 = "wasmoon_jit_ctx_get_memory"
 
 ///|
@@ -79,6 +80,7 @@ extern "c" fn c_jit_call_ctx_void_i64(
 
 ///|
 /// Call JIT function with context: (i64) -> i64
+#warnings("-unused_value")
 extern "c" fn c_jit_call_ctx_i64_i64(
   func_ptr : Int64,
   func_table_ptr : Int64,
@@ -87,6 +89,7 @@ extern "c" fn c_jit_call_ctx_i64_i64(
 
 ///|
 /// Call JIT function with context: (i64, i64) -> i64
+#warnings("-unused_value")
 extern "c" fn c_jit_call_ctx_i64i64_i64(
   func_ptr : Int64,
   func_table_ptr : Int64,
@@ -103,6 +106,7 @@ extern "c" fn c_jit_call_ctx_void_void(
 
 ///|
 /// Call JIT function with context: (i64) -> void
+#warnings("-unused_value")
 extern "c" fn c_jit_call_ctx_i64_void(
   func_ptr : Int64,
   func_table_ptr : Int64,
@@ -111,6 +115,7 @@ extern "c" fn c_jit_call_ctx_i64_void(
 
 ///|
 /// Call JIT function with context: (i64, i64) -> void
+#warnings("-unused_value")
 extern "c" fn c_jit_call_ctx_i64i64_void(
   func_ptr : Int64,
   func_table_ptr : Int64,

--- a/vcode/emit.mbt
+++ b/vcode/emit.mbt
@@ -1757,30 +1757,6 @@ fn fcmp_kind_to_cond(kind : FCmpKind) -> Int {
 }
 
 ///|
-fn emit_terminator(mc : MachineCode, term : VCodeTerminator) -> Unit {
-  match term {
-    Jump(target) => emit_b(mc, target)
-    Branch(cond, then_b, else_b) => {
-      let rt = reg_num(cond)
-      emit_cbnz(mc, rt, then_b)
-      emit_b(mc, else_b)
-    }
-    Return(values) => {
-      // Move return values to their ABI registers (X0, X1, etc.)
-      for i, value in values {
-        let src = reg_num(value)
-        if src != i {
-          // Only emit mov if source != destination
-          emit_mov_reg(mc, i, src)
-        }
-      }
-      emit_ret(mc, 30)
-    }
-    Trap(_) => mc.emit_inst(0, 0, 32, 212) // BRK #0 = 0xD4200000
-  }
-}
-
-///|
 /// Emit terminator with epilogue for Return
 fn emit_terminator_with_epilogue(
   mc : MachineCode,

--- a/vcode/lower_wbtest.mbt
+++ b/vcode/lower_wbtest.mbt
@@ -176,16 +176,6 @@ test "lower memory operations" {
   builder.return_([sum])
   let vcode_func = lower_function(builder.get_function())
   let output = vcode_func.print()
-  let expected =
-    #|vcode load_store(v0:int) -> int {
-    #|block0:
-    #|    v1 = load.i32 +0 v0
-    #|    v2 = ldi 1
-    #|    v3 = add v1, v2
-    #|    store.i32 +4 v0, v3
-    #|    ret v3
-    #|}
-    #|
   inspect(
     output,
     content=(


### PR DESCRIPTION
## Summary
- Remove unused `emit_terminator` function (superseded by `emit_terminator_with_epilogue`)
- Remove unused `expected` variable in `lower_wbtest.mbt`
- Add `#warnings("-unused_value")` to JIT FFI functions reserved for future use

## Test plan
- [x] `moon check` passes with 0 warnings
- [x] `moon test` passes (510 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)