### PR TITLE
fix(conversion): fix trunc/convert boundary conditions and NaN parsing

### DIFF
--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -3208,3 +3208,207 @@ test "call_indirect type index bug reproduction" {
     _ => fail("Expected I32 result")
   }
 }
+
+// ============================================================
+// Conversion instruction tests for boundary cases
+// ============================================================
+
+///|
+test "i32.trunc_f64_u: value in (-1, 0) truncates to 0" {
+  // Values in (-1, 0) should truncate to 0, not overflow
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), I32TruncF64U],
+  }
+  let func_type : @types.FuncType = {
+    params: [@types.ValueType::F64],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "trunc", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  // -0.9 should truncate to 0
+  let results = call_exported_func(store, instance, "trunc", [F64(-0.9)])
+  match results[0] {
+    I32(n) => inspect(n, content="0")
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "i32.trunc_f32_u: value in (-1, 0) truncates to 0" {
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), I32TruncF32U],
+  }
+  let func_type : @types.FuncType = {
+    params: [@types.ValueType::F32],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "trunc", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  // -0.5f should truncate to 0
+  let results = call_exported_func(store, instance, "trunc", [F32(-0.5)])
+  match results[0] {
+    I32(n) => inspect(n, content="0")
+    _ => fail("Expected I32 result")
+  }
+}
+
+///|
+test "i64.trunc_f64_u: large value near 2^64" {
+  // Test that values close to but below 2^64 work correctly
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), I64TruncF64U],
+  }
+  let func_type : @types.FuncType = {
+    params: [@types.ValueType::F64],
+    results: [@types.ValueType::I64],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "trunc", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  // 2^63 = 9223372036854775808.0 should convert correctly
+  let pow2_63 = 2.0.pow(63.0)
+  let results = call_exported_func(store, instance, "trunc", [F64(pow2_63)])
+  match results[0] {
+    // 2^63 as unsigned i64, reinterpreted as signed = -9223372036854775808
+    I64(n) => inspect(n, content="-9223372036854775808")
+    _ => fail("Expected I64 result")
+  }
+}
+
+///|
+test "i64.trunc_sat_f64_u: large value saturates correctly" {
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), I64TruncSatF64U],
+  }
+  let func_type : @types.FuncType = {
+    params: [@types.ValueType::F64],
+    results: [@types.ValueType::I64],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "trunc_sat", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  // Value >= 2^64 should saturate to u64::MAX (-1 as i64)
+  let pow2_64 = 2.0.pow(64.0)
+  let results = call_exported_func(store, instance, "trunc_sat", [F64(pow2_64)])
+  match results[0] {
+    I64(n) => inspect(n, content="-1") // u64::MAX = -1 as signed
+    _ => fail("Expected I64 result")
+  }
+}
+
+///|
+test "i64.trunc_sat_f64_u: value in range converts correctly" {
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), I64TruncSatF64U],
+  }
+  let func_type : @types.FuncType = {
+    params: [@types.ValueType::F64],
+    results: [@types.ValueType::I64],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "trunc_sat", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  // 2^63 should convert to -9223372036854775808 (as signed)
+  let pow2_63 = 2.0.pow(63.0)
+  let results = call_exported_func(store, instance, "trunc_sat", [F64(pow2_63)])
+  match results[0] {
+    I64(n) => inspect(n, content="-9223372036854775808")
+    _ => fail("Expected I64 result")
+  }
+}
+
+///|
+test "i32.trunc_f64_s: boundary near INT32_MIN" {
+  let func : @types.FunctionCode = {
+    locals: [],
+    body: [LocalGet(0), I32TruncF64S],
+  }
+  let func_type : @types.FuncType = {
+    params: [@types.ValueType::F64],
+    results: [@types.ValueType::I32],
+  }
+  let mod : @types.Module = {
+    types: [func_type],
+    imports: [],
+    funcs: [0],
+    tables: [],
+    memories: [],
+    globals: [],
+    exports: [{ name: "trunc", desc: @types.ExportDesc::Func(0) }],
+    start: None,
+    elems: [],
+    codes: [func],
+    datas: [],
+  }
+  let (store, instance) = instantiate_module(mod)
+  // -2147483648.0 is exactly INT32_MIN, should work
+  let results = call_exported_func(store, instance, "trunc", [
+    F64(-2147483648.0),
+  ])
+  match results[0] {
+    I32(n) => inspect(n, content="-2147483648")
+    _ => fail("Expected I32 result")
+  }
+}

--- a/executor/instr_conversion.mbt
+++ b/executor/instr_conversion.mbt
@@ -1,5 +1,19 @@
 // Conversion Instructions - type conversion and reinterpret operations
 
+// Constants for conversion bounds (using powers of 2 for precision)
+
+///|
+let pow2_32 : Double = 4294967296.0 // 2^32, exactly representable
+
+///|
+let pow2_31 : Double = 2147483648.0 // 2^31, exactly representable
+
+///|
+let pow2_63 : Double = 2.0.pow(63.0) // 2^63, exactly representable
+
+///|
+let pow2_64 : Double = 2.0.pow(64.0) // 2^64, exactly representable
+
 ///|
 /// Execute conversion instruction
 fn ExecContext::exec_conversion(
@@ -20,9 +34,7 @@ fn ExecContext::exec_conversion(
     // i64.extend_i32_u: i32 -> i64 (无符号扩展)
     I64ExtendI32U => {
       let a = self.stack.pop_i32()
-      // Reinterpret i32 as u32, then zero-extend to i64
-      let u32_val = a.reinterpret_as_uint()
-      self.stack.push(I64(u32_val.to_int64()))
+      self.stack.push(I64(a.reinterpret_as_uint().to_int64()))
     }
     // i32.trunc_f32_s: f32 -> i32 (有符号截断)
     I32TruncF32S => {
@@ -31,7 +43,7 @@ fn ExecContext::exec_conversion(
         raise @runtime.InvalidConversion
       }
       let d = a.to_double()
-      if d >= 2147483648.0 || d < -2147483648.0 {
+      if d >= pow2_31 || d < -pow2_31 {
         raise @runtime.IntegerOverflow
       }
       self.stack.push(I32(a.to_int()))
@@ -43,7 +55,8 @@ fn ExecContext::exec_conversion(
         raise @runtime.InvalidConversion
       }
       let d = a.to_double()
-      if d >= 4294967296.0 || d < 0.0 {
+      // Values in (-1, 0) truncate to 0, only d <= -1 is overflow
+      if d >= pow2_32 || d <= -1.0 {
         raise @runtime.IntegerOverflow
       }
       self.stack.push(I32(d.to_uint().reinterpret_as_int()))
@@ -54,7 +67,9 @@ fn ExecContext::exec_conversion(
       if a.is_nan() {
         raise @runtime.InvalidConversion
       }
-      if a >= 2147483648.0 || a < -2147483648.0 {
+      // -2147483649.0 would truncate to -2147483649 (out of range)
+      // -2147483648.9 would truncate to -2147483648 (in range)
+      if a >= pow2_31 || a <= -(pow2_31 + 1.0) {
         raise @runtime.IntegerOverflow
       }
       self.stack.push(I32(a.to_int()))
@@ -65,7 +80,7 @@ fn ExecContext::exec_conversion(
       if a.is_nan() {
         raise @runtime.InvalidConversion
       }
-      if a >= 4294967296.0 || a < 0.0 {
+      if a >= pow2_32 || a <= -1.0 {
         raise @runtime.IntegerOverflow
       }
       self.stack.push(I32(a.to_uint().reinterpret_as_int()))
@@ -77,7 +92,7 @@ fn ExecContext::exec_conversion(
         raise @runtime.InvalidConversion
       }
       let d = a.to_double()
-      if d >= 9223372036854775808.0 || d < -9223372036854775808.0 {
+      if d >= pow2_63 || d < -pow2_63 {
         raise @runtime.IntegerOverflow
       }
       self.stack.push(I64(d.to_int64()))
@@ -89,10 +104,17 @@ fn ExecContext::exec_conversion(
         raise @runtime.InvalidConversion
       }
       let d = a.to_double()
-      if d >= 18446744073709551616.0 || d < 0.0 {
+      if d >= pow2_64 || d <= -1.0 {
         raise @runtime.IntegerOverflow
       }
-      self.stack.push(I64(d.to_uint64().reinterpret_as_int64()))
+      // For values >= 2^63, manually compute as: (d - 2^63) + MIN_I64
+      let result = if d >= pow2_63 {
+        let offset = (d - pow2_63).to_int64()
+        offset + -9223372036854775808L
+      } else {
+        d.to_int64()
+      }
+      self.stack.push(I64(result))
     }
     // i64.trunc_f64_s: f64 -> i64 (有符号截断)
     I64TruncF64S => {
@@ -100,7 +122,7 @@ fn ExecContext::exec_conversion(
       if a.is_nan() {
         raise @runtime.InvalidConversion
       }
-      if a >= 9223372036854775808.0 || a < -9223372036854775808.0 {
+      if a >= pow2_63 || a < -pow2_63 {
         raise @runtime.IntegerOverflow
       }
       self.stack.push(I64(a.to_int64()))
@@ -111,10 +133,17 @@ fn ExecContext::exec_conversion(
       if a.is_nan() {
         raise @runtime.InvalidConversion
       }
-      if a >= 18446744073709551616.0 || a < 0.0 {
+      if a >= pow2_64 || a <= -1.0 {
         raise @runtime.IntegerOverflow
       }
-      self.stack.push(I64(a.to_uint64().reinterpret_as_int64()))
+      // For values >= 2^63, manually compute as: (a - 2^63) + MIN_I64
+      let result = if a >= pow2_63 {
+        let offset = (a - pow2_63).to_int64()
+        offset + -9223372036854775808L
+      } else {
+        a.to_int64()
+      }
+      self.stack.push(I64(result))
     }
     // f32.convert_i32_s: i32 -> f32 (有符号转换)
     F32ConvertI32S => {
@@ -154,8 +183,7 @@ fn ExecContext::exec_conversion(
     // f64.convert_i64_u: i64 -> f64 (无符号转换)
     F64ConvertI64U => {
       let a = self.stack.pop_i64()
-      let unsigned = a.reinterpret_as_uint64()
-      self.stack.push(F64(unsigned.to_double()))
+      self.stack.push(F64(a.reinterpret_as_uint64().to_double()))
     }
     // f32.demote_f64: f64 -> f32
     F32DemoteF64 => {
@@ -256,9 +284,9 @@ fn ExecContext::exec_trunc_sat(
       let d = a.to_double()
       let result = if a.is_nan() {
         0L
-      } else if d >= 9223372036854775807.0 {
+      } else if d >= pow2_63 {
         9223372036854775807L
-      } else if d <= -9223372036854775808.0 {
+      } else if d <= -pow2_63 {
         -9223372036854775808L
       } else {
         d.to_int64()
@@ -271,10 +299,13 @@ fn ExecContext::exec_trunc_sat(
       let d = a.to_double()
       let result = if a.is_nan() || d <= 0.0 {
         0L
-      } else if d >= 18446744073709551615.0 {
+      } else if d >= pow2_64 {
         -1L // 0xFFFFFFFFFFFFFFFF as signed
+      } else if d >= pow2_63 {
+        let offset = (d - pow2_63).to_int64()
+        offset + -9223372036854775808L
       } else {
-        d.to_uint64().reinterpret_as_int64()
+        d.to_int64()
       }
       self.stack.push(I64(result))
     }
@@ -283,9 +314,9 @@ fn ExecContext::exec_trunc_sat(
       let a = self.stack.pop_f64()
       let result = if a.is_nan() {
         0L
-      } else if a >= 9223372036854775807.0 {
+      } else if a >= pow2_63 {
         9223372036854775807L
-      } else if a <= -9223372036854775808.0 {
+      } else if a <= -pow2_63 {
         -9223372036854775808L
       } else {
         a.to_int64()
@@ -297,10 +328,13 @@ fn ExecContext::exec_trunc_sat(
       let a = self.stack.pop_f64()
       let result = if a.is_nan() || a <= 0.0 {
         0L
-      } else if a >= 18446744073709551615.0 {
+      } else if a >= pow2_64 {
         -1L // 0xFFFFFFFFFFFFFFFF as signed
+      } else if a >= pow2_63 {
+        let offset = (a - pow2_63).to_int64()
+        offset + -9223372036854775808L
       } else {
-        a.to_uint64().reinterpret_as_int64()
+        a.to_int64()
       }
       self.stack.push(I64(result))
     }

--- a/wast/wast.mbt
+++ b/wast/wast.mbt
@@ -958,8 +958,16 @@ fn Parser::parse_f32(self : Parser) -> Float raise WastError {
       parse_float32(s)
     }
     Keyword(k) =>
-      // Handle special float values like nan, inf
-      if k == "nan" || k == "inf" || k.has_prefix("nan:") {
+      // Handle special float values like nan, inf, -nan:0x..., +nan:0x..., etc.
+      if k == "nan" ||
+        k == "inf" ||
+        k == "-nan" ||
+        k == "+nan" ||
+        k == "-inf" ||
+        k == "+inf" ||
+        k.has_prefix("nan:") ||
+        k.has_prefix("-nan:") ||
+        k.has_prefix("+nan:") {
         self.advance()
         parse_float32(k)
       } else {
@@ -977,7 +985,16 @@ fn Parser::parse_f64(self : Parser) -> Double raise WastError {
       parse_float64(s)
     }
     Keyword(k) =>
-      if k == "nan" || k == "inf" || k.has_prefix("nan:") {
+      // Handle special float values like nan, inf, -nan:0x..., +nan:0x..., etc.
+      if k == "nan" ||
+        k == "inf" ||
+        k == "-nan" ||
+        k == "+nan" ||
+        k == "-inf" ||
+        k == "+inf" ||
+        k.has_prefix("nan:") ||
+        k.has_prefix("-nan:") ||
+        k.has_prefix("+nan:") {
         self.advance()
         parse_float64(k)
       } else {
@@ -1116,13 +1133,30 @@ fn parse_hex_int64(s : String) -> Int64 raise WastError {
 ///|
 fn parse_float32(s : String) -> Float raise WastError {
   // Handle special values
-  if s == "nan" || s == "+nan" || s.has_prefix("nan:") || s.has_prefix("+nan:") {
-    return (0.0 : Float) / (0.0 : Float) // positive NaN
+  if s == "nan" || s == "+nan" {
+    // Canonical positive NaN: 0x7fc00000
+    return Float::reinterpret_from_int(0x7fc00000)
   }
-  if s == "-nan" || s.has_prefix("-nan:") {
-    // Negative NaN: set sign bit on canonical NaN
-    // Canonical NaN is 0x7FC00000, negative NaN is 0xFFC00000
-    return Float::reinterpret_from_uint(0xFFC00000U)
+  if s == "-nan" {
+    // Canonical negative NaN: 0xffc00000 = -4194304 as signed int
+    return Float::reinterpret_from_int(-4194304)
+  }
+  if s.has_prefix("nan:0x") || s.has_prefix("+nan:0x") {
+    // Parse payload from nan:0x...
+    let payload_start = if s.has_prefix("+") { 7 } else { 6 }
+    let payload_str = try! s[payload_start:].to_string()
+    let payload = parse_hex_int(payload_str)
+    // Positive NaN: 0x7f800000 | payload
+    let bits = 0x7f800000 | (payload & 0x7fffff)
+    return Float::reinterpret_from_int(bits)
+  }
+  if s.has_prefix("-nan:0x") {
+    // Parse payload from -nan:0x...
+    let payload_str = try! s[7:].to_string()
+    let payload = parse_hex_int(payload_str)
+    // Negative NaN: 0xff800000 | payload = -8388608 | payload
+    let bits = -8388608 | (payload & 0x7fffff)
+    return Float::reinterpret_from_int(bits)
   }
   if s == "inf" || s == "+inf" {
     return (1.0 : Float) / (0.0 : Float) // positive infinity
@@ -1148,13 +1182,30 @@ fn parse_float32(s : String) -> Float raise WastError {
 ///|
 fn parse_float64(s : String) -> Double raise WastError {
   // Handle special values
-  if s == "nan" || s == "+nan" || s.has_prefix("nan:") || s.has_prefix("+nan:") {
-    return 0.0 / 0.0 // positive NaN
+  if s == "nan" || s == "+nan" {
+    // Canonical positive NaN: 0x7ff8000000000000
+    return 0x7ff8000000000000L.reinterpret_as_double()
   }
-  if s == "-nan" || s.has_prefix("-nan:") {
-    // Negative NaN: set sign bit on canonical NaN
-    // Canonical NaN is 0x7FF8000000000000, negative NaN is 0xFFF8000000000000
-    return 0xFFF8000000000000UL.reinterpret_as_double()
+  if s == "-nan" {
+    // Canonical negative NaN: 0xfff8000000000000
+    return 0xfff8000000000000L.reinterpret_as_double()
+  }
+  if s.has_prefix("nan:0x") || s.has_prefix("+nan:0x") {
+    // Parse payload from nan:0x...
+    let payload_start = if s.has_prefix("+") { 7 } else { 6 }
+    let payload_str = try! s[payload_start:].to_string()
+    let payload = parse_hex_int64(payload_str)
+    // Positive NaN: 0x7ff0000000000000 | payload
+    let bits = 0x7ff0000000000000L | (payload & 0xfffffffffffffL)
+    return bits.reinterpret_as_double()
+  }
+  if s.has_prefix("-nan:0x") {
+    // Parse payload from -nan:0x...
+    let payload_str = try! s[7:].to_string()
+    let payload = parse_hex_int64(payload_str)
+    // Negative NaN: 0xfff0000000000000 | payload
+    let bits = 0xfff0000000000000L | (payload & 0xfffffffffffffL)
+    return bits.reinterpret_as_double()
   }
   if s == "inf" || s == "+inf" {
     return 1.0 / 0.0 // positive infinity

--- a/wast/wast_wbtest.mbt
+++ b/wast/wast_wbtest.mbt
@@ -113,6 +113,34 @@ test "parse_float32: nan with payload" {
 }
 
 ///|
+test "parse_float32: nan with max payload preserves bits" {
+  // -nan:0x7fffff should have all mantissa bits set (except quiet bit)
+  // Expected bit pattern: 0xff800000 | 0x7fffff = 0xffffffff = -1 as i32
+  let result = parse_float32("-nan:0x7fffff") catch {
+    _ => fail("unexpected error")
+  }
+  inspect(result.reinterpret_as_int(), content="-1")
+}
+
+///|
+test "parse_float32: positive nan with payload preserves bits" {
+  // nan:0x200000 should produce 0x7f800000 | 0x200000 = 0x7fa00000 = 2141192192
+  let result = parse_float32("nan:0x200000") catch {
+    _ => fail("unexpected error")
+  }
+  inspect(result.reinterpret_as_int(), content="2141192192")
+}
+
+///|
+test "parse_float32: negative nan with payload preserves bits" {
+  // -nan:0x200000 should produce 0xff800000 | 0x200000 = 0xffa00000 = -6291456
+  let result = parse_float32("-nan:0x200000") catch {
+    _ => fail("unexpected error")
+  }
+  inspect(result.reinterpret_as_int(), content="-6291456")
+}
+
+///|
 test "parse_float32: hex float zero" {
   let result = parse_float32("0x0p+0") catch { _ => fail("unexpected error") }
   inspect(result, content="0")
@@ -149,6 +177,34 @@ test "parse_float64: nan with payload" {
     _ => fail("unexpected error")
   }
   inspect(result.is_nan(), content="true")
+}
+
+///|
+test "parse_float64: nan with max payload preserves bits" {
+  // -nan:0xfffffffffffff should have all mantissa bits set
+  // Expected: 0xfff0000000000000 | 0xfffffffffffff = 0xffffffffffffffff = -1 as i64
+  let result = parse_float64("-nan:0xfffffffffffff") catch {
+    _ => fail("unexpected error")
+  }
+  inspect(result.reinterpret_as_int64(), content="-1")
+}
+
+///|
+test "parse_float64: positive nan with payload preserves bits" {
+  // nan:0x4000000000000 should produce 0x7ff0000000000000 | 0x4000000000000 = 9219994337134247936
+  let result = parse_float64("nan:0x4000000000000") catch {
+    _ => fail("unexpected error")
+  }
+  inspect(result.reinterpret_as_int64(), content="9219994337134247936")
+}
+
+///|
+test "parse_float64: negative nan with payload preserves bits" {
+  // -nan:0x4000000000000 should produce 0xfff0000000000000 | 0x4000000000000 = -3377699720527872
+  let result = parse_float64("-nan:0x4000000000000") catch {
+    _ => fail("unexpected error")
+  }
+  inspect(result.reinterpret_as_int64(), content="-3377699720527872")
 }
 
 ///|

--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -389,13 +389,30 @@ fn parse_float32(s : String) -> Float raise WatError {
     return (-1.0 : Float) / (0.0 : Float) // negative infinity
   }
   // Handle nan and nan:payload
-  if s == "nan" ||
-    s == "+nan" ||
-    s == "-nan" ||
-    s.has_prefix("nan:") ||
-    s.has_prefix("+nan:") ||
-    s.has_prefix("-nan:") {
-    return (0.0 : Float) / (0.0 : Float) // NaN (payload ignored for now)
+  if s == "nan" || s == "+nan" {
+    // Canonical positive NaN: 0x7fc00000
+    return Float::reinterpret_from_int(0x7fc00000)
+  }
+  if s == "-nan" {
+    // Canonical negative NaN: 0xffc00000 = -4194304 as signed int
+    return Float::reinterpret_from_int(-4194304)
+  }
+  if s.has_prefix("nan:0x") || s.has_prefix("+nan:0x") {
+    // Parse payload from nan:0x...
+    let payload_start = if s.has_prefix("+") { 7 } else { 6 }
+    let payload_str = try! s[payload_start:].to_string()
+    let payload = parse_hex_int(payload_str)
+    // Positive NaN: 0x7f800000 | payload
+    let bits = 0x7f800000 | (payload & 0x7fffff)
+    return Float::reinterpret_from_int(bits)
+  }
+  if s.has_prefix("-nan:0x") {
+    // Parse payload from -nan:0x...
+    let payload_str = try! s[7:].to_string()
+    let payload = parse_hex_int(payload_str)
+    // Negative NaN: 0xff800000 | payload = -8388608 | payload
+    let bits = -8388608 | (payload & 0x7fffff)
+    return Float::reinterpret_from_int(bits)
   }
   // Handle hex float
   if s.has_prefix("0x") ||
@@ -420,13 +437,30 @@ fn parse_float64(s : String) -> Double raise WatError {
     return -1.0 / 0.0 // negative infinity
   }
   // Handle nan and nan:payload
-  if s == "nan" ||
-    s == "+nan" ||
-    s == "-nan" ||
-    s.has_prefix("nan:") ||
-    s.has_prefix("+nan:") ||
-    s.has_prefix("-nan:") {
-    return 0.0 / 0.0 // NaN (payload ignored for now)
+  if s == "nan" || s == "+nan" {
+    // Canonical positive NaN: 0x7ff8000000000000
+    return 0x7ff8000000000000L.reinterpret_as_double()
+  }
+  if s == "-nan" {
+    // Canonical negative NaN: 0xfff8000000000000
+    return 0xfff8000000000000L.reinterpret_as_double()
+  }
+  if s.has_prefix("nan:0x") || s.has_prefix("+nan:0x") {
+    // Parse payload from nan:0x...
+    let payload_start = if s.has_prefix("+") { 7 } else { 6 }
+    let payload_str = try! s[payload_start:].to_string()
+    let payload = parse_hex_int64(payload_str)
+    // Positive NaN: 0x7ff0000000000000 | payload
+    let bits = 0x7ff0000000000000L | (payload & 0xfffffffffffffL)
+    return bits.reinterpret_as_double()
+  }
+  if s.has_prefix("-nan:0x") {
+    // Parse payload from -nan:0x...
+    let payload_str = try! s[7:].to_string()
+    let payload = parse_hex_int64(payload_str)
+    // Negative NaN: 0xfff0000000000000 | payload
+    let bits = 0xfff0000000000000L | (payload & 0xfffffffffffffL)
+    return bits.reinterpret_as_double()
   }
   // Handle hex float
   if s.has_prefix("0x") ||


### PR DESCRIPTION
## Summary
- Fix unsigned truncation instructions (`i32.trunc_f32_u`, `i32.trunc_f64_u`, `i64.trunc_f32_u`, `i64.trunc_f64_u`) to handle values in range (-1, 0) correctly - they should truncate to 0, not overflow
- Fix i64 unsigned truncation for large values >= 2^63 by manually computing `(value - 2^63) + MIN_I64`
- Fix saturating truncation (`i64.trunc_sat_f32_u`, `i64.trunc_sat_f64_u`) to handle large values properly
- Fix NaN payload parsing in WAST/WAT parsers to preserve exact bit patterns (e.g., `-nan:0x7fffff` → `0xffffffff`)
- Add comprehensive tests for conversion boundary cases

## Test plan
- [x] All 567 existing tests pass
- [x] New tests added for:
  - NaN payload bit pattern preservation (f32 and f64)
  - trunc_u boundary cases for values in (-1, 0)
  - i64 unsigned truncation for values near 2^63 and 2^64
  - i64 saturating truncation behavior
  - i32.trunc_f64_s boundary near INT32_MIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)