### PR TITLE
fix(call_indirect): fix call_indirect.wast all 169 tests passing

### DIFF
--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -389,10 +389,12 @@ pub fn instantiate_module(
 ) -> (@runtime.Store, @runtime.ModuleInstance) {
   let store = @runtime.Store::new()
 
-  // Allocate functions
+  // Allocate functions with their types
   let func_addrs : Array[Int] = []
-  for code in mod.codes {
-    let addr = store.alloc_func(code)
+  for i, code in mod.codes {
+    let type_idx = mod.funcs[i]
+    let func_type = mod.types[type_idx]
+    let addr = store.alloc_func(code, func_type~)
     func_addrs.push(addr)
   }
 
@@ -597,11 +599,13 @@ pub fn instantiate_module_with_imports(
     }
   }
 
-  // Allocate module functions
+  // Allocate module functions with their types
   for i, code in mod.codes {
-    let addr = store.alloc_func(code)
+    let type_idx = mod.funcs[i]
+    let func_type = mod.types[type_idx]
+    let addr = store.alloc_func(code, func_type~)
     func_addrs.push(addr)
-    func_type_indices.push(mod.funcs[i])
+    func_type_indices.push(type_idx)
   }
 
   // Allocate memories (after imported memories)

--- a/executor/executor_wbtest.mbt
+++ b/executor/executor_wbtest.mbt
@@ -1395,9 +1395,15 @@ test "table import: call_indirect with imported table" {
     body: [LocalGet(0), LocalGet(1), I32Sub],
   }
 
-  // Allocate the functions in store
-  let add_addr = store.alloc_func(add_func)
-  let sub_addr = store.alloc_func(sub_func)
+  // The type for add/sub functions
+  let binary_type : @types.FuncType = {
+    params: [@types.ValueType::I32, @types.ValueType::I32],
+    results: [@types.ValueType::I32],
+  }
+
+  // Allocate the functions in store with their type
+  let add_addr = store.alloc_func(add_func, func_type=binary_type)
+  let sub_addr = store.alloc_func(sub_func, func_type=binary_type)
 
   // Set function references in table
   shared_table.set(0, @types.Value::FuncRef(add_addr)) catch {
@@ -1418,10 +1424,6 @@ test "table import: call_indirect with imported table" {
       CallIndirect(0, 0),
     ],
   } // type 0, table 0
-  let binary_type : @types.FuncType = {
-    params: [@types.ValueType::I32, @types.ValueType::I32],
-    results: [@types.ValueType::I32],
-  }
   let apply_type : @types.FuncType = {
     params: [
       @types.ValueType::I32,

--- a/executor/instr_call.mbt
+++ b/executor/instr_call.mbt
@@ -47,8 +47,14 @@ fn ExecContext::exec_call_indirect(
     _ => raise @runtime.IndirectCallTypeMismatch
   }
 
-  // Get the expected type and the function
+  // Get the expected type
   let expected_type = self.instance.types[type_idx]
+
+  // Get the actual function type and verify it matches
+  let actual_type = self.store.get_func_type(store_addr)
+  if expected_type != actual_type {
+    raise @runtime.IndirectCallTypeMismatch
+  }
 
   // Pop arguments from stack in reverse order
   let num_params = expected_type.params.length()

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -169,20 +169,22 @@ pub impl Show for Stack
 
 pub struct Store {
   funcs : Array[FuncInst]
+  func_types : Array[@types.FuncType]
   tables : Array[Table]
   mems : Array[Memory]
   globals : Array[GlobalInstance]
   func_owners : Array[Int]
   instances : Array[ModuleInstance]
 }
-pub fn Store::alloc_func(Self, @types.FunctionCode) -> Int
+pub fn Store::alloc_func(Self, @types.FunctionCode, func_type? : @types.FuncType) -> Int
 pub fn Store::alloc_global(Self, GlobalInstance) -> Int
-pub fn Store::alloc_host_func(Self, (Array[@types.Value]) -> Array[@types.Value] raise RuntimeError) -> Int
+pub fn Store::alloc_host_func(Self, (Array[@types.Value]) -> Array[@types.Value] raise RuntimeError, func_type? : @types.FuncType) -> Int
 pub fn Store::alloc_mem(Self, Memory) -> Int
 pub fn Store::alloc_table(Self, Table) -> Int
 pub fn Store::get_func(Self, Int) -> @types.FunctionCode raise RuntimeError
 pub fn Store::get_func_inst(Self, Int) -> FuncInst raise RuntimeError
 pub fn Store::get_func_owner(Self, Int) -> ModuleInstance?
+pub fn Store::get_func_type(Self, Int) -> @types.FuncType raise RuntimeError
 pub fn Store::get_global(Self, Int) -> GlobalInstance raise RuntimeError
 pub fn Store::get_mem(Self, Int) -> Memory raise RuntimeError
 pub fn Store::get_memory(Self, Int) -> Memory

--- a/runtime/store.mbt
+++ b/runtime/store.mbt
@@ -2,6 +2,7 @@
 /// The store contains all global runtime state
 pub struct Store {
   funcs : Array[FuncInst]
+  func_types : Array[@types.FuncType] // Type of each function
   tables : Array[Table]
   mems : Array[Memory]
   globals : Array[GlobalInstance]
@@ -16,6 +17,7 @@ pub struct Store {
 pub fn Store::new() -> Store {
   {
     funcs: [],
+    func_types: [],
     tables: [],
     mems: [],
     globals: [],
@@ -25,22 +27,29 @@ pub fn Store::new() -> Store {
 }
 
 ///|
-/// Allocate a WASM function
-pub fn Store::alloc_func(self : Store, func : @types.FunctionCode) -> Int {
+/// Allocate a WASM function with its type
+pub fn Store::alloc_func(
+  self : Store,
+  func : @types.FunctionCode,
+  func_type? : @types.FuncType = { params: [], results: [] },
+) -> Int {
   let idx = self.funcs.length()
   self.funcs.push(FuncInst::WasmFunc(func))
+  self.func_types.push(func_type)
   self.func_owners.push(-1) // Owner not yet known
   idx
 }
 
 ///|
-/// Allocate a host function
+/// Allocate a host function with its type
 pub fn Store::alloc_host_func(
   self : Store,
   func : (Array[@types.Value]) -> Array[@types.Value] raise RuntimeError,
+  func_type? : @types.FuncType = { params: [], results: [] },
 ) -> Int {
   let idx = self.funcs.length()
   self.funcs.push(FuncInst::HostFunc(func))
+  self.func_types.push(func_type)
   self.func_owners.push(-1) // Host functions don't have an owner
   idx
 }
@@ -75,6 +84,18 @@ pub fn Store::get_func_inst(
     raise UndefinedElement
   }
   self.funcs[idx]
+}
+
+///|
+/// Get function type by store address
+pub fn Store::get_func_type(
+  self : Store,
+  idx : Int,
+) -> @types.FuncType raise RuntimeError {
+  if idx < 0 || idx >= self.func_types.length() {
+    raise UndefinedElement
+  }
+  self.func_types[idx]
 }
 
 ///|

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -307,6 +307,18 @@ pub fn validate_module(mod : @types.Module) -> Unit raise ValidationError {
     }
   }
 
+  // Validate elem segments reference valid functions
+  for elem in mod.elems {
+    for init in elem.init {
+      // Each init is an array of instructions (usually just RefFunc)
+      for instr in init {
+        if instr is RefFunc(func_idx) && func_idx >= ctx.funcs.length() {
+          raise InvalidFunctionIndex(func_idx)
+        }
+      }
+    }
+  }
+
   // Validate all function bodies
   let num_imports = count_func_imports(mod.imports)
   for i, code in mod.codes {
@@ -350,6 +362,19 @@ pub fn validate_module_with_context(
       raise WithContext(
         ValidationErrorContext::from_error(InvalidMemoryIndex(data.memory_idx)),
       )
+    }
+  }
+
+  // Validate elem segments reference valid functions
+  for elem in mod.elems {
+    for init in elem.init {
+      for instr in init {
+        if instr is RefFunc(func_idx) && func_idx >= ctx.funcs.length() {
+          raise WithContext(
+            ValidationErrorContext::from_error(InvalidFunctionIndex(func_idx)),
+          )
+        }
+      }
     }
   }
 
@@ -1145,6 +1170,13 @@ fn validate_instr(
     CallIndirect(type_idx, table_idx) => {
       if table_idx >= ctx.tables.length() {
         raise InvalidTableIndex(table_idx)
+      }
+      // call_indirect requires a funcref table
+      let table_type = ctx.tables[table_idx]
+      if table_type.elem_type != @types.ValueType::FuncRef {
+        raise TypeMismatch(
+          "call_indirect requires funcref table, got \{table_type.elem_type}",
+        )
       }
       if type_idx >= ctx.types.length() {
         raise InvalidTypeIndex(type_idx)

--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -839,9 +839,15 @@ fn Parser::parse_module(self : Parser) -> @types.Module raise WatError {
             mod_.imports.push(imp)
           }
           Keyword("table") => {
-            let (table, export_name, inline_elem) = self.parse_table_def(mod_)
+            let (table, export_name, inline_elem, tbl_name) = self.parse_table_def(
+              mod_,
+            )
             let table_idx = mod_.tables.length()
             mod_.tables.push(table)
+            // Register table name with correct index
+            if tbl_name is Some(name) {
+              self.table_names.set(name, table_idx)
+            }
             if export_name is Some(name) {
               mod_.exports.push({
                 name,
@@ -1529,11 +1535,26 @@ fn Parser::parse_plain_instruction(
     "call" => @types.Instruction::Call(self.parse_func_idx())
     "call_indirect" => {
       // call_indirect can have various forms:
+      // (call_indirect $table (type $t) ...)
       // (call_indirect (type $t) ...)
       // (call_indirect (param ...) (result ...) ...)
       // (call_indirect ...)  - empty type
-      let table_idx = 0
+      let mut table_idx = 0
       let mut type_idx = -1
+
+      // Check for optional table index/name before the type
+      match self.current {
+        Id(name) =>
+          match self.table_names.get(name) {
+            Some(idx) => {
+              table_idx = idx
+              self.advance()
+            }
+            None => () // Not a table name, might be something else
+          }
+        Number(_) => table_idx = self.parse_u32()
+        _ => ()
+      }
 
       // Parse optional type/param/result annotations
       while self.current == LParen {
@@ -2427,14 +2448,17 @@ fn Parser::parse_global_def(self : Parser) -> GlobalDefResult raise WatError {
 fn Parser::parse_table_def(
   self : Parser,
   mod_ : @types.Module,
-) -> (@types.TableType, String?, @types.Element?) raise WatError {
+) -> (@types.TableType, String?, @types.Element?, String?) raise WatError {
+  // Returns (table_type, export_name, inline_elem, table_name)
   self.advance() // skip "table"
   let mut export_name : String? = None
+  let mut table_name : String? = None
 
   // Optional name
   match self.current {
     Id(name) => {
-      self.table_names.set(name, 0)
+      table_name = Some(name)
+      // Don't set table_names here; caller will set with correct index
       self.advance()
     }
     _ => ()
@@ -2509,7 +2533,12 @@ fn Parser::parse_table_def(
         }
         mod_.imports.push(imp)
         // Return a placeholder table type (the import is what matters)
-        return ({ elem_type, limits: { min, max } }, export_name, None)
+        return (
+          { elem_type, limits: { min, max } },
+          export_name,
+          None,
+          table_name,
+        )
       }
       _ => {
         // Not an inline import, restore state
@@ -2582,7 +2611,7 @@ fn Parser::parse_table_def(
               max: Some(func_indices.length()),
             },
           }
-          (table_type, export_name, Some(elem))
+          (table_type, export_name, Some(elem), table_name)
         }
         _ => raise UnexpectedToken("expected elem in inline table", self.loc())
       }
@@ -2596,7 +2625,7 @@ fn Parser::parse_table_def(
       }
       let elem_type = self.parse_value_type()
       self.expect_rparen()
-      ({ elem_type, limits: { min, max } }, export_name, None)
+      ({ elem_type, limits: { min, max } }, export_name, None, table_name)
     }
   }
 }
@@ -2924,9 +2953,12 @@ fn Parser::parse_elem_def(self : Parser) -> @types.Element raise WatError {
         _ => 0
       }
       self.expect_rparen()
-      // Now expect (offset ...)
+      // Now expect offset expression - either (offset ...) or directly (i32.const ...)
       self.expect_lparen()
-      self.expect_keyword("offset")
+      // Check if explicit "offset" keyword is present
+      if self.current is Keyword("offset") {
+        self.advance()
+      }
     }
     Keyword("offset") => self.advance()
     _ => ()


### PR DESCRIPTION
## Summary
- Add func_types array to Store for runtime type checking in call_indirect
- Update alloc_func to accept optional func_type parameter for storing function signatures
- Add type checking in exec_call_indirect to verify function signatures match expected type
- Fix WAT parser to handle optional table index in call_indirect (e.g., `(call_indirect $t1 (type $t) ...)`)
- Fix WAT parser to handle elem offset without explicit "offset" keyword (e.g., `(elem (table $t) (i32.const 0) func ...)`)
- Fix table name registration with correct indices for multi-table support
- Add validator check for call_indirect on non-funcref tables
- Add validator check for elem segments referencing invalid functions

## Test plan
- [x] All 567 unit tests pass
- [x] call_indirect.wast: 169/169 tests pass (was 0 due to parsing errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)