### PR TITLE
feat(jit): add polymorphic call interface and update tests

### DIFF
--- a/jit/execution_wbtest.mbt
+++ b/jit/execution_wbtest.mbt
@@ -147,23 +147,19 @@ test "execute br_table with f32 locals (f32_br_2locals.wast)" {
   // For proper WAST behavior, see the "end-to-end" test below which parses actual WAST
 
   // test(0) should return 10.0 (store 10 to mem[0], load back)
-  let result0 = jm.call_with_context(f, [0L])
-  let result0_f32 = Float::from_double(result0[0].reinterpret_as_double())
+  let Single((result0_f32 : Float)) = jm.call_with_context_poly(f, Single(0))
   inspect(result0_f32, content="10")
 
   // test(1) should return 10.0
-  let result1 = jm.call_with_context(f, [1L])
-  let result1_f32 = Float::from_double(result1[0].reinterpret_as_double())
+  let Single((result1_f32 : Float)) = jm.call_with_context_poly(f, Single(1))
   inspect(result1_f32, content="10")
 
   // test(2) should return 10.0
-  let result2 = jm.call_with_context(f, [2L])
-  let result2_f32 = Float::from_double(result2[0].reinterpret_as_double())
+  let Single((result2_f32 : Float)) = jm.call_with_context_poly(f, Single(2))
   inspect(result2_f32, content="10")
 
   // test(3) - default case: jumps directly to exit, d2 retains value from d0 (which is 10.0)
-  let result3 = jm.call_with_context(f, [3L])
-  let result3_f32 = Float::from_double(result3[0].reinterpret_as_double())
+  let Single((result3_f32 : Float)) = jm.call_with_context_poly(f, Single(3))
   inspect(result3_f32, content="10")
 }
 
@@ -639,9 +635,9 @@ test "end-to-end: f32_br_2locals.wast from source" {
             }
 
             // Call the JIT-compiled function
-            let result = jm.call_with_context(f, [arg.to_int64()])
-            let result_f32 = Float::from_double(
-              result[0].reinterpret_as_double(),
+            let Single((result_f32 : Float)) = jm.call_with_context_poly(
+              f,
+              Single(arg),
             )
             results.push((arg.to_int64(), expected_f32, result_f32))
           }

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -63,6 +63,12 @@ pub fn memory_init(Int64, Int64, Bytes) -> Bool
 pub suberror JITTrap String
 pub impl Show for JITTrap
 
+pub suberror PolycallError {
+  InputNumber(Int, Int)
+  OutputNumber(Int, Int)
+  JIT(JITTrap)
+}
+
 // Types and methods
 pub(all) struct Breakpoint {
   id : Int
@@ -237,6 +243,7 @@ pub struct JITModule {
   // private fields
 }
 pub fn JITModule::call_with_context(Self, JITFunction, Array[Int64]) -> Array[Int64] raise JITTrap
+pub fn[Arg : DynamicArgs, Ret : DynamicReturn] JITModule::call_with_context_poly(Self, JITFunction, Arg) -> Ret raise PolycallError
 pub fn JITModule::free(Self) -> Unit
 pub fn JITModule::from_single_function(Array[Int], String, Int, Array[@types.ValueType], Int64) -> Self?
 pub fn JITModule::get_func(Self, Int) -> JITFunction?
@@ -262,6 +269,12 @@ pub fn Profiler::record_call(Self, Int) -> (Int, Bool)
 pub fn Profiler::should_use_jit(Self, Int) -> Bool
 pub fn Profiler::stats(Self) -> (Int, Int, Int, Int)
 pub impl Show for Profiler
+
+pub(all) struct Single[A](A)
+#deprecated
+pub fn[A] Single::inner(Self[A]) -> A
+pub impl[A : ToInt64] DynamicArgs for Single[A]
+pub impl[A : FromInt64] DynamicReturn for Single[A]
 
 pub(all) struct SourceLocation {
   func_idx : Int
@@ -329,6 +342,30 @@ pub fn TieredConfig::eager() -> Self
 // Type aliases
 
 // Traits
+pub trait DynamicArgs {
+  to_int64_array(Self) -> Array[Int64]
+}
+pub impl DynamicArgs for Unit
+pub impl[A : ToInt64, B : ToInt64] DynamicArgs for (A, B)
+pub impl[A : ToInt64, B : ToInt64, C : ToInt64] DynamicArgs for (A, B, C)
+pub impl[A : ToInt64, B : ToInt64, C : ToInt64, D : ToInt64] DynamicArgs for (A, B, C, D)
+
+pub trait DynamicReturn {
+  from_int64_array(Array[Int64]) -> Self
+}
+pub impl DynamicReturn for Unit
+pub impl[A : FromInt64, B : FromInt64] DynamicReturn for (A, B)
+pub impl[A : FromInt64, B : FromInt64, C : FromInt64] DynamicReturn for (A, B, C)
+pub impl[A : FromInt64, B : FromInt64, C : FromInt64, D : FromInt64] DynamicReturn for (A, B, C, D)
+
+pub trait FromInt64 {
+  from_int64_bits(Int64) -> Self
+}
+pub impl FromInt64 for Int
+pub impl FromInt64 for Int64
+pub impl FromInt64 for Float
+pub impl FromInt64 for Double
+
 pub(open) trait JITArg {
   to_jit_arg(Self) -> Int64
 }
@@ -336,4 +373,12 @@ pub impl JITArg for Int
 pub impl JITArg for Int64
 pub impl JITArg for Float
 pub impl JITArg for Double
+
+pub trait ToInt64 {
+  to_int64_bits(Self) -> Int64
+}
+pub impl ToInt64 for Int
+pub impl ToInt64 for Int64
+pub impl ToInt64 for Float
+pub impl ToInt64 for Double
 

--- a/jit/polycall.mbt
+++ b/jit/polycall.mbt
@@ -1,7 +1,189 @@
-// pub fn JITModule::call_with_context(
-//   self : JITModule,
-//   func : JITFunction,
-//   args : Array[Int64],
-// ) -> Array[Int64] raise JITTrap
+///|
+pub suberror PolycallError {
+  InputNumber(Int, Int)
+  OutputNumber(Int, Int)
+  JIT(JITTrap)
+}
 
-// pub trait Dynamic
+///|
+impl Show for PolycallError with output(self, logger) {
+  let msg = match self {
+    OutputNumber(expected, got) =>
+      "output number error: expected \{expected}, got \{got}"
+    InputNumber(expected, got) =>
+      "input number error: expected \{expected}, got \{got}"
+    JIT(e) => e.to_string()
+  }
+  logger.write_string(msg)
+}
+
+///|
+pub(all) struct Single[A](A)
+
+///|
+pub trait ToInt64 {
+  to_int64_bits(Self) -> Int64
+}
+
+///|
+pub impl ToInt64 for Int64 with to_int64_bits(self) {
+  self
+}
+
+///|
+pub impl ToInt64 for Int with to_int64_bits(self) {
+  self.to_int64()
+}
+
+///|
+pub impl ToInt64 for Double with to_int64_bits(self) {
+  self.reinterpret_as_int64()
+}
+
+///|
+pub impl ToInt64 for Float with to_int64_bits(self) {
+  self.reinterpret_as_int().to_int64()
+}
+
+///|
+pub trait DynamicArgs {
+  to_int64_array(Self) -> Array[Int64]
+}
+
+///|
+pub impl DynamicArgs for Unit with to_int64_array(_self) {
+  []
+}
+
+///|
+pub impl[A : ToInt64] DynamicArgs for Single[A] with to_int64_array(self) {
+  [self.0.to_int64_bits()]
+}
+
+///|
+pub impl[A : ToInt64, B : ToInt64] DynamicArgs for (A, B) with to_int64_array(
+  self,
+) {
+  [ToInt64::to_int64_bits(self.0), ToInt64::to_int64_bits(self.1)]
+}
+
+///|
+pub impl[A : ToInt64, B : ToInt64, C : ToInt64] DynamicArgs for (A, B, C) with to_int64_array(
+  self,
+) {
+  [
+    ToInt64::to_int64_bits(self.0),
+    ToInt64::to_int64_bits(self.1),
+    ToInt64::to_int64_bits(self.2),
+  ]
+}
+
+///|
+pub impl[A : ToInt64, B : ToInt64, C : ToInt64, D : ToInt64] DynamicArgs for (
+  A,
+  B,
+  C,
+  D,
+) with to_int64_array(self) {
+  [
+    ToInt64::to_int64_bits(self.0),
+    ToInt64::to_int64_bits(self.1),
+    ToInt64::to_int64_bits(self.2),
+    ToInt64::to_int64_bits(self.3),
+  ]
+}
+
+///|
+pub trait FromInt64 {
+  from_int64_bits(Int64) -> Self
+}
+
+///|
+pub impl FromInt64 for Int64 with from_int64_bits(v) {
+  v
+}
+
+///|
+pub impl FromInt64 for Int with from_int64_bits(v) {
+  v.to_int()
+}
+
+///|
+pub impl FromInt64 for Double with from_int64_bits(v) {
+  v.reinterpret_as_double()
+}
+
+///|
+pub impl FromInt64 for Float with from_int64_bits(v) {
+  Float::from_double(v.reinterpret_as_double())
+}
+
+///|
+pub trait DynamicReturn {
+  from_int64_array(Array[Int64]) -> Self
+}
+
+///|
+pub impl DynamicReturn for Unit with from_int64_array(_arr) {
+  ()
+}
+
+///|
+pub impl[A : FromInt64] DynamicReturn for Single[A] with from_int64_array(arr) {
+  Single(arr[0] |> A::from_int64_bits())
+}
+
+///|
+pub impl[A : FromInt64, B : FromInt64] DynamicReturn for (A, B) with from_int64_array(
+  arr,
+) {
+  (FromInt64::from_int64_bits(arr[0]), FromInt64::from_int64_bits(arr[1]))
+}
+
+///|
+pub impl[A : FromInt64, B : FromInt64, C : FromInt64] DynamicReturn for (
+  A,
+  B,
+  C,
+) with from_int64_array(arr) {
+  (
+    FromInt64::from_int64_bits(arr[0]),
+    FromInt64::from_int64_bits(arr[1]),
+    FromInt64::from_int64_bits(arr[2]),
+  )
+}
+
+///|
+pub impl[A : FromInt64, B : FromInt64, C : FromInt64, D : FromInt64] DynamicReturn for (
+  A,
+  B,
+  C,
+  D,
+) with from_int64_array(arr) {
+  (
+    FromInt64::from_int64_bits(arr[0]),
+    FromInt64::from_int64_bits(arr[1]),
+    FromInt64::from_int64_bits(arr[2]),
+    FromInt64::from_int64_bits(arr[3]),
+  )
+}
+
+///|
+pub fn[Arg : DynamicArgs, Ret : DynamicReturn] JITModule::call_with_context_poly(
+  self : JITModule,
+  func : JITFunction,
+  args : Arg,
+) -> Ret raise PolycallError {
+  let args_array = DynamicArgs::to_int64_array(args)
+  if args_array.length() != func.num_params {
+    raise InputNumber(func.num_params, args_array.length())
+  }
+  let result_array = self.call_with_context(func, args_array) catch {
+    e => raise JIT(e)
+  }
+  let expected_results = func.result_types.length()
+  if result_array.length() != expected_results {
+    raise OutputNumber(expected_results, result_array.length())
+  }
+  DynamicReturn::from_int64_array(result_array)
+}

--- a/testsuite/br_test.mbt
+++ b/testsuite/br_test.mbt
@@ -14,7 +14,7 @@ test "br_simple" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "simple", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -30,7 +30,7 @@ test "br_dead_code" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "dead-code", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -44,7 +44,7 @@ test "br_as_block_first" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "as-block-first", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -58,7 +58,7 @@ test "br_type_i32" {
     #|  (func (export "type-i32") (block (drop (i32.ctz (br 0)))))
     #|)
   let result = compare_jit_interp(source, "type-i32", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -79,7 +79,7 @@ test "br_nested_block_value" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "nested-block-value", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -96,7 +96,7 @@ test "break_bare" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "break-bare", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -110,5 +110,5 @@ test "as_call_value" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "as-call-value", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }

--- a/testsuite/call_indirect_test.mbt
+++ b/testsuite/call_indirect_test.mbt
@@ -24,7 +24,7 @@ test "call_indirect_with_many_functions" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "test", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -41,7 +41,7 @@ test "call_indirect_simple" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "test", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -62,7 +62,7 @@ test "call_indirect_block_mid" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "test", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -83,5 +83,5 @@ test "call_indirect_block_last" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "test", [])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }

--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -11,6 +11,15 @@ struct CompareResult {
 }
 
 ///|
+pub impl Show for CompareResult with output(self, logger) {
+  if self.match_ {
+    logger.write_string("matched")
+  } else {
+    logger.write_string(self.to_string())
+  }
+}
+
+///|
 /// Convert JIT Int64 results to @types.Value using result_types
 fn jit_results_to_values(
   results : Array[Int64],

--- a/testsuite/f32_identity_test.mbt
+++ b/testsuite/f32_identity_test.mbt
@@ -14,7 +14,7 @@ test "f32 identity function" {
       #|Result: MATCH
     ),
   )
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -33,7 +33,7 @@ test "f32 add simple" {
       #|Result: MATCH
     ),
   )
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -52,5 +52,5 @@ test "f32 mul simple" {
       #|Result: MATCH
     ),
   )
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }

--- a/testsuite/f32_minmax_test.mbt
+++ b/testsuite/f32_minmax_test.mbt
@@ -8,7 +8,7 @@ test "f32_min_basic" {
     #|)
   // min(1.0, 2.0) should return 1.0
   let result = compare_jit_interp(source, "min", [F32(1.0), F32(2.0)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -21,7 +21,7 @@ test "f32_max_basic" {
     #|)
   // max(1.0, 2.0) should return 2.0
   let result = compare_jit_interp(source, "max", [F32(1.0), F32(2.0)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -34,7 +34,7 @@ test "f32_min_negative" {
     #|)
   // min(-1.0, 1.0) should return -1.0
   let result = compare_jit_interp(source, "min", [F32(-1.0), F32(1.0)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -47,7 +47,7 @@ test "f32_max_negative" {
     #|)
   // max(-1.0, 1.0) should return 1.0
   let result = compare_jit_interp(source, "max", [F32(-1.0), F32(1.0)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -60,7 +60,7 @@ test "f64_min_basic" {
     #|)
   // min(1.0, 2.0) should return 1.0
   let result = compare_jit_interp(source, "min", [F64(1.0), F64(2.0)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -73,5 +73,5 @@ test "f64_max_basic" {
     #|)
   // max(1.0, 2.0) should return 2.0
   let result = compare_jit_interp(source, "max", [F64(1.0), F64(2.0)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }

--- a/testsuite/f32_test.mbt
+++ b/testsuite/f32_test.mbt
@@ -84,13 +84,11 @@ test "f32 add" {
   guard func is Some(f) else { return }
   // Pass Float values (f32) since the WASM function takes f32 parameter
   // JITArg for Float reinterprets the f32 bit pattern and passes it correctly
-  let result0 = jm.call_with_context(f, [
-    (0.0 : Float).reinterpret_as_int().to_int64(),
-  ])
-  inspect(
-    @types.Value::F32(Float::from_double(result0[0].reinterpret_as_double())),
-    content="F32(15.5)",
+  let @jit.Single((result0 : Float)) = jm.call_with_context_poly(
+    f,
+    @jit.Single((0.0 : Float)),
   )
+  inspect(result0, content="15.5")
   let result1 = jm.call_with_context(f, [
     (1.0 : Float).reinterpret_as_int().to_int64(),
   ])

--- a/testsuite/fac_test.mbt
+++ b/testsuite/fac_test.mbt
@@ -24,7 +24,7 @@ test "fac_iter" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "fac-iter", [I64(5)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -42,7 +42,7 @@ test "fac_rec" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "fac-rec", [I64(5)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -68,7 +68,7 @@ test "fac_ssa" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "fac-ssa", [I64(5)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -86,7 +86,7 @@ test "fac_rec_named" {
     #|  )
     #|)
   let result = compare_jit_interp(source, "fac-rec-named", [I64(5)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -113,7 +113,7 @@ test "fac_iter_named" {
     #|  (local.get $res)
     #|)
   let result = compare_jit_interp(source, "fac-iter-named", [I64(5)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -133,5 +133,5 @@ test "fac_opt" {
     #|  (local.get 1)
     #|)
   let result = compare_jit_interp(source, "fac-opt", [I64(5)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }

--- a/testsuite/float_exprs_test.mbt
+++ b/testsuite/float_exprs_test.mbt
@@ -25,7 +25,7 @@ test "f32_no_fma" {
     ),
   )
   // S register f32 operations now implemented
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -45,7 +45,7 @@ test "f32_no_reassociate_mul" {
     F32(0x1.f04508p-56),
   ])
   // S register f32 operations now implemented
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -58,7 +58,7 @@ test "i32_no_fold_f32_s" {
     #|    (i32.trunc_f32_s (f32.convert_i32_s (local.get $x))))
     #|)
   let result = compare_jit_interp(source, "i32.no_fold_f32_s", [I32(16777216)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -71,7 +71,7 @@ test "i32_no_fold_f32_u" {
     #|    (i32.trunc_f32_u (f32.convert_i32_s (local.get $x))))
     #|)
   let result = compare_jit_interp(source, "i32.no_fold_f32_u", [I32(16777216)])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -86,7 +86,7 @@ test "i64_no_fold_f64_s" {
   let result = compare_jit_interp(source, "i64.no_fold_f64_s", [
     I64(9007199254740992L),
   ])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -101,7 +101,7 @@ test "f32_i32_no_fold_trunc_s_convert_s" {
   let result = compare_jit_interp(source, "f32.i32.no_fold_trunc_s_convert_s", [
     F32(1.5),
   ])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -116,7 +116,7 @@ test "f64_i32_no_fold_trunc_s_convert_s" {
   let result = compare_jit_interp(source, "f64.i32.no_fold_trunc_s_convert_s", [
     F64(1.5),
   ])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }
 
 ///|
@@ -131,5 +131,5 @@ test "no_fold_demote_promote" {
   let result = compare_jit_interp(source, "no_fold_demote_promote", [
     F64(-1.7176275796615013e-40),
   ])
-  inspect(result.matched(), content="true")
+  inspect(result, content="matched")
 }

--- a/testsuite/i32_mul_test.mbt
+++ b/testsuite/i32_mul_test.mbt
@@ -103,12 +103,21 @@ test "i32 mul" {
   let func = jm.get_func_by_name("test")
   guard func is Some(f) else { return }
   // 4 * 3 = 12
-  let result0 = jm.call_with_context(f, [4L])
-  inspect(result0[0], content="12")
+  let @jit.Single((result0 : Int)) = jm.call_with_context_poly(
+    f,
+    @jit.Single(4),
+  )
+  inspect(result0, content="12")
   // 7 * 3 = 21
-  let result1 = jm.call_with_context(f, [7L])
-  inspect(result1[0], content="21")
+  let @jit.Single((result1 : Int)) = jm.call_with_context_poly(
+    f,
+    @jit.Single(7),
+  )
+  inspect(result1, content="21")
   // 0 * 3 = 0
-  let result2 = jm.call_with_context(f, [0L])
-  inspect(result2[0], content="0")
+  let @jit.Single((result2 : Int)) = jm.call_with_context_poly(
+    f,
+    @jit.Single(0),
+  )
+  inspect(result2, content="0")
 }

--- a/testsuite/multi_return_test.mbt
+++ b/testsuite/multi_return_test.mbt
@@ -45,10 +45,13 @@ test "multi return: 3 integers" {
   defer jm.free()
   let func = jm.get_func_by_name("test")
   guard func is Some(f) else { return }
-  let result = jm.call_with_context(f, [10L])
-  inspect(result[0], content="10")
-  inspect(result[1], content="11")
-  inspect(result[2], content="12")
+  let (r0, r1, r2) : (Int, Int, Int) = jm.call_with_context_poly(
+    f,
+    @jit.Single(10),
+  )
+  inspect(r0, content="10")
+  inspect(r1, content="11")
+  inspect(r2, content="12")
 }
 
 ///|
@@ -106,11 +109,14 @@ test "multi return: 4 integers" {
   defer jm.free()
   let func = jm.get_func_by_name("test")
   guard func is Some(f) else { return }
-  let result = jm.call_with_context(f, [100L])
-  inspect(result[0], content="100")
-  inspect(result[1], content="110")
-  inspect(result[2], content="120")
-  inspect(result[3], content="130")
+  let (r0, r1, r2, r3) : (Int, Int, Int, Int) = jm.call_with_context_poly(
+    f,
+    @jit.Single(100),
+  )
+  inspect(r0, content="100")
+  inspect(r1, content="110")
+  inspect(r2, content="120")
+  inspect(r3, content="130")
 }
 
 ///|
@@ -156,10 +162,10 @@ test "multi return: 3 floats" {
   defer jm.free()
   let func = jm.get_func_by_name("test")
   guard func is Some(f) else { return }
-  let result = jm.call_with_context(f, [])
-  inspect(result[0].reinterpret_as_double(), content="1.5")
-  inspect(result[1].reinterpret_as_double(), content="2.5")
-  inspect(result[2].reinterpret_as_double(), content="3.5")
+  let (r0, r1, r2) : (Double, Double, Double) = jm.call_with_context_poly(f, ())
+  inspect(r0, content="1.5")
+  inspect(r1, content="2.5")
+  inspect(r2, content="3.5")
 }
 
 ///|
@@ -215,11 +221,14 @@ test "multi return: mixed int and float" {
   defer jm.free()
   let func = jm.get_func_by_name("test")
   guard func is Some(f) else { return }
-  let result = jm.call_with_context(f, [5L])
-  inspect(result[0], content="5")
-  inspect(result[1], content="15")
-  inspect(result[2], content="25")
-  inspect(result[3].reinterpret_as_double(), content="3.14")
+  let (r0, r1, r2, r3) : (Int, Int, Int, Double) = jm.call_with_context_poly(
+    f,
+    @jit.Single(5),
+  )
+  inspect(r0, content="5")
+  inspect(r1, content="15")
+  inspect(r2, content="25")
+  inspect(r3, content="3.14")
 }
 
 ///|
@@ -264,7 +273,7 @@ test "multi return: 2 integers (no extra buffer)" {
   defer jm.free()
   let func = jm.get_func_by_name("test")
   guard func is Some(f) else { return }
-  let result = jm.call_with_context(f, [])
-  inspect(result[0], content="42")
-  inspect(result[1], content="99")
+  let (r0, r1) : (Int, Int) = jm.call_with_context_poly(f, ())
+  inspect(r0, content="42")
+  inspect(r1, content="99")
 }

--- a/testsuite/pkg.generated.mbti
+++ b/testsuite/pkg.generated.mbti
@@ -37,6 +37,7 @@ pub impl Show for TestRunnerError
 type CompareResult
 pub fn CompareResult::matched(Self) -> Bool
 pub fn CompareResult::to_string(Self) -> String
+pub impl Show for CompareResult
 
 pub(all) struct JsonValue {
   type_ : String


### PR DESCRIPTION
## Summary
- Add `call_with_context_poly` for type-safe JIT function calls with automatic argument/return conversion
- Add `PolycallError` for input/output count validation
- Add `ToInt64`, `FromInt64` traits for type conversion
- Add `DynamicArgs`, `DynamicReturn` traits for tuple support (2-4 elements)
- Add `Single[A]` wrapper for single-value args/returns
- Implement `Show` for `CompareResult` (shows "matched" when equal)
- Update various tests to use new poly call interface

## Test plan
- [x] All existing tests pass with `moon test`
- [x] Type checking passes with `moon check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)