### PR TITLE
fix(validator): detect unconsumed values after unreachable code

### DIFF
--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -256,11 +256,12 @@ fn is_ref_type(ty : @types.ValueType) -> Bool {
 priv struct OperandStack {
   stack : Array[@types.ValueType]
   mut polymorphic : Bool // true after unreachable instruction
+  mut underflow_limit : Int // stack height at which polymorphism was enabled
 }
 
 ///|
 fn OperandStack::new() -> OperandStack {
-  { stack: [], polymorphic: false }
+  { stack: [], polymorphic: false, underflow_limit: 0 }
 }
 
 ///|
@@ -308,18 +309,32 @@ fn OperandStack::pop_any(
 ///|
 fn OperandStack::set_polymorphic(self : OperandStack) -> Unit {
   self.polymorphic = true
+  self.underflow_limit = self.stack.length()
 }
 
 ///|
 /// Check that stack has exactly the expected height
+/// In polymorphic mode, we can synthesize values from below the underflow_limit,
+/// but actual values pushed after unreachable still count.
 fn OperandStack::check_height(
   self : OperandStack,
   expected : Int,
   context : String,
 ) -> Unit raise ValidationError {
-  if !self.polymorphic && self.stack.length() != expected {
+  let actual = self.stack.length()
+  if self.polymorphic {
+    // Values above underflow_limit are real values that were pushed after unreachable
+    let real_values = actual - self.underflow_limit
+    // We can synthesize up to (expected - real_values) values from the polymorphic stack,
+    // but if we have more real values than expected, that's an error
+    if real_values > expected {
+      raise StackHeightMismatch(
+        "\{context}: expected stack height \{expected}, got at least \{real_values} values after unreachable code",
+      )
+    }
+  } else if actual != expected {
     raise StackHeightMismatch(
-      "\{context}: expected stack height \{expected}, got \{self.stack.length()}",
+      "\{context}: expected stack height \{expected}, got \{actual}",
     )
   }
 }


### PR DESCRIPTION
## Summary
- Fixed a bug where the validator was not correctly detecting type mismatches for values pushed onto the stack after unreachable code
- Added `underflow_limit` tracking to `OperandStack` to distinguish between polymorphic stack values and real values pushed after unreachable
- The `check_height` function now properly validates that real values pushed after unreachable don't exceed the expected count

## Test plan
- [x] All 19 previously failing test cases in `unreached-invalid.wast` now pass
- [x] `unreached-valid.wast` still passes (no regressions)
- [x] All 622 MoonBit unit tests pass
- [x] All other WAST tests maintain their previous status (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)