### PR TITLE
fix(executor): implement proper branch value passing and stack unwinding

### DIFF
--- a/executor/context.mbt
+++ b/executor/context.mbt
@@ -5,6 +5,17 @@
 let max_call_stack_depth : Int = 1000
 
 ///|
+/// Label info for tracking block arity during branching
+/// is_loop: true for loops (branch goes to start, uses param arity)
+/// arity: number of values to carry when branching
+/// stack_height: stack depth when the block was entered (for stack unwinding)
+priv struct LabelInfo {
+  is_loop : Bool
+  arity : Int
+  stack_height : Int
+} derive(Show)
+
+///|
 /// Execution context for running WASM code
 struct ExecContext {
   stack : @runtime.Stack
@@ -12,6 +23,7 @@ struct ExecContext {
   mut instance : @runtime.ModuleInstance // mutable for cross-module call context switching
   frames : Array[@runtime.Frame]
   mut current_frame : Int
+  labels : Array[LabelInfo] // Stack of labels for tracking branch arities
 } derive(Show)
 
 ///|
@@ -25,6 +37,50 @@ fn ExecContext::new(
     instance,
     frames: [],
     current_frame: 0,
+    labels: [],
+  }
+}
+
+///|
+/// Push a label for a block/loop/if
+fn ExecContext::push_label(
+  self : ExecContext,
+  is_loop : Bool,
+  arity : Int,
+) -> Unit {
+  self.labels.push(LabelInfo::{
+    is_loop,
+    arity,
+    stack_height: self.stack.size(),
+  })
+}
+
+///|
+/// Pop a label when exiting a block/loop/if
+fn ExecContext::pop_label(self : ExecContext) -> Unit {
+  if self.labels.length() > 0 {
+    self.labels.pop() |> ignore
+  }
+}
+
+///|
+/// Get the arity for a branch to the given depth
+fn ExecContext::get_branch_arity(self : ExecContext, depth : Int) -> Int {
+  let label_idx = self.labels.length() - 1 - depth
+  if label_idx >= 0 && label_idx < self.labels.length() {
+    self.labels[label_idx].arity
+  } else {
+    0
+  }
+}
+
+///|
+/// Restore stack to the given height (discard values above it)
+fn ExecContext::restore_stack_to(self : ExecContext, height : Int) -> Unit {
+  while self.stack.size() > height {
+    try self.stack.pop() |> ignore catch {
+      _ => break
+    }
   }
 }
 

--- a/executor/instr_control.mbt
+++ b/executor/instr_control.mbt
@@ -37,62 +37,91 @@ fn ExecContext::exec_control(
     // Block: execute body, br 0 jumps to end
     Block(bt, body) => {
       let arity = self.block_arity(bt)
-      self.exec_block(body) catch {
-        BranchWith(0, values) =>
+      let stack_height = self.stack.size()
+      self.push_label(false, arity) // Block branches use result arity
+      let result = try? self.exec_block(body)
+      self.pop_label()
+      match result {
+        Ok(_) => () // Normal completion
+        Err(BranchWith(0, values)) => {
+          // Restore stack to block entry point (discard intermediate values)
+          self.restore_stack_to(stack_height)
           // Push the branch values back onto the stack
           for v in values {
             self.stack.push(v)
           }
-        BranchWith(n, values) => raise BranchWith(n - 1, values)
-        e => raise e
+        }
+        Err(BranchWith(n, values)) => raise BranchWith(n - 1, values)
+        Err(e) => raise e
       }
-      // After block ends normally, top `arity` values remain on stack
-      ignore(arity)
     }
     // Loop: execute body, br 0 jumps to start
     Loop(bt, body) => {
       let param_arity = self.block_param_arity(bt)
+      let stack_height = self.stack.size()
+      self.push_label(true, param_arity) // Loop branches use param arity
       loop () {
-        _ =>
-          try {
-            self.exec_block(body)
-            break () // Normal exit
-          } catch {
-            BranchWith(0, values) => {
-              // For loop, branch to start: push params back and continue
+        _ => {
+          let result = try? self.exec_block(body)
+          match result {
+            Ok(_) => {
+              self.pop_label()
+              break () // Normal exit
+            }
+            Err(BranchWith(0, values)) => {
+              // For loop, branch to start: restore stack and push params back
+              self.restore_stack_to(stack_height)
               for v in values {
                 self.stack.push(v)
               }
               continue ()
             }
-            BranchWith(n, values) => raise BranchWith(n - 1, values)
-            e => raise e
+            Err(BranchWith(n, values)) => {
+              self.pop_label()
+              raise BranchWith(n - 1, values)
+            }
+            Err(e) => {
+              self.pop_label()
+              raise e
+            }
           }
+        }
       }
-      ignore(param_arity)
     }
     // If-else: pop condition, execute appropriate branch
     If(bt, then_body, else_body) => {
       let cond = self.stack.pop_i32()
       let body = if cond != 0 { then_body } else { else_body }
       let arity = self.block_arity(bt)
-      self.exec_block(body) catch {
-        BranchWith(0, values) =>
+      let stack_height = self.stack.size()
+      self.push_label(false, arity) // If branches use result arity
+      let result = try? self.exec_block(body)
+      self.pop_label()
+      match result {
+        Ok(_) => () // Normal completion
+        Err(BranchWith(0, values)) => {
+          self.restore_stack_to(stack_height)
           for v in values {
             self.stack.push(v)
           }
-        BranchWith(n, values) => raise BranchWith(n - 1, values)
-        e => raise e
+        }
+        Err(BranchWith(n, values)) => raise BranchWith(n - 1, values)
+        Err(e) => raise e
       }
-      ignore(arity)
     }
-    // Unconditional branch - need to collect values for multi-value
-    Br(depth) => raise BranchWith(depth, [])
+    // Unconditional branch - collect values based on target block arity
+    Br(depth) => {
+      let arity = self.get_branch_arity(depth)
+      let values = self.stack.pop_n(arity)
+      raise BranchWith(depth, values)
+    }
     // Conditional branch
     BrIf(depth) => {
       let cond = self.stack.pop_i32()
       if cond != 0 {
-        raise BranchWith(depth, [])
+        let arity = self.get_branch_arity(depth)
+        let values = self.stack.pop_n(arity)
+        raise BranchWith(depth, values)
       }
     }
     // Table-driven branch
@@ -103,7 +132,9 @@ fn ExecContext::exec_control(
       } else {
         default
       }
-      raise BranchWith(depth, [])
+      let arity = self.get_branch_arity(depth)
+      let values = self.stack.pop_n(arity)
+      raise BranchWith(depth, values)
     }
     // Unreachable trap
     Unreachable => raise @runtime.RuntimeError::Unreachable

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -162,6 +162,7 @@ pub fn Stack::pop_f32(Self) -> Float raise RuntimeError
 pub fn Stack::pop_f64(Self) -> Double raise RuntimeError
 pub fn Stack::pop_i32(Self) -> Int raise RuntimeError
 pub fn Stack::pop_i64(Self) -> Int64 raise RuntimeError
+pub fn Stack::pop_n(Self, Int) -> Array[@types.Value] raise RuntimeError
 pub fn Stack::push(Self, @types.Value) -> Unit raise RuntimeError
 pub fn Stack::size(Self) -> Int
 pub impl Show for Stack

--- a/runtime/stack.mbt
+++ b/runtime/stack.mbt
@@ -84,3 +84,24 @@ pub fn Stack::size(self : Stack) -> Int {
 pub fn Stack::clear(self : Stack) -> Unit {
   self.sp = 0
 }
+
+///|
+/// Pop n values from the stack, returning them in order (first popped is last in array)
+pub fn Stack::pop_n(
+  self : Stack,
+  n : Int,
+) -> Array[@types.Value] raise RuntimeError {
+  if n <= 0 {
+    return []
+  }
+  if self.sp < n {
+    raise StackUnderflow
+  }
+  let values : Array[@types.Value] = Array::make(n, @types.Value::I32(0))
+  // Pop in reverse order so the array maintains stack order
+  for i = n - 1; i >= 0; i = i - 1 {
+    self.sp = self.sp - 1
+    values[i] = self.values[self.sp]
+  }
+  values
+}


### PR DESCRIPTION
## Summary
- Add `LabelInfo` struct to track block arity and stack height for branching
- Add label stack to `ExecContext` for tracking nested blocks
- Implement `Stack::pop_n` to pop multiple values at once
- Fix `Br`, `BrIf`, and `BrTable` to pop values based on target block arity
- Restore stack to block entry height when handling branch exceptions

## Problem
The `br.wast` test had 4 failing tests:
- `as-return-values`: expected I32(2), got I32(1)
- `nested-block-value`: expected I32(9), got I32(12)
- `nested-br_if-value-cond`: expected I32(9), got I32(12)
- `nested-br_table-value-index`: expected I32(9), got I32(12)

The issue was that:
1. Branch instructions (`br`, `br_if`, `br_table`) were not carrying values from the stack
2. Intermediate values pushed inside a block were not being discarded when branching out

## Solution
Implemented proper WebAssembly branch semantics:
1. Track block information (arity, stack height) using a label stack
2. When branching, pop the appropriate number of values based on target block's arity
3. When catching a branch at block level, restore stack to entry height before pushing branch values

## Test Results
- br.wast: 96/96 tests pass (was 92/96)
- All 536 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)