### PR TITLE
feat(wast): add support for 'module definition' syntax

### DIFF
--- a/main/wast.mbt
+++ b/main/wast.mbt
@@ -339,6 +339,26 @@ fn run_wast_command(
         "line \{line}: skipped (binary parse failed: \{err})",
       )
     }
+    ModuleDefinition(mod_, name) => {
+      // Module definition - only validates, does not instantiate
+      // Used for testing large memory declarations that can't actually be allocated
+      @validator.validate_module(mod_) catch {
+        e => {
+          result.failed = result.failed + 1
+          result.failures.push(
+            "line \{line}: module definition validation failed: \{e}",
+          )
+          return
+        }
+      }
+      // Update the named module map if name is provided, but don't set as current
+      // since this module is not instantiated
+      if name is Some(_) {
+        // Skip - can't add to named_modules without instance
+        ()
+      }
+      result.passed = result.passed + 1
+    }
     AssertReturn(action, expected) =>
       match run_assert_return(ctx, action, expected) {
         None => result.passed = result.passed + 1

--- a/wast/pkg.generated.mbti
+++ b/wast/pkg.generated.mbti
@@ -29,6 +29,7 @@ pub impl Show for WastAction
 
 pub enum WastCommand {
   Module(@types.Module, String?)
+  ModuleDefinition(@types.Module, String?)
   ModuleQuote(Array[String])
   ModuleBinaryFailed(String)
   AssertReturn(WastAction, Array[WastValue])

--- a/wast/wast.mbt
+++ b/wast/wast.mbt
@@ -100,6 +100,7 @@ priv enum Token {
 /// WAST command types
 pub enum WastCommand {
   Module(@types.Module, String?) // module and optional name
+  ModuleDefinition(@types.Module, String?) // module definition only (not instantiated)
   ModuleQuote(Array[String]) // quoted module (for malformed tests)
   ModuleBinaryFailed(String) // binary module that failed to parse (skip in tests)
   AssertReturn(WastAction, Array[WastValue])
@@ -654,8 +655,19 @@ fn Parser::parse_module_command(self : Parser) -> WastCommand raise WastError {
   self.advance() // skip "module"
   // Check for optional module name
   let name = self.parse_optional_id()
-  // Check for binary or quote module
+  // Check for binary, quote, or definition module
   match self.current {
+    Keyword("definition") => {
+      // module definition - defines but doesn't instantiate
+      self.advance()
+      let module_start_line = self.current_line()
+      let wat_text = self.collect_module_text()
+      self.expect_rparen()
+      let mod_ = @wat.parse(wat_text) catch {
+        e => raise WatError(e, module_start_line)
+      }
+      ModuleDefinition(mod_, name)
+    }
     Keyword("binary") => {
       self.advance()
       let bytes = self.parse_binary_module()

--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -158,7 +158,7 @@ fn Parser::parse_u32(self : Parser) -> Int raise WatError {
   match self.current {
     Number(s) => {
       self.advance()
-      parse_int(s)
+      parse_u32(s)
     }
     _ =>
       raise UnexpectedToken("expected number, got \{self.current}", self.loc())

--- a/wat/parser_wbtest.mbt
+++ b/wat/parser_wbtest.mbt
@@ -236,6 +236,13 @@ test "parse_u32: decimal overflow raises error" {
 }
 
 ///|
+test "parse_u32: hex overflow 0x1_0000_0000 raises error" {
+  // 0x1_0000_0000 = 4294967296, exceeds u32 max
+  let result = try? parse_u32("0x1_0000_0000")
+  inspect(result is Err(_), content="true")
+}
+
+///|
 test "parse WAT: multiple inline exports on func" {
   // Test: (module (func (export "a") (export "b") (export "c")))
   let wat = "(module (func (export \"a\") (export \"b\") (export \"c\")))"


### PR DESCRIPTION
## Summary
- Add `ModuleDefinition` variant to `WastCommand` enum for modules that should only be validated but not instantiated
- Handle `(module definition ...)` syntax in WAST parser - used for testing large memory declarations that can't actually be allocated
- Fix `Parser::parse_u32` to properly use `parse_u32()` function instead of `parse_int()`, ensuring values exceeding u32 max (0xFFFFFFFF) are rejected

## Test plan
- [x] `./wasmoon test testsuite/data/memory.wast` - 79/79 passing (was 73/79 with 6 failures)
- [x] `./wasmoon test testsuite/data/func.wast` - 171/171 passing (no regression)
- [x] `./wasmoon test testsuite/data/local_init.wast` - 8/8 passing (no regression)
- [x] `moon test --package Milky2018/wasmoon/wat` - All parser tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)