### PR TITLE
fix(wat): support optional labels after else and end in flat form

### DIFF
--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -154,6 +154,15 @@ fn Parser::expect_keyword(self : Parser, kw : String) -> Unit raise WatError {
 }
 
 ///|
+/// Skip an optional identifier (e.g., label after 'end' or 'else' in flat form)
+fn Parser::skip_optional_id(self : Parser) -> Unit raise WatError {
+  match self.current {
+    Id(_) => self.advance()
+    _ => ()
+  }
+}
+
+///|
 fn Parser::parse_u32(self : Parser) -> Int raise WatError {
   match self.current {
     Number(s) => {
@@ -2652,6 +2661,8 @@ fn Parser::parse_plain_instruction(
       let body = self.parse_instructions()
       self.pop_label()
       self.expect_keyword("end")
+      // Skip optional label after 'end' (e.g., "end $label")
+      self.skip_optional_id()
       @types.Instruction::Block(bt, body)
     }
     "loop" => {
@@ -2668,6 +2679,8 @@ fn Parser::parse_plain_instruction(
       let body = self.parse_instructions()
       self.pop_label()
       self.expect_keyword("end")
+      // Skip optional label after 'end' (e.g., "end $label")
+      self.skip_optional_id()
       @types.Instruction::Loop(bt, body)
     }
     "if" => {
@@ -2686,12 +2699,16 @@ fn Parser::parse_plain_instruction(
       let else_body : Array[@types.Instruction] = if self.current ==
         Keyword("else") {
         self.advance()
+        // Skip optional label after 'else' (e.g., "else $label")
+        self.skip_optional_id()
         self.parse_instructions()
       } else {
         []
       }
       self.pop_label()
       self.expect_keyword("end")
+      // Skip optional label after 'end' (e.g., "end $label")
+      self.skip_optional_id()
       @types.Instruction::If(bt, then_body, else_body)
     }
     "br" => @types.Instruction::Br(self.parse_label_idx())

--- a/wat/parser_wbtest.mbt
+++ b/wat/parser_wbtest.mbt
@@ -521,3 +521,46 @@ test "regression: select with nested ref type in result annotation" {
   inspect(code.body.length(), content="4")
   inspect(code.body[3], content="Select")
 }
+
+///|
+test "regression: flat form with optional labels after else and end" {
+  // WAT flat form allows optional label IDs after 'if', 'else', and 'end'
+  // These labels are for documentation purposes and should be skipped.
+  // Previously: parser failed with "expected 'end', got Id("body")"
+  let wat =
+    #|(module
+    #|  (func (export "fac-stack-raw") (param $n i64) (result i64)
+    #|    (local $i i64)
+    #|    (local $res i64)
+    #|    local.get $n
+    #|    local.set $i
+    #|    i64.const 1
+    #|    local.set $res
+    #|    block $done
+    #|      loop $loop
+    #|        local.get $i
+    #|        i64.const 0
+    #|        i64.eq
+    #|        if $body
+    #|          br $done
+    #|        else $body
+    #|          local.get $i
+    #|          local.get $res
+    #|          i64.mul
+    #|          local.set $res
+    #|          local.get $i
+    #|          i64.const 1
+    #|          i64.sub
+    #|          local.set $i
+    #|        end $body
+    #|        br $loop
+    #|      end $loop
+    #|    end $done
+    #|    local.get $res
+    #|  )
+    #|)
+  let mod = parse(wat) catch { e => fail("Parse error: \{e}") }
+  inspect(mod.funcs.length(), content="1")
+  inspect(mod.exports.length(), content="1")
+  inspect(mod.exports[0].name, content="fac-stack-raw")
+}


### PR DESCRIPTION
## Summary

Fix WAT parser to support optional label IDs after `else` and `end` keywords in flat form syntax.

## Problem

The WAT flat form allows optional label IDs after `if`, `else`, and `end` keywords for documentation purposes:

```wat
if $body
  br $done
else $body      ;; <- optional label after else
  ...
end $body       ;; <- optional label after end
```

Previously the parser failed with: `"expected 'end', got Id("body")"`

## Solution

Add `skip_optional_id()` helper function to skip these optional labels after:
- `end` in block, loop, and if constructs
- `else` in if constructs

## Test Plan

- [x] `stack.wast` now passes (5 tests)
- [x] All 622 unit tests pass
- [x] No regressions in WAST test suite

## Results

| Metric | Before | After |
|--------|--------|-------|
| Fully Passed Files | 66/72 | **67/72** |
| Parse Errors | 2 | **1** |
| Total Passed | 18711 | **18716** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)