### PR TITLE
fix(validator): validate RefFunc references valid function index

### DIFF
--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -319,8 +319,8 @@ fn validate_const_expr(
       F64Const(_) => result_type = Some(@types.ValueType::F64)
       RefNull(t) => result_type = Some(t)
       RefFunc(func_idx) => {
-        // Check function exists if funcs array is provided
-        if funcs.length() > 0 && func_idx >= funcs.length() {
+        // Check function index is valid
+        if func_idx >= funcs.length() {
           raise InvalidFunctionIndex(func_idx)
         }
         result_type = Some(@types.ValueType::FuncRef)

--- a/validator/validator_wbtest.mbt
+++ b/validator/validator_wbtest.mbt
@@ -1141,3 +1141,32 @@ test "validator: elem init with wrong type should fail" {
   }
   inspect((try? validate_module(mod)) is Err(TypeMismatch(_)), content="true")
 }
+
+///|
+test "validator: elem with unknown function should fail" {
+  // call_indirect.wast line 1037: (module (table funcref (elem 0 0)))
+  // elem segment references function index 0, but no functions are defined
+  let mod : @types.Module = {
+    types: [],
+    imports: [],
+    funcs: [],
+    tables: [
+      { elem_type: @types.ValueType::FuncRef, limits: { min: 2, max: None } },
+    ],
+    memories: [],
+    globals: [],
+    exports: [],
+    start: None,
+    elems: [
+      {
+        mode: Active(0, [I32Const(0)]),
+        type_: @types.ValueType::FuncRef,
+        init: [[RefFunc(0)], [RefFunc(0)]], // references func 0, which doesn't exist
+      },
+    ],
+    codes: [],
+    datas: [],
+  }
+  // Should fail with "unknown function" error
+  inspect((try? validate_module(mod)) is Err(_), content="true")
+}


### PR DESCRIPTION
## Summary
Fix elem segment validation to reject `RefFunc` instructions that reference non-existent functions.

**Root cause**: The condition `funcs.length() > 0 && func_idx >= funcs.length()` would skip validation when the module had no functions defined, allowing invalid `RefFunc(0)` to pass validation.

**Fix**: Changed to `func_idx >= funcs.length()` to always validate function indices.

## Test plan
- [x] Added unit test reproducing call_indirect.wast line 1037
- [x] All 593 unit tests pass
- [x] call_indirect.wast: 169/169 tests pass
- [x] elem.wast: 72/72 tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)