### PR TITLE
fix(validator,parser): add memory alignment validation

### DIFF
--- a/parser/parser.mbt
+++ b/parser/parser.mbt
@@ -16,6 +16,7 @@ suberror ParserError {
   UnknownOpcode(Int)
   InvalidImportKind(Int)
   InvalidExportKind(Int)
+  MalformedMemopFlags // alignment value too large
   ParseError(String) // Generic error with message
 }
 
@@ -90,6 +91,7 @@ pub impl Show for ParserError with output(self, logger) {
       }
       "invalid export kind \{kind}\{kind_hint}"
     }
+    MalformedMemopFlags => "malformed memop flags"
     ParseError(msg) => msg
   }
   logger.write_string(msg)
@@ -252,6 +254,19 @@ fn Parser::read_leb128_i64(self : Parser) -> Int64 raise ParserError {
 /// Read a u32
 fn Parser::read_u32(self : Parser) -> Int raise ParserError {
   self.read_leb128_u32()
+}
+
+///|
+/// Read memory argument (align, offset) with validation
+/// Alignment values >= 32 are reserved and should be rejected as malformed
+fn Parser::read_memarg(self : Parser) -> (Int, Int) raise ParserError {
+  let align = self.read_leb128_u32()
+  // WebAssembly spec: alignment values >= 32 are reserved
+  if align >= 32 {
+    raise MalformedMemopFlags
+  }
+  let offset = self.read_leb128_u32()
+  (align, offset)
 }
 
 ///|
@@ -492,121 +507,98 @@ fn Parser::read_instruction(
     0x22 => LocalTee(self.read_u32())
     0x23 => GlobalGet(self.read_u32())
     0x24 => GlobalSet(self.read_u32())
-    // Memory instructions
+    // Memory instructions (with alignment validation)
     0x28 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I32Load(align, offset)
     }
     0x29 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Load(align, offset)
     }
     0x2A => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       F32Load(align, offset)
     }
     0x2B => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       F64Load(align, offset)
     }
     0x2C => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I32Load8S(align, offset)
     }
     0x2D => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I32Load8U(align, offset)
     }
     0x2E => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I32Load16S(align, offset)
     }
     0x2F => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I32Load16U(align, offset)
     }
     0x30 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Load8S(align, offset)
     }
     0x31 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Load8U(align, offset)
     }
     0x32 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Load16S(align, offset)
     }
     0x33 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Load16U(align, offset)
     }
     0x34 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Load32S(align, offset)
     }
     0x35 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Load32U(align, offset)
     }
-    // Memory store instructions
+    // Memory store instructions (with alignment validation)
     0x36 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I32Store(align, offset)
     }
     0x37 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Store(align, offset)
     }
     0x38 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       F32Store(align, offset)
     }
     0x39 => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       F64Store(align, offset)
     }
     0x3A => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I32Store8(align, offset)
     }
     0x3B => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I32Store16(align, offset)
     }
     0x3C => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Store8(align, offset)
     }
     0x3D => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Store16(align, offset)
     }
     0x3E => {
-      let align = self.read_u32()
-      let offset = self.read_u32()
+      let (align, offset) = self.read_memarg()
       I64Store32(align, offset)
     }
     0x3F => {

--- a/validator/pkg.generated.mbti
+++ b/validator/pkg.generated.mbti
@@ -28,6 +28,7 @@ pub(all) suberror ValidationError {
   MultipleMemories
   MultipleTables
   InvalidLimits(String)
+  InvalidAlignment(String)
   WithContext(ValidationErrorContext)
 }
 pub impl Show for ValidationError

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -17,6 +17,7 @@ pub(all) suberror ValidationError {
   MultipleMemories // More than one memory is not allowed in MVP
   MultipleTables // More than one table is not allowed in MVP
   InvalidLimits(String) // Invalid limits (e.g., min > max)
+  InvalidAlignment(String) // Alignment must not be larger than natural
   // Error with location context
   WithContext(ValidationErrorContext)
 } derive(Show)
@@ -54,6 +55,7 @@ pub fn ValidationErrorContext::from_error(
     MultipleMemories => "multiple memories not allowed in MVP"
     MultipleTables => "multiple tables not allowed in MVP"
     InvalidLimits(m) => "invalid limits: \{m}"
+    InvalidAlignment(m) => "alignment must not be larger than natural: \{m}"
     WithContext(ctx) => ctx.error_msg
   }
   { error_msg: msg, func_idx: None, instr_offset: None, instruction: None }
@@ -799,68 +801,219 @@ fn validate_instr(
     }
 
     // Memory operations - all require memory index 0 to exist
-    I32Load(_, _)
-    | I32Load8S(_, _)
-    | I32Load8U(_, _)
-    | I32Load16S(_, _)
-    | I32Load16U(_, _) => {
+    // Natural alignment: 8-bit=0, 16-bit=1, 32-bit=2, 64-bit=3
+    I32Load(align, _) => {
       if ctx.mems.length() == 0 {
         raise InvalidMemoryIndex(0)
+      }
+      if align > 2 {
+        raise InvalidAlignment(
+          "i32.load alignment \{align} exceeds natural alignment 2",
+        )
       }
       stack.pop(@types.ValueType::I32) // address
       stack.push(@types.ValueType::I32)
     }
-    I64Load(_, _)
-    | I64Load8S(_, _)
-    | I64Load8U(_, _)
-    | I64Load16S(_, _)
-    | I64Load16U(_, _)
-    | I64Load32S(_, _)
-    | I64Load32U(_, _) => {
+    I32Load8S(align, _) | I32Load8U(align, _) => {
       if ctx.mems.length() == 0 {
         raise InvalidMemoryIndex(0)
+      }
+      if align > 0 {
+        raise InvalidAlignment(
+          "i32.load8 alignment \{align} exceeds natural alignment 0",
+        )
+      }
+      stack.pop(@types.ValueType::I32) // address
+      stack.push(@types.ValueType::I32)
+    }
+    I32Load16S(align, _) | I32Load16U(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 1 {
+        raise InvalidAlignment(
+          "i32.load16 alignment \{align} exceeds natural alignment 1",
+        )
+      }
+      stack.pop(@types.ValueType::I32) // address
+      stack.push(@types.ValueType::I32)
+    }
+    I64Load(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 3 {
+        raise InvalidAlignment(
+          "i64.load alignment \{align} exceeds natural alignment 3",
+        )
       }
       stack.pop(@types.ValueType::I32) // address
       stack.push(@types.ValueType::I64)
     }
-    F32Load(_, _) => {
+    I64Load8S(align, _) | I64Load8U(align, _) => {
       if ctx.mems.length() == 0 {
         raise InvalidMemoryIndex(0)
+      }
+      if align > 0 {
+        raise InvalidAlignment(
+          "i64.load8 alignment \{align} exceeds natural alignment 0",
+        )
+      }
+      stack.pop(@types.ValueType::I32) // address
+      stack.push(@types.ValueType::I64)
+    }
+    I64Load16S(align, _) | I64Load16U(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 1 {
+        raise InvalidAlignment(
+          "i64.load16 alignment \{align} exceeds natural alignment 1",
+        )
+      }
+      stack.pop(@types.ValueType::I32) // address
+      stack.push(@types.ValueType::I64)
+    }
+    I64Load32S(align, _) | I64Load32U(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 2 {
+        raise InvalidAlignment(
+          "i64.load32 alignment \{align} exceeds natural alignment 2",
+        )
+      }
+      stack.pop(@types.ValueType::I32) // address
+      stack.push(@types.ValueType::I64)
+    }
+    F32Load(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 2 {
+        raise InvalidAlignment(
+          "f32.load alignment \{align} exceeds natural alignment 2",
+        )
       }
       stack.pop(@types.ValueType::I32) // address
       stack.push(@types.ValueType::F32)
     }
-    F64Load(_, _) => {
+    F64Load(align, _) => {
       if ctx.mems.length() == 0 {
         raise InvalidMemoryIndex(0)
+      }
+      if align > 3 {
+        raise InvalidAlignment(
+          "f64.load alignment \{align} exceeds natural alignment 3",
+        )
       }
       stack.pop(@types.ValueType::I32) // address
       stack.push(@types.ValueType::F64)
     }
-    I32Store(_, _) | I32Store8(_, _) | I32Store16(_, _) => {
+    I32Store(align, _) => {
       if ctx.mems.length() == 0 {
         raise InvalidMemoryIndex(0)
+      }
+      if align > 2 {
+        raise InvalidAlignment(
+          "i32.store alignment \{align} exceeds natural alignment 2",
+        )
       }
       stack.pop(@types.ValueType::I32) // value
       stack.pop(@types.ValueType::I32) // address
     }
-    I64Store(_, _) | I64Store8(_, _) | I64Store16(_, _) | I64Store32(_, _) => {
+    I32Store8(align, _) => {
       if ctx.mems.length() == 0 {
         raise InvalidMemoryIndex(0)
+      }
+      if align > 0 {
+        raise InvalidAlignment(
+          "i32.store8 alignment \{align} exceeds natural alignment 0",
+        )
+      }
+      stack.pop(@types.ValueType::I32) // value
+      stack.pop(@types.ValueType::I32) // address
+    }
+    I32Store16(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 1 {
+        raise InvalidAlignment(
+          "i32.store16 alignment \{align} exceeds natural alignment 1",
+        )
+      }
+      stack.pop(@types.ValueType::I32) // value
+      stack.pop(@types.ValueType::I32) // address
+    }
+    I64Store(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 3 {
+        raise InvalidAlignment(
+          "i64.store alignment \{align} exceeds natural alignment 3",
+        )
       }
       stack.pop(@types.ValueType::I64) // value
       stack.pop(@types.ValueType::I32) // address
     }
-    F32Store(_, _) => {
+    I64Store8(align, _) => {
       if ctx.mems.length() == 0 {
         raise InvalidMemoryIndex(0)
+      }
+      if align > 0 {
+        raise InvalidAlignment(
+          "i64.store8 alignment \{align} exceeds natural alignment 0",
+        )
+      }
+      stack.pop(@types.ValueType::I64) // value
+      stack.pop(@types.ValueType::I32) // address
+    }
+    I64Store16(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 1 {
+        raise InvalidAlignment(
+          "i64.store16 alignment \{align} exceeds natural alignment 1",
+        )
+      }
+      stack.pop(@types.ValueType::I64) // value
+      stack.pop(@types.ValueType::I32) // address
+    }
+    I64Store32(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 2 {
+        raise InvalidAlignment(
+          "i64.store32 alignment \{align} exceeds natural alignment 2",
+        )
+      }
+      stack.pop(@types.ValueType::I64) // value
+      stack.pop(@types.ValueType::I32) // address
+    }
+    F32Store(align, _) => {
+      if ctx.mems.length() == 0 {
+        raise InvalidMemoryIndex(0)
+      }
+      if align > 2 {
+        raise InvalidAlignment(
+          "f32.store alignment \{align} exceeds natural alignment 2",
+        )
       }
       stack.pop(@types.ValueType::F32) // value
       stack.pop(@types.ValueType::I32) // address
     }
-    F64Store(_, _) => {
+    F64Store(align, _) => {
       if ctx.mems.length() == 0 {
         raise InvalidMemoryIndex(0)
+      }
+      if align > 3 {
+        raise InvalidAlignment(
+          "f64.store alignment \{align} exceeds natural alignment 3",
+        )
       }
       stack.pop(@types.ValueType::F64) // value
       stack.pop(@types.ValueType::I32) // address


### PR DESCRIPTION
## Summary
- Add alignment validation in validator to reject alignments exceeding natural alignment
  - 8-bit ops: max align = 0
  - 16-bit ops: max align = 1  
  - 32-bit ops: max align = 2
  - 64-bit ops: max align = 3
- Add malformed memop flags detection in parser (alignment values >= 32 are reserved per WebAssembly spec)

## Test plan
- [x] `./wasmoon test testsuite/data/align.wast` - 140/140 tests pass
- [x] `moon test` - All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)