### PR TITLE
fix(wat): handle small integers in decimal float parsing

### DIFF
--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -888,9 +888,24 @@ fn parse_decimal_float32_precise(s : String) -> Float raise WatError {
   // The top bit is at position bit_len - 1
   // We want bits [bit_len - 24, bit_len - 1) for the 23-bit mantissa
   let mantissa_start = bit_len - 24
-  let raw_mantissa = sig.extract_bits(mantissa_start, 23)
-  let round_bit = sig.extract_bits(mantissa_start - 1, 1)
-  let sticky = sig.has_bits_below(mantissa_start - 1)
+
+  // Handle small numbers where bit_len < 24
+  // In this case, we need to shift sig left to align the bits properly
+  let (raw_mantissa, round_bit, sticky) = if mantissa_start < 0 {
+    // Shift sig left to align the leading bit at position 23
+    let shift = -mantissa_start
+    let shifted_sig = sig << shift
+    // Extract mantissa (bits 0-22, removing the implicit leading 1 at bit 23)
+    let mantissa = shifted_sig.extract_bits(0, 23)
+    // No round bit or sticky bits since we're shifting left (adding zeros)
+    (mantissa, 0UL, false)
+  } else {
+    // Normal case: extract bits from the correct position
+    let mantissa = sig.extract_bits(mantissa_start, 23)
+    let round = sig.extract_bits(mantissa_start - 1, 1)
+    let sticky_bits = sig.has_bits_below(mantissa_start - 1)
+    (mantissa, round, sticky_bits)
+  }
 
   // Round to nearest, ties to even
   let mut final_mantissa = raw_mantissa.reinterpret_as_int64().to_int()

--- a/wat/wat_test.mbt
+++ b/wat/wat_test.mbt
@@ -528,3 +528,27 @@ test "f32 decimal literal rounding - case 557" {
     _ => panic()
   }
 }
+
+// ============================================================
+// Regression test: f32.const 3 should parse correctly
+// ============================================================
+
+///|
+test "f32 simple integer constant - regression" {
+  // br.wast line 22-23: (func (export "type-f32-value") (result f32)
+  //   (block (result f32) (f32.neg (br 0 (f32.const 3)))))
+  // Expected: f32.const 3 should be 3.0, not 2.0
+  let wat =
+    #|(module
+    #|  (func (export "f") (result f32) (f32.const 3))
+    #|)
+  let mod_ = parse(wat)
+  match mod_.codes[0].body[0] {
+    F32Const(f) => {
+      // f32 3.0 should be 0x40400000 = 1077936128
+      inspect(f, content="3")
+      inspect(f.reinterpret_as_int(), content="1077936128")
+    }
+    _ => panic()
+  }
+}


### PR DESCRIPTION
## Summary

- Fix decimal float parsing for small integers (e.g., `f32.const 3`)
- When `bit_len < 24`, `mantissa_start` becomes negative, causing `extract_bits` to fail
- Solution: shift sig left to align bits before extraction when `mantissa_start < 0`
- Add regression test for this case

## Test plan

- [x] `moon test -p wat` passes (349/349)
- [x] `./wasmoon test testsuite/data/br.wast` passes (96/96)
- [x] `./wasmoon test testsuite/data/const.wast` passes (376/376)

🤖 Generated with [Claude Code](https://claude.com/claude-code)