### PR TITLE
fix(cli): correct command descriptions and add choices validation

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -592,4 +592,5 @@ _请在此处继续添加新的意见和建议_
 - [x] 代码中仍然有非常多的 `for <identifier> = <initial>; ` 这样的 c 风格循环 → 已修复所有正向迭代的 C 风格循环（保留反向迭代 `i = i - 1` 因为更简洁）
 - [x] JIT太奇怪了，干的完全是AOT的活儿，怎么处理更合适？ → **调研结论**：Wasmtime/Wasmer 的"JIT"也是在加载时编译所有函数，不是传统的热点 JIT。Wasmtime 虽有 Winch（快速编译）和 Cranelift（优化编译）两层，但目前不支持自动分层——模块全部用一种编译器。wasmoon 当前实现与业界一致，保留"JIT"命名，在文档中说明是"预编译 JIT"（eager JIT）而非热点 JIT。参考：[Cranelift Progress 2022](https://bytecodealliance.org/articles/cranelift-progress-2022)
 - [x] LEB128 的 parsing 缺乏相关测试 → 已添加 9 个 LEB128 验证测试，覆盖 u32/i32/i64 的边界情况和错误检测
-- [x] 把 cwasm 后缀纳入 gitignore，并清除已经被 git 跟踪的 cwasm 文件 → 已将 `*.cwasm` 添加到 .gitignore，并用 `git rm --cached` 移除了 5 个已跟踪的 cwasm 文件 
+- [x] 把 cwasm 后缀纳入 gitignore，并清除已经被 git 跟踪的 cwasm 文件 → 已将 `*.cwasm` 添加到 .gitignore，并用 `git rm --cached` 移除了 5 个已跟踪的 cwasm 文件
+- [x] CLI 的诸多命令描述有误，比如现在的 test 命令和 wast 命令实际上是一回事，而且都和 json 无关。`debug` 等参数应该有 choices 参数。在 `.mooncakes/TheWaWaR/clap/src/clap.mbti` 中查看 named 函数的声明。 → 已修复：更新 test 命令描述为 "Run WebAssembly test script (.wast format)"，为 debug 和 config action 参数添加 choices

--- a/main/main.mbt
+++ b/main/main.mbt
@@ -1,5 +1,14 @@
 ///|
 fn main {
+  // Define choices for debug options
+  let debug_choices = @hashset.HashSet::from_array([
+    "verbose", "print-ir", "print-vcode", "print-regalloc", "trace-exec",
+  ])
+
+  // Define choices for config action
+  let config_action_choices = @hashset.HashSet::from_array([
+    "show", "path", "init",
+  ])
   let parser = @clap.Parser::new(
     prog="wasmoon",
     description="WebAssembly Runtime in MoonBit",
@@ -31,7 +40,8 @@ fn main {
         "debug": @clap.Arg::named(
           short='D',
           nargs=@clap.Nargs::Any,
-          help="Debug option (e.g., verbose, print-ir, trace-exec)",
+          choices=debug_choices,
+          help="Debug option (verbose, print-ir, print-vcode, print-regalloc, trace-exec)",
         ),
         "wasm-opt": @clap.Arg::named(
           short='W',
@@ -64,9 +74,10 @@ fn main {
           ),
         },
       ),
-      "test": @clap.SubCommand::new(help="Run wasm-testsuite JSON spec file", args={
-        "file": @clap.Arg::positional(help="Path to JSON spec file"),
-      }),
+      "test": @clap.SubCommand::new(
+        help="Run WebAssembly test script (.wast format)",
+        args={ "file": @clap.Arg::positional(help="Path to WAST file") },
+      ),
       "disasm": @clap.SubCommand::new(
         help="Disassemble WASM file to text format",
         args={ "file": @clap.Arg::positional(help="Path to WASM file") },
@@ -103,7 +114,10 @@ fn main {
         help="Display available compiler settings",
       ),
       "config": @clap.SubCommand::new(help="Manage configuration", args={
-        "action": @clap.Arg::positional(help="Action: show, path, init"),
+        "action": @clap.Arg::positional(
+          choices=config_action_choices,
+          help="Action: show, path, init",
+        ),
       }),
       "help": @clap.SubCommand::new(help="Display help message"),
     },


### PR DESCRIPTION
## Summary

- Update `test` command description from "Run wasm-testsuite JSON spec file" to "Run WebAssembly test script (.wast format)"
- Add `choices` parameter to `debug` option to validate input values
- Add `choices` parameter to `config action` to validate input values
- Use `HashSet::from_array` for cleaner code

## Test plan

- [x] `moon check` passes
- [x] `moon test` passes (575/575)
- [x] `./wasmoon help` shows correct descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)