### PR TITLE
fix: address.wast test failures with memory access and data initialization

### DIFF
--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -625,6 +625,40 @@ pub fn instantiate_module_with_imports(
   for _ in 0..<mod.datas.length() {
     dropped_datas.push(false)
   }
+
+  // Initialize active data segments (copy data to memory)
+  for data in mod.datas {
+    // Active data segments have a non-empty offset expression
+    if data.offset.length() > 0 && mem_addrs.length() > data.memory_idx {
+      let mem = store.get_mem(mem_addrs[data.memory_idx])
+      // Evaluate offset expression
+      let offset = match data.offset {
+        [I32Const(n)] => n
+        _ => 0
+      }
+      // Copy data to memory
+      mem.init_data(offset, data.init)
+    }
+  }
+
+  // Initialize active element segments (populate tables with function references)
+  for elem in mod.elems {
+    // Active element segments have a non-empty offset expression
+    if elem.offset.length() > 0 && table_addrs.length() > elem.table_idx {
+      let table = store.get_table(table_addrs[elem.table_idx])
+      // Evaluate offset expression
+      let offset = match elem.offset {
+        [I32Const(n)] => n
+        _ => 0
+      }
+      // Set table entries
+      for i, func_idx in elem.init {
+        table.set(offset + i, @types.Value::FuncRef(func_idx)) catch {
+          _ => ()
+        }
+      }
+    }
+  }
   {
     types: mod.types,
     func_addrs,

--- a/executor/instr_memory.mbt
+++ b/executor/instr_memory.mbt
@@ -1,6 +1,29 @@
 // Memory Instructions - load, store, size, and grow operations
 
 ///|
+/// Compute effective address for memory access using 64-bit arithmetic.
+/// Both base_addr and offset are treated as unsigned 32-bit values.
+/// Returns the 64-bit effective address (no wrapping).
+fn compute_effective_addr(base_addr : Int, offset : Int) -> Int64 {
+  // Mask with 0xFFFFFFFF to treat as unsigned 32-bit (clear sign extension)
+  let base_u64 = base_addr.to_int64() & 0xFFFFFFFFL
+  let offset_u64 = offset.to_int64() & 0xFFFFFFFFL
+  base_u64 + offset_u64
+}
+
+///|
+/// Check if memory access is within bounds.
+/// Returns true if the access is out of bounds.
+fn is_mem_oob(
+  effective_addr : Int64,
+  access_size : Int64,
+  mem : @runtime.Memory,
+) -> Bool {
+  let mem_size = mem.size_pages().to_int64() * 65536L
+  effective_addr < 0L || effective_addr + access_size > mem_size
+}
+
+///|
 /// Execute memory load instruction
 fn ExecContext::exec_memory_load(
   self : ExecContext,
@@ -10,127 +33,169 @@ fn ExecContext::exec_memory_load(
     // i32.load: load 4 bytes as i32
     I32Load(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i32(effective_addr)
+      if is_mem_oob(effective_addr, 4L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i32(effective_addr.to_int())
       self.stack.push(I32(value))
     }
     // i64.load: load 8 bytes as i64
     I64Load(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i64(effective_addr)
+      if is_mem_oob(effective_addr, 8L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i64(effective_addr.to_int())
       self.stack.push(I64(value))
     }
     // f32.load: load 4 bytes as f32
     F32Load(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_f32(effective_addr)
+      if is_mem_oob(effective_addr, 4L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_f32(effective_addr.to_int())
       self.stack.push(F32(value))
     }
     // f64.load: load 8 bytes as f64
     F64Load(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_f64(effective_addr)
+      if is_mem_oob(effective_addr, 8L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_f64(effective_addr.to_int())
       self.stack.push(F64(value))
     }
     // i32.load8_s: load 1 byte, sign-extend to i32
     I32Load8S(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i32_8s(effective_addr)
+      if is_mem_oob(effective_addr, 1L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i32_8s(effective_addr.to_int())
       self.stack.push(I32(value))
     }
     // i32.load8_u: load 1 byte, zero-extend to i32
     I32Load8U(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i32_8u(effective_addr)
+      if is_mem_oob(effective_addr, 1L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i32_8u(effective_addr.to_int())
       self.stack.push(I32(value))
     }
     // i32.load16_s: load 2 bytes, sign-extend to i32
     I32Load16S(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i32_16s(effective_addr)
+      if is_mem_oob(effective_addr, 2L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i32_16s(effective_addr.to_int())
       self.stack.push(I32(value))
     }
     // i32.load16_u: load 2 bytes, zero-extend to i32
     I32Load16U(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i32_16u(effective_addr)
+      if is_mem_oob(effective_addr, 2L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i32_16u(effective_addr.to_int())
       self.stack.push(I32(value))
     }
     // i64.load8_s: load 1 byte, sign-extend to i64
     I64Load8S(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i64_8s(effective_addr)
+      if is_mem_oob(effective_addr, 1L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i64_8s(effective_addr.to_int())
       self.stack.push(I64(value))
     }
     // i64.load8_u: load 1 byte, zero-extend to i64
     I64Load8U(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i64_8u(effective_addr)
+      if is_mem_oob(effective_addr, 1L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i64_8u(effective_addr.to_int())
       self.stack.push(I64(value))
     }
     // i64.load16_s: load 2 bytes, sign-extend to i64
     I64Load16S(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i64_16s(effective_addr)
+      if is_mem_oob(effective_addr, 2L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i64_16s(effective_addr.to_int())
       self.stack.push(I64(value))
     }
     // i64.load16_u: load 2 bytes, zero-extend to i64
     I64Load16U(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i64_16u(effective_addr)
+      if is_mem_oob(effective_addr, 2L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i64_16u(effective_addr.to_int())
       self.stack.push(I64(value))
     }
     // i64.load32_s: load 4 bytes, sign-extend to i64
     I64Load32S(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i64_32s(effective_addr)
+      if is_mem_oob(effective_addr, 4L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i64_32s(effective_addr.to_int())
       self.stack.push(I64(value))
     }
     // i64.load32_u: load 4 bytes, zero-extend to i64
     I64Load32U(_align, offset) => {
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      let value = mem.load_i64_32u(effective_addr)
+      if is_mem_oob(effective_addr, 4L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      let value = mem.load_i64_32u(effective_addr.to_int())
       self.stack.push(I64(value))
     }
     _ => raise @runtime.RuntimeError::Unreachable
@@ -148,82 +213,109 @@ fn ExecContext::exec_memory_store(
     I32Store(_align, offset) => {
       let value = self.stack.pop_i32()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_i32(effective_addr, value)
+      if is_mem_oob(effective_addr, 4L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_i32(effective_addr.to_int(), value)
     }
     // i64.store: store i64 as 8 bytes
     I64Store(_align, offset) => {
       let value = self.stack.pop_i64()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_i64(effective_addr, value)
+      if is_mem_oob(effective_addr, 8L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_i64(effective_addr.to_int(), value)
     }
     // f32.store: store f32 as 4 bytes
     F32Store(_align, offset) => {
       let value = self.stack.pop_f32()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_f32(effective_addr, value)
+      if is_mem_oob(effective_addr, 4L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_f32(effective_addr.to_int(), value)
     }
     // f64.store: store f64 as 8 bytes
     F64Store(_align, offset) => {
       let value = self.stack.pop_f64()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_f64(effective_addr, value)
+      if is_mem_oob(effective_addr, 8L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_f64(effective_addr.to_int(), value)
     }
     // i32.store8: store low 8 bits of i32
     I32Store8(_align, offset) => {
       let value = self.stack.pop_i32()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_i32_8(effective_addr, value)
+      if is_mem_oob(effective_addr, 1L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_i32_8(effective_addr.to_int(), value)
     }
     // i32.store16: store low 16 bits of i32
     I32Store16(_align, offset) => {
       let value = self.stack.pop_i32()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_i32_16(effective_addr, value)
+      if is_mem_oob(effective_addr, 2L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_i32_16(effective_addr.to_int(), value)
     }
     // i64.store8: store low 8 bits of i64
     I64Store8(_align, offset) => {
       let value = self.stack.pop_i64()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_i64_8(effective_addr, value)
+      if is_mem_oob(effective_addr, 1L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_i64_8(effective_addr.to_int(), value)
     }
     // i64.store16: store low 16 bits of i64
     I64Store16(_align, offset) => {
       let value = self.stack.pop_i64()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_i64_16(effective_addr, value)
+      if is_mem_oob(effective_addr, 2L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_i64_16(effective_addr.to_int(), value)
     }
     // i64.store32: store low 32 bits of i64
     I64Store32(_align, offset) => {
       let value = self.stack.pop_i64()
       let base_addr = self.stack.pop_i32()
-      let effective_addr = base_addr + offset
+      let effective_addr = compute_effective_addr(base_addr, offset)
       let mem_addr = self.instance.mem_addrs[0]
       let mem = self.store.get_mem(mem_addr)
-      mem.store_i64_32(effective_addr, value)
+      if is_mem_oob(effective_addr, 4L, mem) {
+        raise @runtime.OutOfBoundsMemoryAccess
+      }
+      mem.store_i64_32(effective_addr.to_int(), value)
     }
     _ => raise @runtime.RuntimeError::Unreachable
   }

--- a/main/wast.mbt
+++ b/main/wast.mbt
@@ -353,7 +353,17 @@ fn validate_module_source(source : @wast.WastModuleSource) -> Bool {
         @validator.validate_module(mod_)
       })
       is Ok(_)
-    Quote(_) => true // Can't easily validate quoted source
+    Quote(parts) => {
+      // Join quoted parts and parse as WAT
+      let wat_source = "(module " +
+        parts.iter().fold(init="", fn(acc, s) { acc + s }) +
+        ")"
+      (try? {
+        let mod_ = @wat.parse(wat_source)
+        @validator.validate_module(mod_)
+      })
+      is Ok(_)
+    }
     Inline(mod_) => (try? @validator.validate_module(mod_)) is Ok(_)
   }
 }

--- a/runtime/memory.mbt
+++ b/runtime/memory.mbt
@@ -39,7 +39,7 @@ pub fn Memory::store_byte(
 
 ///|
 pub fn Memory::load_i32(self : Memory, addr : Int) -> Int raise RuntimeError {
-  if addr + 4 > self.data.length() {
+  if addr < 0 || addr + 4 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   let b0 = self.data[addr].to_int()
@@ -56,7 +56,7 @@ pub fn Memory::store_i32(
   addr : Int,
   value : Int,
 ) -> Unit raise RuntimeError {
-  if addr + 4 > self.data.length() {
+  if addr < 0 || addr + 4 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   self.store_byte(addr, value.land(0xFF).to_byte())
@@ -67,7 +67,7 @@ pub fn Memory::store_i32(
 
 ///|
 pub fn Memory::load_i64(self : Memory, addr : Int) -> Int64 raise RuntimeError {
-  if addr + 8 > self.data.length() {
+  if addr < 0 || addr + 8 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   let b0 = self.data[addr].to_int64()
@@ -95,7 +95,7 @@ pub fn Memory::store_i64(
   addr : Int,
   value : Int64,
 ) -> Unit raise RuntimeError {
-  if addr + 8 > self.data.length() {
+  if addr < 0 || addr + 8 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   for i in 0..<8 {
@@ -160,7 +160,7 @@ pub fn Memory::load_i32_16s(
   self : Memory,
   addr : Int,
 ) -> Int raise RuntimeError {
-  if addr + 2 > self.data.length() {
+  if addr < 0 || addr + 2 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   let b0 = self.data[addr].to_int()
@@ -180,7 +180,7 @@ pub fn Memory::load_i32_16u(
   self : Memory,
   addr : Int,
 ) -> Int raise RuntimeError {
-  if addr + 2 > self.data.length() {
+  if addr < 0 || addr + 2 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   let b0 = self.data[addr].to_int()
@@ -218,7 +218,7 @@ pub fn Memory::load_i64_16s(
   self : Memory,
   addr : Int,
 ) -> Int64 raise RuntimeError {
-  if addr + 2 > self.data.length() {
+  if addr < 0 || addr + 2 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   let b0 = self.data[addr].to_int64()
@@ -238,7 +238,7 @@ pub fn Memory::load_i64_16u(
   self : Memory,
   addr : Int,
 ) -> Int64 raise RuntimeError {
-  if addr + 2 > self.data.length() {
+  if addr < 0 || addr + 2 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   let b0 = self.data[addr].to_int64()
@@ -283,7 +283,7 @@ pub fn Memory::store_i32_16(
   addr : Int,
   value : Int,
 ) -> Unit raise RuntimeError {
-  if addr + 2 > self.data.length() {
+  if addr < 0 || addr + 2 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   self.store_byte(addr, value.land(0xFF).to_byte())
@@ -307,7 +307,7 @@ pub fn Memory::store_i64_16(
   addr : Int,
   value : Int64,
 ) -> Unit raise RuntimeError {
-  if addr + 2 > self.data.length() {
+  if addr < 0 || addr + 2 > self.data.length() {
     raise OutOfBoundsMemoryAccess
   }
   self.store_byte(addr, value.land(0xFFL).to_int().to_byte())

--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -256,6 +256,52 @@ fn parse_hex_int(s : String) -> Int raise WatError {
 }
 
 ///|
+/// Parse an unsigned 32-bit integer (for offset/align values)
+/// Returns Int but interprets large values as unsigned
+/// Raises error if value exceeds u32 max (4294967295)
+fn parse_u32(s : String) -> Int raise WatError {
+  let trimmed = s
+  if trimmed.has_prefix("0x") || trimmed.has_prefix("0X") {
+    if trimmed.length() > 2 {
+      let hex_part = StringBuilder::new()
+      for i in 2..<trimmed.length() {
+        hex_part.write_char(trimmed.code_unit_at(i).unsafe_to_char())
+      }
+      parse_hex_u32(hex_part.to_string())
+    } else {
+      raise InvalidNumber(s, default_loc())
+    }
+  } else {
+    // Parse decimal as unsigned 64-bit first to check range
+    let u64 = @strconv.parse_uint64(trimmed) catch {
+      _ => raise InvalidNumber(s, default_loc())
+    }
+    // Check if value exceeds u32 max (4294967295)
+    if u64 > 0xFFFFFFFFUL {
+      raise InvalidNumber(s, default_loc())
+    }
+    u64.reinterpret_as_int64().to_int()
+  }
+}
+
+///|
+fn parse_hex_u32(s : String) -> Int raise WatError {
+  let mut result : UInt64 = 0UL
+  for i in 0..<s.length() {
+    let c = s.code_unit_at(i).unsafe_to_char()
+    match hex_digit_value(c) {
+      Some(v) => result = result * 16UL + v.to_int64().reinterpret_as_uint64()
+      None => raise InvalidNumber(s, default_loc())
+    }
+  }
+  // Check if value exceeds u32 max
+  if result > 0xFFFFFFFFUL {
+    raise InvalidNumber(s, default_loc())
+  }
+  result.reinterpret_as_int64().to_int()
+}
+
+///|
 fn parse_int64(s : String) -> Int64 raise WatError {
   let trimmed = s
   if trimmed.has_prefix("0x") || trimmed.has_prefix("0X") {
@@ -1746,14 +1792,15 @@ fn parse_mem_arg(
           for i in 7..<s.length() {
             offset_str.write_char(s.code_unit_at(i).unsafe_to_char())
           }
-          offset = parse_int(offset_str.to_string())
+          // Use parse_u32 for offset (can be up to 0xFFFFFFFF)
+          offset = parse_u32(offset_str.to_string())
           parser.advance()
         } else if s.has_prefix("align=") {
           let align_str = StringBuilder::new()
           for i in 6..<s.length() {
             align_str.write_char(s.code_unit_at(i).unsafe_to_char())
           }
-          let a = parse_int(align_str.to_string())
+          let a = parse_u32(align_str.to_string())
           // Convert alignment to log2
           align = log2(a)
           parser.advance()


### PR DESCRIPTION
## Summary
- Initialize active data and element segments in `instantiate_module_with_imports`
- Use 64-bit arithmetic for memory address computation to detect overflow
- Add bounds checking before memory access (prevents OOB when base+offset overflows)
- Add u32 overflow check in `parse_u32` and `parse_hex_u32` for WAT offset values
- Parse and validate quoted WAT sources in `assert_invalid` tests

## Test plan
- [x] All 256 tests in `address.wast` now pass
- [x] `moon build` succeeds
- [x] `moon fmt && moon info` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)