### PR TITLE
fix(vcode): simplify call_indirect dump output

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -596,4 +596,4 @@ _请在此处继续添加新的意见和建议_
 - [x] CLI 的诸多命令描述有误，比如现在的 test 命令和 wast 命令实际上是一回事，而且都和 json 无关。`debug` 等参数应该有 choices 参数。在 `.mooncakes/TheWaWaR/clap/src/clap.mbti` 中查看 named 函数的声明。 → 已修复：更新 test 命令描述为 "Run WebAssembly test script (.wast format)"，为 debug 和 config action 参数添加 choices
 - [x] Sign/Zero Extension Instructions、br、adr 也需要添加到 "all emit functions disasm" 中
 - [ ] `pub fn` 过多了
-- [ ] call_indirect 在 vcode 的 dump 中会打印很长一个东西，比如 `f9 = call_indirect(8) -> 1 results v8, f0, f1, f2, f3, f4, f5, f6, f7`
+- [x] call_indirect 在 vcode 的 dump 中会打印很长一个东西，比如 `f9 = call_indirect(8) -> 1 results v8, f0, f1, f2, f3, f4, f5, f6, f7` → 已简化：只打印函数指针（第一个 use），不打印所有参数；只打印结果寄存器，不打印 clobber 寄存器

--- a/vcode/regalloc_wbtest.mbt
+++ b/vcode/regalloc_wbtest.mbt
@@ -1480,7 +1480,7 @@ test "regalloc: CallIndirect with 8 f64 arguments" {
       #|    f6 = ldf 7
       #|    f7 = ldf 8
       #|    v8 = ldi 4096
-      #|    f9 = call_indirect(8) -> 1 results v8, f0, f1, f2, f3, f4, f5, f6, f7
+      #|    f9 = call_indirect(8) -> 1 results v8
       #|    ret f9
       #|}
       #|
@@ -1513,7 +1513,7 @@ test "regalloc: CallIndirect with 8 f64 arguments" {
       #|    d6 = ldf 7
       #|    d7 = ldf 8
       #|    x8 = ldi 4096
-      #|    d8 = call_indirect(8) -> 1 results x8, d0, d1, d2, d3, d4, d5, d6, d7
+      #|    d8 = call_indirect(8) -> 1 results x8
       #|    ret d8
       #|}
       #|
@@ -1574,7 +1574,7 @@ test "regalloc: f32 value live across CallIndirect" {
       #|    f0 = ldf 42
       #|    f1 = ldf 3.14
       #|    v2 = ldi 8192
-      #|    f3 = call_indirect(1) -> 1 results v2, f1
+      #|    f3 = call_indirect(1) -> 1 results v2
       #|    ret f0, f3
       #|}
       #|
@@ -1603,7 +1603,7 @@ test "regalloc: f32 value live across CallIndirect" {
       #|    d8 = ldf 42
       #|    d0 = ldf 3.14
       #|    x8 = ldi 8192
-      #|    d9 = call_indirect(1) -> 1 results x8, d0
+      #|    d9 = call_indirect(1) -> 1 results x8
       #|    ret d8, d9
       #|}
       #|

--- a/vcode/vcode.mbt
+++ b/vcode/vcode.mbt
@@ -239,9 +239,15 @@ pub fn VCodeInst::add_use(self : VCodeInst, reg : Reg) -> Unit {
 ///|
 fn VCodeInst::to_string(self : VCodeInst) -> String {
   let mut result = ""
-  // Print definitions
-  if self.defs.length() > 0 {
-    for i, def in self.defs {
+  // Print definitions (skip clobbers for CallIndirect)
+  let defs_to_print = match self.opcode {
+    CallIndirect(_, num_results) =>
+      // Only print result registers, not clobbers
+      self.defs.iter().take(num_results).collect()
+    _ => self.defs
+  }
+  if defs_to_print.length() > 0 {
+    for i, def in defs_to_print {
       if i > 0 {
         result = result + ", "
       }
@@ -251,15 +257,23 @@ fn VCodeInst::to_string(self : VCodeInst) -> String {
   }
   // Print opcode
   result = result + self.opcode.to_string()
-  // Print uses
-  if self.uses.length() > 0 {
-    result = result + " "
-    for i, use_ in self.uses {
-      if i > 0 {
-        result = result + ", "
+  // Print uses (simplified for CallIndirect)
+  match self.opcode {
+    CallIndirect(_, _) =>
+      // For call_indirect, only print the function pointer (first use)
+      if self.uses.length() > 0 {
+        result = result + " " + self.uses[0].to_string()
       }
-      result = result + use_.to_string()
-    }
+    _ =>
+      if self.uses.length() > 0 {
+        result = result + " "
+        for i, use_ in self.uses {
+          if i > 0 {
+            result = result + ", "
+          }
+          result = result + use_.to_string()
+        }
+      }
   }
   result
 }


### PR DESCRIPTION
## Summary

- Simplified `CallIndirect` instruction dump output in VCode
- Only print result registers (skip clobbers) 
- Only print function pointer (skip all argument registers)

**Before:**
```
f9 = call_indirect(8) -> 1 results v8, f0, f1, f2, f3, f4, f5, f6, f7
```

**After:**
```
f9 = call_indirect(8) -> 1 results v8
```

The opcode already contains `num_args` info, so printing all arguments is redundant.

## Test plan

- [x] All 173 vcode tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)