### PR TITLE
fix(wat,validator): handle select with nested reference types

### DIFF
--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -237,6 +237,20 @@ fn is_non_nullable_ref(ty : @types.ValueType) -> Bool {
 }
 
 ///|
+/// Check if a value type is any reference type (nullable or non-nullable)
+fn is_ref_type(ty : @types.ValueType) -> Bool {
+  match ty {
+    FuncRef
+    | ExternRef
+    | RefFunc
+    | RefExtern
+    | RefFuncTyped(_)
+    | RefNullFuncTyped(_) => true
+    _ => false
+  }
+}
+
+///|
 /// Operand stack for type validation
 /// Uses Option to represent polymorphic stack (after unreachable)
 priv struct OperandStack {
@@ -1428,6 +1442,13 @@ fn validate_instr(
       if t1 != t2 {
         raise TypeMismatch(
           "select operands must have same type: \{t1} vs \{t2}",
+        )
+      }
+      // Untyped select (without explicit result type) only works with numeric types.
+      // For reference types, the typed form `select t*` must be used.
+      if is_ref_type(t1) {
+        raise TypeMismatch(
+          "type mismatch: select with reference type requires explicit type annotation",
         )
       }
       stack.push(t1)

--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -2787,11 +2787,18 @@ fn Parser::parse_plain_instruction(
         self.advance()
         match self.current {
           Keyword("result") => {
-            // Skip result type annotation
-            while self.current != RParen {
+            // Skip result type annotation, tracking nested parentheses
+            let mut depth = 1 // We're inside (result ...)
+            while depth > 0 {
               self.advance()
+              match self.current {
+                LParen => depth += 1
+                RParen => depth -= 1
+                Eof => break
+                _ => ()
+              }
             }
-            self.expect_rparen()
+            self.advance() // Move past the closing RParen
           }
           _ => {
             // Not a type annotation, restore state

--- a/wat/parser_wbtest.mbt
+++ b/wat/parser_wbtest.mbt
@@ -494,3 +494,30 @@ test "regression: ref type local parsing" {
   inspect(code.locals.length(), content="1")
   inspect(code.locals[0], content="RefFuncTyped(0)")
 }
+
+///|
+test "regression: select with nested ref type in result annotation" {
+  // select (result (ref null func)) should properly parse the nested parentheses
+  // in the result type annotation. Previously, the parser would stop at the first
+  // closing paren inside (ref null func), leaving the operands unparsed.
+  let wat =
+    #|(module
+    #|  (type $t (func))
+    #|  (func $tf) (elem declare func $tf)
+    #|  (func (export "join-funcnull") (param i32) (result (ref null func))
+    #|    (select (result (ref null func))
+    #|      (ref.func $tf)
+    #|      (ref.null func)
+    #|      (local.get 0)
+    #|    )
+    #|  )
+    #|)
+  let mod = parse(wat) catch { e => fail("Parse error: \{e}") }
+  // Should have parsed successfully with 2 functions
+  inspect(mod.funcs.length(), content="2")
+  // The exported function should have the select instruction
+  let code = mod.codes[1]
+  // Body should contain: RefFunc, RefNull, LocalGet, Select
+  inspect(code.body.length(), content="4")
+  inspect(code.body[3], content="Select")
+}


### PR DESCRIPTION
## Summary

- Fixed WAT parser to correctly handle `select` with nested reference types like `(result (ref null func))`
- Added validation to reject untyped `select` with reference types (per WebAssembly spec, typed form must be used)

## Details

**Parser fix**: The `select` instruction can have an optional `(result ...)` annotation. When the result type contains nested parentheses (e.g., `(ref null func)`), the parser previously stopped at the first `)` instead of tracking parenthesis depth. This caused the operands to not be parsed correctly.

**Validation fix**: According to the WebAssembly spec, the untyped `select` instruction only works with numeric types (i32, i64, f32, f64). For reference types, the typed form `select t*` must be used. Added a check to reject reference types with untyped select.

## Test plan

- [x] Run `moon test` - all 621 tests pass
- [x] Run `./wasmoon test testsuite/data/select.wast` - all 154 tests pass (was 69 failures)
- [x] Added regression test for select with nested reference types

🤖 Generated with [Claude Code](https://claude.com/claude-code)