### PR TITLE
fix(validator): include RefFuncTyped in non-nullable reference check

### DIFF
--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -231,7 +231,7 @@ fn ValidationContext::new(mod : @types.Module) -> ValidationContext {
 /// Check if a value type is a non-nullable reference type
 fn is_non_nullable_ref(ty : @types.ValueType) -> Bool {
   match ty {
-    RefFunc | RefExtern => true
+    RefFunc | RefExtern | RefFuncTyped(_) => true
     _ => false
   }
 }


### PR DESCRIPTION
## Summary
Fixed regression from PR #134: `RefFuncTyped` was not included in the `is_non_nullable_ref` check, causing uninitialized typed function reference locals to incorrectly pass validation.

## Fix
Added `RefFuncTyped(_)` to the pattern match in `is_non_nullable_ref`.

## Test Results
- func.wast: 170/171 → 171/171 (line 659 now passes)
- All 618 unit tests pass
- All 133 linking.wast tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)