### PR TITLE
fix: use flags.contains instead of args.contains for --no-jit flag

### DIFF
--- a/main/main.mbt
+++ b/main/main.mbt
@@ -190,7 +190,8 @@ fn main {
                     None => ()
                   }
                   // Check if JIT is disabled (default: enabled)
-                  let use_jit = !sub.args.contains("no-jit")
+                  let has_no_jit = sub.flags.contains("no-jit")
+                  let use_jit = !has_no_jit
                   run_wasm(
                     file_path, invoke_opt, func_args, preloads, dirs, envs, wasi_options,
                     debug_config, wasm_config, use_jit,


### PR DESCRIPTION
## Summary
- Fixed `--no-jit` flag not being recognized due to using `sub.args.contains()` instead of `sub.flags.contains()`
- In clap, `args` is for named arguments with values, while `flags` is for boolean flags
- This caused JIT mode to always run even when `--no-jit` was specified

## Test plan
- [x] Verify `./wasmoon run --no-jit examples/wasi_file_io.wat --dir ./examples` uses interpreter mode
- [x] Verify `./wasmoon run examples/wasi_file_io.wat --dir ./examples` uses JIT mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)