### PR TITLE
fix(wat): fix float parsing bugs for hex zero, large hex int, and decimal subnormals

### DIFF
--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -576,6 +576,40 @@ impl Shl for BigUInt with shl(self, n) {
 }
 
 ///|
+/// Right shift by n bits
+impl Shr for BigUInt with shr(self, n) {
+  if n == 0 {
+    return { limbs: self.limbs.copy() }
+  }
+  let limb_shift = n / 64
+  let bit_shift = n % 64
+  if limb_shift >= self.limbs.length() {
+    return { limbs: [0UL] }
+  }
+  let result : Array[UInt64] = []
+  if bit_shift == 0 {
+    for i in limb_shift..<self.limbs.length() {
+      result.push(self.limbs[i])
+    }
+  } else {
+    for i in limb_shift..<self.limbs.length() {
+      let lo = self.limbs[i] >> bit_shift
+      let hi = if i + 1 < self.limbs.length() {
+        self.limbs[i + 1] << (64 - bit_shift)
+      } else {
+        0UL
+      }
+      result.push(lo | hi)
+    }
+  }
+  // Remove leading zeros
+  while result.length() > 1 && result[result.length() - 1] == 0UL {
+    result.pop() |> ignore
+  }
+  { limbs: result }
+}
+
+///|
 /// Get the highest set bit position (0-indexed from LSB), -1 if zero
 fn BigUInt::bit_length(self : BigUInt) -> Int {
   let mut idx = self.limbs.length() - 1
@@ -777,8 +811,9 @@ fn parse_decimal_float32_precise(s : String) -> Float raise WatError {
     // We need to compute mantissa / 5^|decimal_exp| with enough precision
     // Strategy: multiply mantissa by 2^extra_bits, then divide by 5^|decimal_exp|
     // We need at least 24 + 2 (guard, round) + some extra bits for precision
-    // Use 128 extra bits to be safe
-    let extra_bits = 128
+    // For subnormal numbers, we need up to 149 extra bits (f32 subnormal range)
+    // Use 256 extra bits to be safe for all cases
+    let extra_bits = 256
     let abs_exp = -decimal_exp
 
     // Compute 5^abs_exp
@@ -837,45 +872,97 @@ fn parse_decimal_float32_precise(s : String) -> Float raise WatError {
 
   // Check for underflow (subnormal or zero)
   if ieee_exp <= 0 {
-    // Subnormal: shift right more, ieee_exp becomes 0
-    let shift_more = 1 - ieee_exp
-    if shift_more >= bit_len {
-      // Underflow to zero
+    // Subnormal: the value is sig * 2^binary_exp
+    // For subnormal f32, we need to represent as mantissa * 2^(-149)
+    // where mantissa is at most 23 bits (no implicit leading 1)
+    //
+    // The effective exponent for subnormal is fixed at -149 (unbiased: -126 - 23)
+    // We need to shift sig right so that its value becomes mantissa * 2^(-149)
+    //
+    // Currently: value = sig * 2^binary_exp
+    // Target:    value = mantissa * 2^(-149)
+    // So: mantissa = sig * 2^(binary_exp + 149)
+    //
+    // If binary_exp + 149 < 0, we need to shift sig right by -(binary_exp + 149)
+    // If binary_exp + 149 >= 0, we need to shift sig left
+
+    let target_exp = -149
+    let shift_amount = binary_exp - target_exp // = binary_exp + 149
+    let (shifted_sig, extra_round, extra_sticky) = if shift_amount >= 0 {
+      // Shift left - no precision loss
+      (sig << shift_amount, false, false)
+    } else {
+      // Shift right - may lose precision
+      // Round bit is at position (right_shift - 1) in original sig
+      // Sticky bits are below that
+      let right_shift = -shift_amount
+      let round = if right_shift > 0 {
+        sig.extract_bits(right_shift - 1, 1) != 0UL
+      } else {
+        false
+      }
+      let sticky = if right_shift > 1 {
+        sig.has_bits_below(right_shift - 1)
+      } else {
+        false
+      }
+      (sig >> right_shift, round, sticky)
+    }
+    let shifted_bit_len = shifted_sig.bit_length()
+    if shifted_bit_len == 0 {
+      // Underflow to zero, but check if we should round up to 1
+      if extra_round && (extra_sticky || true) {
+        // Round up from 0 to 1
+        let sign_bit : UInt = if neg { 0x80000000U } else { 0U }
+        let result_bits = sign_bit | 1U
+        return Float::reinterpret_from_uint(result_bits)
+      }
       if neg {
         return Float::reinterpret_from_uint(0x80000000U)
       }
       return (0.0 : Float)
     }
-    // For subnormal, we extract fewer bits
-    let mantissa_bits = bit_len - shift_more
-    if mantissa_bits <= 0 {
-      if neg {
-        return Float::reinterpret_from_uint(0x80000000U)
+
+    // For subnormal, mantissa is at most 23 bits
+    // If shifted_sig has more than 23 bits, we need to truncate and round
+    if shifted_bit_len <= 23 {
+      // All bits fit in mantissa
+      // Round bit and sticky come from the earlier shift
+      let raw_mantissa = shifted_sig.extract_bits(0, shifted_bit_len)
+      let mut final_mantissa = raw_mantissa.reinterpret_as_int64().to_int()
+      if extra_round && (extra_sticky || (final_mantissa & 1) != 0) {
+        final_mantissa += 1
       }
-      return (0.0 : Float)
+      // Check if rounding promoted to normal
+      if final_mantissa >= 0x800000 {
+        let result_bits = if neg { 0x80800000U } else { 0x00800000U }
+        return Float::reinterpret_from_uint(result_bits)
+      }
+      let sign_bit : UInt = if neg { 0x80000000U } else { 0U }
+      let result_bits = sign_bit | final_mantissa.reinterpret_as_uint()
+      return Float::reinterpret_from_uint(result_bits)
     }
-    // Extract mantissa (no implicit 1 for subnormals)
-    let raw_mantissa = sig.extract_bits(
-      bit_len - mantissa_bits - 1,
-      mantissa_bits,
-    )
-    let round_pos = bit_len - mantissa_bits - 1
-    let round_bit = if round_pos >= 0 {
-      sig.extract_bits(round_pos, 1)
-    } else {
-      0UL
-    }
-    let sticky = if round_pos > 0 {
-      sig.has_bits_below(round_pos)
-    } else {
-      false
-    }
+
+    // shifted_bit_len > 23: need to extract top 23 bits and round
+    let mantissa_start = shifted_bit_len - 23
+    let raw_mantissa = shifted_sig.extract_bits(mantissa_start, 23)
+
+    // Round bit is at position mantissa_start - 1 in shifted_sig
+    let round_pos = mantissa_start - 1
+    let round_bit = shifted_sig.extract_bits(round_pos, 1) != 0UL
+
+    // Sticky bits are all bits below round_pos in shifted_sig, plus extra from earlier shift
+    let sticky = extra_round ||
+      extra_sticky ||
+      (round_pos > 0 && shifted_sig.has_bits_below(round_pos))
+
     // Round to nearest, ties to even
     let mut final_mantissa = raw_mantissa.reinterpret_as_int64().to_int()
-    if round_bit != 0UL && (sticky || (final_mantissa & 1) != 0) {
+    if round_bit && (sticky || (final_mantissa & 1) != 0) {
       final_mantissa += 1
     }
-    // Check if rounding promoted to normal
+
+    // Check if rounding promoted to normal (mantissa >= 2^23)
     if final_mantissa >= 0x800000 {
       // Became normal with exp = 1
       let result_bits = if neg { 0x80800000U } else { 0x00800000U }
@@ -1018,6 +1105,7 @@ fn parse_hex_float32_precise(s : String) -> Float raise WatError {
   // Parse significand as a 64-bit integer, tracking the binary exponent
   let mut significand : UInt64 = 0UL
   let mut frac_bits = 0
+  let mut int_bits_overflow = 0 // Extra integer bits that didn't fit
   let mut seen_dot = false
   let mut seen_digit = false
   let mut extra_bits = false
@@ -1047,8 +1135,15 @@ fn parse_hex_float32_precise(s : String) -> Float raise WatError {
           if seen_dot {
             frac_bits += 4
           }
-        } else if v != 0 {
-          extra_bits = true
+        } else {
+          // Beyond 64 bits
+          if !seen_dot {
+            // Integer part overflow - these bits add to the exponent
+            int_bits_overflow += 4
+          }
+          if v != 0 {
+            extra_bits = true
+          }
         }
         idx += 1
       }
@@ -1095,7 +1190,12 @@ fn parse_hex_float32_precise(s : String) -> Float raise WatError {
   }
 
   // Calculate the binary exponent
-  let total_exp = if exp_neg { -exp - frac_bits } else { exp - frac_bits }
+  // int_bits_overflow accounts for integer bits that didn't fit in significand
+  let total_exp = if exp_neg {
+    -exp - frac_bits + int_bits_overflow
+  } else {
+    exp - frac_bits + int_bits_overflow
+  }
 
   // Normalize: shift significand so leading 1 is at bit 63
   let mut norm_sig = significand
@@ -1349,8 +1449,11 @@ fn parse_hex_float64(s : String) -> Double raise WatError {
   }
 
   // Handle zero
+  // NOTE: Using bit manipulation to work around MoonBit compiler bug
+  // where `if neg { -0.0 } else { 0.0 }` incorrectly returns -0.0 even when neg=false
   if significand == 0UL {
-    return if neg { -0.0 } else { 0.0 }
+    let sign_bit : Int64 = if neg { 0x8000000000000000L } else { 0L }
+    return sign_bit.reinterpret_as_double()
   }
 
   // Calculate the binary exponent
@@ -1393,7 +1496,9 @@ fn parse_hex_float64(s : String) -> Double raise WatError {
   if ieee_exp <= 0 {
     let shift = 1 - ieee_exp
     if shift >= 64 {
-      return if neg { -0.0 } else { 0.0 }
+      // NOTE: Work around MoonBit compiler bug with conditional float literals
+      let sign_bit : Int64 = if neg { 0x8000000000000000L } else { 0L }
+      return sign_bit.reinterpret_as_double()
     }
     let shifted_sig = norm_sig >> shift
     // For double subnormal: mantissa is bits 62-11 of shifted_sig (52 bits)

--- a/wat/parser_wbtest.mbt
+++ b/wat/parser_wbtest.mbt
@@ -295,3 +295,130 @@ test "parse WAT: forward reference table" {
   inspect(mod.exports[0].name, content="t")
   inspect(mod.exports[0].desc is @types.ExportDesc::Table(_), content="true")
 }
+
+// ============================================================
+// Regression tests for float_literals.wast failures
+// ============================================================
+
+///|
+test "debug: MoonBit 0.0 bit pattern" {
+  // Verify MoonBit's 0.0 and -0.0 bit patterns
+  let pos_zero : Double = 0.0
+  let neg_zero : Double = -0.0
+  inspect(pos_zero.reinterpret_as_int64(), content="0")
+  inspect(neg_zero.reinterpret_as_int64(), content="-9223372036854775808")
+}
+
+///|
+// NOTE: This test documents a MoonBit compiler bug where
+// `if neg { -0.0 } else { 0.0 }` returns -0.0 even when neg=false.
+// Keep this test to track when the bug is fixed.
+test "moonbit-bug: conditional 0.0 vs -0.0 returns wrong value" {
+  let neg = false
+  let result = if neg { -0.0 } else { 0.0 }
+  let bits = result.reinterpret_as_int64()
+  // BUG: Should be 0, but MoonBit returns -9223372036854775808 (negative zero)
+  inspect(bits, content="-9223372036854775808")
+}
+
+///|
+test "regression: f64.zero - hex float 0x0.0p0 should be positive zero" {
+  // f64.zero: 0x0.0p0 should return bit pattern 0x0000000000000000 (positive zero)
+  // NOT 0x8000000000000000 (negative zero)
+  let result = parse_float64("0x0.0p0") catch { e => fail("Parse error: \{e}") }
+  let bits = result.reinterpret_as_int64()
+  inspect(bits, content="0") // Should be 0, not -9223372036854775808
+}
+
+///|
+test "regression: f64.positive_zero - hex float +0x0.0p0 with explicit plus" {
+  // +0x0.0p0 should also be positive zero
+  let result = parse_float64("+0x0.0p0") catch {
+    e => fail("Parse error: \{e}")
+  }
+  let bits = result.reinterpret_as_int64()
+  inspect(bits, content="0") // Should be 0, not -9223372036854775808
+}
+
+///|
+test "regression: f32.large_int - 80-bit hex integer" {
+  // 0x1_0000_0000_0000_0000_0000 is 2^80
+  // As f32, this should be 0x67800000 (1736441856)
+  let result = parse_float32("0x1_0000_0000_0000_0000_0000") catch {
+    e => fail("Parse error: \{e}")
+  }
+  let bits = result.reinterpret_as_int()
+  inspect(bits, content="1736441856") // 0x67800000
+}
+
+///|
+test "regression: f32_dec.min_positive - smallest positive f32" {
+  // 1.4013e-45 is the smallest positive subnormal f32
+  // Should have bit pattern 0x00000001 (1)
+  // f32 subnormal: value = mantissa * 2^(-149) where mantissa is in [0, 2^23-1]
+  // For bit pattern 1: value = 1 * 2^(-149) ≈ 1.4012984643e-45
+  let result = parse_float32("1.4013e-45") catch {
+    e => fail("Parse error: \{e}")
+  }
+  let bits = result.reinterpret_as_int()
+  inspect(bits, content="1") // Should be 1, not 0
+}
+
+///|
+test "debug: f32 subnormal boundary values" {
+  // 2^(-149) ≈ 1.4012984643e-45 is the smallest positive f32
+  // 1.4e-45 is slightly less than 2^(-149), but close enough to round to 1
+  let r1 = parse_float32("1.4e-45") catch { e => fail("Parse error: \{e}") }
+  inspect(r1.reinterpret_as_int(), content="1")
+
+  // 1.5e-45 should definitely round to 1
+  let r2 = parse_float32("1.5e-45") catch { e => fail("Parse error: \{e}") }
+  inspect(r2.reinterpret_as_int(), content="1")
+}
+
+///|
+test "debug: strconv parse_double for subnormal" {
+  // What does MoonBit's strconv return for 1.4013e-45?
+  let d = @strconv.parse_double("1.4013e-45") catch { _ => fail("parse error") }
+  // Convert double to float (may lose precision)
+  let f = Float::from_double(d)
+  inspect(f.reinterpret_as_int(), content="1")
+}
+
+///|
+test "debug: strconv for max subnormal" {
+  let d = @strconv.parse_double("1.1754942e-38") catch {
+    _ => fail("parse error")
+  }
+  let f = Float::from_double(d)
+  inspect(f.reinterpret_as_int(), content="8388607")
+}
+
+///|
+test "regression: f32_dec.max_subnormal - largest subnormal f32" {
+  // 1.1754942e-38 is close to the largest subnormal f32
+  // max_subnormal = 8388607 * 2^(-149) ≈ 1.1754942106924411e-38
+  // 8388606 * 2^(-149) ≈ 1.1754940705955805e-38
+  // midpoint ≈ 1.1754941406440108e-38
+  // 1.1754942e-38 > midpoint, so should round up to 8388607
+  let result = parse_float32("1.1754942e-38") catch {
+    e => fail("Parse error: \{e}")
+  }
+  let bits = result.reinterpret_as_int()
+  inspect(bits, content="8388607") // 0x007fffff
+}
+
+///|
+test "debug: max subnormal with more precision" {
+  // Use exact value that should definitely be 8388607
+  let r1 = parse_float32("1.17549421e-38") catch {
+    e => fail("Parse error: \{e}")
+  }
+  inspect(r1.reinterpret_as_int(), content="8388607")
+
+  // Use exact value for 8388606
+  let r2 = parse_float32("1.17549407e-38") catch {
+    e => fail("Parse error: \{e}")
+  }
+  inspect(r2.reinterpret_as_int(), content="8388606")
+}


### PR DESCRIPTION
## Summary

- Fix f64 hex zero sign issue: work around MoonBit compiler bug where `if neg { -0.0 } else { 0.0 }` incorrectly returns -0.0 even when neg=false
- Fix f32 large hex integer overflow (e.g., `0x1_0000_0000_0000_0000_0000` which is 2^80)
- Fix decimal subnormal parsing with correct shift amount and round/sticky bit handling

## Test plan

- [x] All 177 float_literals.wast tests pass (was 5 failures)
- [x] All 610 moon tests pass
- [x] `moon check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)