### PR TITLE
fix(validator): add type verification for if-then/else branches

### DIFF
--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -1556,6 +1556,10 @@ fn validate_instr(
       }
       validate_expr(ctx, then_stack, then_body)
       then_stack.check_height(results.length(), "if-then exit")
+      // Verify then result types
+      for i = results.length() - 1; i >= 0; i = i - 1 {
+        then_stack.pop(results[i])
+      }
       // Validate else branch
       let else_stack = OperandStack::new()
       for param in params {
@@ -1563,6 +1567,10 @@ fn validate_instr(
       }
       validate_expr(ctx, else_stack, else_body)
       else_stack.check_height(results.length(), "if-else exit")
+      // Verify else result types
+      for i = results.length() - 1; i >= 0; i = i - 1 {
+        else_stack.pop(results[i])
+      }
       // Pop label
       let _ = ctx.labels.pop()
       // Push results onto outer stack


### PR DESCRIPTION
## Summary
- Fixed missing type verification in if-then/else branch validation
- The validator was only checking stack height, not actual types
- Added explicit type checks for both then and else branches, matching Block/Loop pattern

## Test Results
- if.wast: 240/240 passed (was 236/240)
- block.wast: 222/222 passed
- loop.wast: 119/119 passed
- All unit tests: 618/618 passed

## Test plan
- [x] Run `./wasmoon test testsuite/data/if.wast` - all 240 tests pass
- [x] Run `moon test` - all unit tests pass
- [x] Run block.wast and loop.wast - no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)