### PR TITLE
fix(validator): restore local_init state after block/loop/if

### DIFF
--- a/testsuite/data/local.wast
+++ b/testsuite/data/local.wast
@@ -1,1 +1,0 @@
-404: Not Found

--- a/testsuite/data/local_init.wast
+++ b/testsuite/data/local_init.wast
@@ -1,0 +1,74 @@
+;; Uninitialized undefaulted locals
+
+(module
+  (func (export "get-after-set") (param $p (ref extern)) (result (ref extern))
+    (local $x (ref extern))
+    (local.set $x (local.get $p))
+    (local.get $x)
+  )
+  (func (export "get-after-tee") (param $p (ref extern)) (result (ref extern))
+    (local $x (ref extern))
+    (drop (local.tee $x (local.get $p)))
+    (local.get $x)
+  )
+  (func (export "get-in-block-after-set") (param $p (ref extern)) (result (ref extern))
+    (local $x (ref extern))
+    (local.set $x (local.get $p))
+    (block (result (ref extern)) (local.get $x))
+  )
+)
+
+(assert_return (invoke "get-after-set" (ref.extern 1)) (ref.extern 1))
+(assert_return (invoke "get-after-tee" (ref.extern 2)) (ref.extern 2))
+(assert_return (invoke "get-in-block-after-set" (ref.extern 3)) (ref.extern 3))
+
+(assert_invalid
+  (module (func $uninit (local $x (ref extern)) (drop (local.get $x))))
+  "uninitialized local"
+)
+(assert_invalid
+  (module
+    (func $uninit-after-end (param $p (ref extern))
+      (local $x (ref extern))
+      (block (local.set $x (local.get $p)) (drop (local.tee $x (local.get $p))))
+      (drop (local.get $x))
+    )
+  )
+  "uninitialized local"
+)
+(assert_invalid
+  (module
+    (func $uninit-in-else (param $p (ref extern))
+      (local $x (ref extern))
+      (if (i32.const 0)
+        (then (local.set $x (local.get $p)))
+	(else (local.get $x))
+      )
+    )
+  )
+  "uninitialized local"
+)
+
+(assert_invalid
+  (module
+    (func $uninit-from-if (param $p (ref extern))
+      (local $x (ref extern))
+      (if (i32.const 0)
+        (then (local.set $x (local.get $p)))
+	(else (local.set $x (local.get $p)))
+      )
+      (drop (local.get $x))
+    )
+  )
+  "uninitialized local"
+)
+
+(module
+  (func (export "tee-init") (param $p (ref extern)) (result (ref extern))
+    (local $x (ref extern))
+    (drop (local.tee $x (local.get $p)))
+    (local.get $x)
+  )
+)
+
+(assert_return (invoke "tee-init" (ref.extern 1)) (ref.extern 1))

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -1490,13 +1490,19 @@ fn validate_instr(
       for param in params {
         block_stack.push(param)
       }
+      // Save local_init state - locals initialized inside block don't count outside
+      let saved_init = ctx.local_init.copy()
       // Push label for block (br jumps to end, uses results)
       let label : LabelInfo = { kind: BlockLabel, block_type: bt }
       ctx.labels.push(label)
       // Validate body
       validate_expr(ctx, block_stack, body)
       // Pop label
-      let _ = ctx.labels.pop()
+      ctx.labels.pop() |> ignore
+      // Restore local_init state
+      for i in 0..<saved_init.length() {
+        ctx.local_init[i] = saved_init[i]
+      }
       // Check stack height: should have exactly results.length() values
       block_stack.check_height(results.length(), "block exit")
       // Verify result types
@@ -1520,13 +1526,19 @@ fn validate_instr(
       for param in params {
         block_stack.push(param)
       }
+      // Save local_init state - locals initialized inside loop don't count outside
+      let saved_init = ctx.local_init.copy()
       // Push label for loop (br jumps to start, uses params)
       let label : LabelInfo = { kind: LoopLabel, block_type: bt }
       ctx.labels.push(label)
       // Validate body
       validate_expr(ctx, block_stack, body)
       // Pop label
-      let _ = ctx.labels.pop()
+      ctx.labels.pop() |> ignore
+      // Restore local_init state
+      for i in 0..<saved_init.length() {
+        ctx.local_init[i] = saved_init[i]
+      }
       // Check stack height: should have exactly results.length() values
       block_stack.check_height(results.length(), "loop exit")
       // Verify result types
@@ -1546,6 +1558,8 @@ fn validate_instr(
       for i = params.length() - 1; i >= 0; i = i - 1 {
         stack.pop(params[i])
       }
+      // Save local_init state - locals initialized inside if don't count outside
+      let saved_init = ctx.local_init.copy()
       // Push label for if (br jumps to end, uses results)
       let label : LabelInfo = { kind: BlockLabel, block_type: bt }
       ctx.labels.push(label)
@@ -1560,6 +1574,10 @@ fn validate_instr(
       for i = results.length() - 1; i >= 0; i = i - 1 {
         then_stack.pop(results[i])
       }
+      // Restore local_init state before else branch
+      for i in 0..<saved_init.length() {
+        ctx.local_init[i] = saved_init[i]
+      }
       // Validate else branch
       let else_stack = OperandStack::new()
       for param in params {
@@ -1572,7 +1590,11 @@ fn validate_instr(
         else_stack.pop(results[i])
       }
       // Pop label
-      let _ = ctx.labels.pop()
+      ctx.labels.pop() |> ignore
+      // Restore local_init state - locals initialized in if don't count outside
+      for i in 0..<saved_init.length() {
+        ctx.local_init[i] = saved_init[i]
+      }
       // Push results onto outer stack
       for result in results {
         stack.push(result)


### PR DESCRIPTION
## Summary
- Fix local initialization scoping in validator for block/loop/if structures
- In WebAssembly, locals initialized inside control flow structures are NOT considered initialized after the structure ends
- Add `local_init.wast` test file (renamed from corrupted `local.wast`)

## Test plan
- [x] `local_init.wast`: 8/8 passed (was 6/8)
- [x] `func.wast`: 171/171 passed
- [x] `local_get.wast`: 35/35 passed
- [x] `local_set.wast`: 52/52 passed
- [x] `local_tee.wast`: 97/97 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)