### PR TITLE
feat(jit): implement call_indirect type checking

### DIFF
--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -1454,6 +1454,8 @@ fn Translator::translate_call_indirect(
 ) -> Unit {
   if type_idx < self.func_types.length() {
     let func_type = self.func_types[type_idx]
+    // Compute structural type hash for type checking at runtime
+    let type_hash = func_type.structural_hash()
     // Pop callee (function reference)
     let callee = self.pop()
     // Pop arguments
@@ -1464,9 +1466,9 @@ fn Translator::translate_call_indirect(
     args.rev_in_place()
     // Get result types
     let result_types : Array[Type] = func_type.results.map(Type::from_wasm)
-    // Emit call_indirect with multi-value support
+    // Emit call_indirect with type hash (not type index) for structural equivalence
     let results = self.builder.call_indirect_multi(
-      type_idx, result_types, callee, args,
+      type_hash, result_types, callee, args,
     )
     // Push all results onto the stack
     for v in results {

--- a/jit/ffi_jit.mbt
+++ b/jit/ffi_jit.mbt
@@ -145,13 +145,19 @@ fn JITContext::alloc_indirect_table(self : JITContext, count : Int) -> Bool {
 }
 
 ///|
-/// Set an entry in indirect table (maps table_idx to func_idx)
+/// Set an entry in indirect table (maps table_idx to func_idx with type_idx for type checking)
 fn JITContext::set_indirect(
   self : JITContext,
   table_idx : Int,
   func_idx : Int,
+  type_idx : Int,
 ) -> Unit {
-  @jit_ffi.c_jit_ctx_v2_set_indirect(self.ctx_ptr, table_idx, func_idx)
+  @jit_ffi.c_jit_ctx_v2_set_indirect(
+    self.ctx_ptr,
+    table_idx,
+    func_idx,
+    type_idx,
+  )
 }
 
 ///|

--- a/jit/jit_ffi/ffi.mbt
+++ b/jit/jit_ffi/ffi.mbt
@@ -113,10 +113,12 @@ pub extern "c" fn c_jit_ctx_alloc_indirect_table(
 
 ///|
 /// Set an entry in indirect table (table_idx -> func_table[func_idx])
+/// type_idx: the type index of the function (for type checking)
 pub extern "c" fn c_jit_ctx_set_indirect(
   ctx_ptr : Int64,
   table_idx : Int,
   func_idx : Int,
+  type_idx : Int,
 ) -> Unit = "wasmoon_jit_ctx_set_indirect"
 
 ///|
@@ -164,10 +166,12 @@ pub extern "c" fn c_jit_ctx_v2_alloc_indirect_table(
 
 ///|
 /// Set an entry in indirect table v2 (table_idx -> func_table[func_idx])
+/// type_idx: the type index of the function (for type checking)
 pub extern "c" fn c_jit_ctx_v2_set_indirect(
   ctx_ptr : Int64,
   table_idx : Int,
   func_idx : Int,
+  type_idx : Int,
 ) -> Unit = "wasmoon_jit_ctx_v2_set_indirect"
 
 ///|

--- a/jit/jit_ffi/pkg.generated.mbti
+++ b/jit/jit_ffi/pkg.generated.mbti
@@ -26,7 +26,7 @@ pub fn c_jit_ctx_get_memory(Int64) -> Int64
 
 pub fn c_jit_ctx_set_func(Int64, Int, Int64) -> Unit
 
-pub fn c_jit_ctx_set_indirect(Int64, Int, Int) -> Unit
+pub fn c_jit_ctx_set_indirect(Int64, Int, Int, Int) -> Unit
 
 pub fn c_jit_ctx_set_memory(Int64, Int64, Int64) -> Unit
 
@@ -36,7 +36,7 @@ pub fn c_jit_ctx_v2_get_func_table(Int64) -> Int64
 
 pub fn c_jit_ctx_v2_set_func(Int64, Int, Int64) -> Unit
 
-pub fn c_jit_ctx_v2_set_indirect(Int64, Int, Int) -> Unit
+pub fn c_jit_ctx_v2_set_indirect(Int64, Int, Int, Int) -> Unit
 
 pub fn c_jit_ctx_v2_set_memory(Int64, Int64, Int64) -> Unit
 

--- a/jit/jit_runtime.mbt
+++ b/jit/jit_runtime.mbt
@@ -301,18 +301,18 @@ pub fn JITModule::set_memory(
 ///|
 /// Initialize indirect table for call_indirect.
 /// table_size: number of table elements
-/// elem_init: array of (table_idx, func_idx) pairs
+/// elem_init: array of (table_idx, func_idx, type_idx) triples
 pub fn JITModule::init_indirect_table(
   self : JITModule,
   table_size : Int,
-  elem_init : Array[(Int, Int)],
+  elem_init : Array[(Int, Int, Int)],
 ) -> Unit {
   match self.context {
     Some(ctx) =>
       if ctx.alloc_indirect_table(table_size) {
         for entry in elem_init {
-          let (table_idx, func_idx) = entry
-          ctx.set_indirect(table_idx, func_idx)
+          let (table_idx, func_idx, type_idx) = entry
+          ctx.set_indirect(table_idx, func_idx, type_idx)
         }
       }
     None => ()

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -273,7 +273,7 @@ pub fn JITModule::free(Self) -> Unit
 pub fn JITModule::from_single_function(Array[Int], String, Array[@types.ValueType], Array[@types.ValueType], Int64) -> Self?
 pub fn JITModule::get_func(Self, Int) -> JITFunction?
 pub fn JITModule::get_func_by_name(Self, String) -> JITFunction?
-pub fn JITModule::init_indirect_table(Self, Int, Array[(Int, Int)]) -> Unit
+pub fn JITModule::init_indirect_table(Self, Int, Array[(Int, Int, Int)]) -> Unit
 pub fn JITModule::load(@cwasm.PrecompiledModule, Array[(Array[@types.ValueType], Array[@types.ValueType])]) -> Self?
 pub fn JITModule::new() -> Self
 pub fn JITModule::set_memory(Self, Int64, Int64) -> Unit

--- a/main/wast.mbt
+++ b/main/wast.mbt
@@ -316,8 +316,31 @@ fn init_elem_segments(mod_ : @types.Module, jm : @jit.JITModule) -> Unit {
   if table_size == 0 {
     return // No tables, nothing to do
   }
-  // Collect elem initializers: (table_idx, func_idx)
-  let elem_init : Array[(Int, Int)] = []
+  // Build function index to type hash mapping
+  // We use structural type hash for type equivalence checking
+  let func_type_hashes : Array[Int] = []
+  // Import functions
+  for imp in mod_.imports {
+    if imp.desc is Func(type_idx) {
+      let type_hash = if type_idx < mod_.types.length() {
+        mod_.types[type_idx].structural_hash()
+      } else {
+        0
+      }
+      func_type_hashes.push(type_hash)
+    }
+  }
+  // Local functions
+  for type_idx in mod_.funcs {
+    let type_hash = if type_idx < mod_.types.length() {
+      mod_.types[type_idx].structural_hash()
+    } else {
+      0
+    }
+    func_type_hashes.push(type_hash)
+  }
+  // Collect elem initializers: (table_idx, func_idx, type_hash)
+  let elem_init : Array[(Int, Int, Int)] = []
   for elem in mod_.elems {
     // Only process active element segments
     if elem.mode is @types.ElemMode::Active(_table_idx, offset_expr) {
@@ -332,7 +355,13 @@ fn init_elem_segments(mod_ : @types.Module, jm : @jit.JITModule) -> Unit {
           [I32Const(idx)] => idx
           _ => continue
         }
-        elem_init.push((offset + i, func_idx))
+        // Get the type hash for this function
+        let type_hash = if func_idx < func_type_hashes.length() {
+          func_type_hashes[func_idx]
+        } else {
+          0
+        }
+        elem_init.push((offset + i, func_idx, type_hash))
       }
     }
   }

--- a/testsuite/call_indirect_float_test.mbt
+++ b/testsuite/call_indirect_float_test.mbt
@@ -1,0 +1,101 @@
+///|
+/// Tests for call_indirect with float parameters
+/// These test cases expose a bug where float parameters assigned to callee-saved
+/// FPRs (D8-D15) are not properly saved/restored across nested calls.
+
+///|
+test "call_indirect fac-f32 with recursion" {
+  // This test fails because the float parameter (in D8) is not saved
+  // across the recursive call, causing it to be overwritten.
+  let source =
+    #|(module
+    #|  (type $over-f32 (func (param f32) (result f32)))
+    #|
+    #|  (func $fac-f32 (export "fac-f32") (type $over-f32)
+    #|    (if (result f32) (f32.eq (local.get 0) (f32.const 0.0))
+    #|      (then (f32.const 1.0))
+    #|      (else
+    #|        (f32.mul
+    #|          (local.get 0)
+    #|          (call_indirect (type $over-f32)
+    #|            (f32.sub (local.get 0) (f32.const 1.0))
+    #|            (i32.const 0)
+    #|          )
+    #|        )
+    #|      )
+    #|    )
+    #|  )
+    #|
+    #|  (table funcref (elem $fac-f32))
+    #|)
+  // fac-f32(0.0) = 1.0 (base case, no recursion)
+  let result0 = compare_jit_interp(source, "fac-f32", [F32(0.0)])
+  inspect(result0, content="matched")
+  // fac-f32(1.0) = 1.0 * fac-f32(0.0) = 1.0 * 1.0 = 1.0
+  // This fails: returns 0.0 instead of 1.0
+  // The bug: D8 (holding 1.0) is overwritten by recursive call
+  let result1 = compare_jit_interp(source, "fac-f32", [F32(1.0)])
+  inspect(result1, content="matched")
+  // fac-f32(5.0) = 5.0 * 4.0 * 3.0 * 2.0 * 1.0 * 1.0 = 120.0
+  let result5 = compare_jit_interp(source, "fac-f32", [F32(5.0)])
+  inspect(result5, content="matched")
+}
+
+///|
+test "call_indirect fac-f64 with recursion" {
+  // Same issue with f64 parameters
+  let source =
+    #|(module
+    #|  (type $over-f64 (func (param f64) (result f64)))
+    #|
+    #|  (func $fac-f64 (export "fac-f64") (type $over-f64)
+    #|    (if (result f64) (f64.eq (local.get 0) (f64.const 0.0))
+    #|      (then (f64.const 1.0))
+    #|      (else
+    #|        (f64.mul
+    #|          (local.get 0)
+    #|          (call_indirect (type $over-f64)
+    #|            (f64.sub (local.get 0) (f64.const 1.0))
+    #|            (i32.const 0)
+    #|          )
+    #|        )
+    #|      )
+    #|    )
+    #|  )
+    #|
+    #|  (table funcref (elem $fac-f64))
+    #|)
+  let result0 = compare_jit_interp(source, "fac-f64", [F64(0.0)])
+  inspect(result0, content="matched")
+  let result1 = compare_jit_interp(source, "fac-f64", [F64(1.0)])
+  inspect(result1, content="matched")
+  let result5 = compare_jit_interp(source, "fac-f64", [F64(5.0)])
+  inspect(result5, content="matched")
+}
+
+///|
+test "direct call fac-f32 with recursion" {
+  // Same bug happens with direct call, not just call_indirect
+  let source =
+    #|(module
+    #|  (func $fac-f32 (export "fac-f32") (param f32) (result f32)
+    #|    (if (result f32) (f32.eq (local.get 0) (f32.const 0.0))
+    #|      (then (f32.const 1.0))
+    #|      (else
+    #|        (f32.mul
+    #|          (local.get 0)
+    #|          (call $fac-f32
+    #|            (f32.sub (local.get 0) (f32.const 1.0))
+    #|          )
+    #|        )
+    #|      )
+    #|    )
+    #|  )
+    #|)
+  let result0 = compare_jit_interp(source, "fac-f32", [F32(0.0)])
+  inspect(result0, content="matched")
+  let result1 = compare_jit_interp(source, "fac-f32", [F32(1.0)])
+  inspect(result1, content="matched")
+  let result5 = compare_jit_interp(source, "fac-f32", [F32(5.0)])
+  inspect(result5, content="matched")
+}

--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -343,8 +343,31 @@ fn init_elem_segments(mod_ : @types.Module, jm : @jit.JITModule) -> Unit {
   if table_size == 0 {
     return // No tables, nothing to do
   }
-  // Collect elem initializers: (table_idx, func_idx)
-  let elem_init : Array[(Int, Int)] = []
+  // Build function index to type hash mapping
+  // We use structural type hash for type equivalence checking
+  let func_type_hashes : Array[Int] = []
+  // Import functions
+  for imp in mod_.imports {
+    if imp.desc is Func(type_idx) {
+      let type_hash = if type_idx < mod_.types.length() {
+        mod_.types[type_idx].structural_hash()
+      } else {
+        0
+      }
+      func_type_hashes.push(type_hash)
+    }
+  }
+  // Local functions
+  for type_idx in mod_.funcs {
+    let type_hash = if type_idx < mod_.types.length() {
+      mod_.types[type_idx].structural_hash()
+    } else {
+      0
+    }
+    func_type_hashes.push(type_hash)
+  }
+  // Collect elem initializers: (table_idx, func_idx, type_hash)
+  let elem_init : Array[(Int, Int, Int)] = []
   for elem in mod_.elems {
     // Only process active element segments
     if elem.mode is @types.ElemMode::Active(_table_idx, offset_expr) {
@@ -359,7 +382,13 @@ fn init_elem_segments(mod_ : @types.Module, jm : @jit.JITModule) -> Unit {
           [I32Const(idx)] => idx
           _ => continue
         }
-        elem_init.push((offset + i, func_idx))
+        // Get the type hash for this function
+        let type_hash = if func_idx < func_type_hashes.length() {
+          func_type_hashes[func_idx]
+        } else {
+          0
+        }
+        elem_init.push((offset + i, func_idx, type_hash))
       }
     }
   }

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -60,6 +60,7 @@ pub(all) struct FuncType {
   params : Array[ValueType]
   results : Array[ValueType]
 }
+pub fn FuncType::structural_hash(Self) -> Int
 pub impl Eq for FuncType
 pub impl Show for FuncType
 

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -293,6 +293,47 @@ pub(all) struct FuncType {
 } derive(Eq, Show)
 
 ///|
+/// Compute a hash for structural type equivalence.
+/// Two FuncTypes with the same params and results will have the same hash.
+pub fn FuncType::structural_hash(self : FuncType) -> Int {
+  let mut h = 0
+  // Encode params
+  for param in self.params {
+    h = h * 31 + param.type_code()
+  }
+  // Separator between params and results
+  h = h * 31 + 0xFF
+  // Encode results
+  for result in self.results {
+    h = h * 31 + result.type_code()
+  }
+  // Ensure non-negative
+  if h < 0 {
+    -h
+  } else {
+    h
+  }
+}
+
+///|
+/// Get a numeric code for a value type (for hashing)
+fn ValueType::type_code(self : ValueType) -> Int {
+  match self {
+    I32 => 0
+    I64 => 1
+    F32 => 2
+    F64 => 3
+    V128 => 4
+    FuncRef => 5
+    ExternRef => 6
+    RefFunc => 7
+    RefExtern => 8
+    RefFuncTyped(idx) => 100 + idx
+    RefNullFuncTyped(idx) => 200 + idx
+  }
+}
+
+///|
 /// Limits for memory and tables
 pub(all) struct Limits {
   min : Int

--- a/vcode/disasm_wbtest.mbt
+++ b/vcode/disasm_wbtest.mbt
@@ -521,3 +521,122 @@ test "emit_str_reg_scaled" {
     ),
   )
 }
+
+///|
+test "emit_b_cond_offset" {
+  let mc = MachineCode::new()
+  // B.EQ +8 (skip 2 instructions)
+  emit_b_cond_offset(mc, 0, 8)
+  // B.NE +12 (skip 3 instructions)
+  emit_b_cond_offset(mc, 1, 12)
+  // B.LT +4 (skip 1 instruction)
+  emit_b_cond_offset(mc, 11, 4)
+  mc.resolve_fixups()
+  inspect(
+    mc.dump_disasm(),
+    content=(
+      #|  0000: 40000054  b.eq .+8
+      #|  0004: 61000054  b.ne .+12
+      #|  0008: 2b000054  b.lt .+4
+      #|
+    ),
+  )
+}
+
+///|
+test "emit_brk" {
+  let mc = MachineCode::new()
+  // BRK #0
+  emit_brk(mc, 0)
+  // BRK #2 (type mismatch trap)
+  emit_brk(mc, 2)
+  // BRK #1 (general trap)
+  emit_brk(mc, 1)
+  mc.resolve_fixups()
+  inspect(
+    mc.dump_disasm(),
+    content=(
+      #|  0000: 000020d4  brk #0
+      #|  0004: 400020d4  brk #2
+      #|  0008: 200020d4  brk #1
+      #|
+    ),
+  )
+}
+
+///|
+/// Test type check with small immediate (<=4095) - uses CMP immediate
+test "type_check_small_immediate" {
+  let mc = MachineCode::new()
+  // Simulate TypeCheckIndirect with expected_type = 100 (small, fits in 12 bits)
+  let expected_type = 100
+  let actual_type_reg = 9 // x9
+  // This path should use CMP immediate
+  emit_cmp_imm(mc, actual_type_reg, expected_type)
+  emit_b_cond_offset(mc, 0, 8) // B.EQ +8
+  emit_brk(mc, 2)
+  mc.resolve_fixups()
+  inspect(
+    mc.dump_disasm(),
+    content=(
+      #|  0000: 3f9101f1  cmp x9, #100
+      #|  0004: 40000054  b.eq .+8
+      #|  0008: 400020d4  brk #2
+      #|
+    ),
+  )
+}
+
+///|
+/// Test type check with large immediate (>4095) - uses load + CMP register
+test "type_check_large_immediate" {
+  let mc = MachineCode::new()
+  // Simulate TypeCheckIndirect with expected_type = 7905 (0x1EE1, > 4095)
+  let expected_type = 7905
+  let actual_type_reg = 9 // x9
+  // This path should load into x17 first, then use CMP register
+  emit_load_imm64(mc, 17, expected_type.to_int64())
+  emit_cmp_reg(mc, actual_type_reg, 17)
+  emit_b_cond_offset(mc, 0, 8) // B.EQ +8
+  emit_brk(mc, 2)
+  mc.resolve_fixups()
+  inspect(
+    mc.dump_disasm(),
+    content=(
+      #|  0000: 31dc83d2  movz x17, #7905, lsl #0
+      #|  0004: 3f0111eb  cmp x9, x17
+      #|  0008: 40000054  b.eq .+8
+      #|  000c: 400020d4  brk #2
+      #|
+    ),
+  )
+}
+
+///|
+/// Test that CMP immediate truncates values > 4095 (this is the bug we fixed)
+/// This test documents the limitation of emit_cmp_imm
+test "cmp_imm_truncates_large_values" {
+  let mc = MachineCode::new()
+  // 7905 = 0x1EE1, masked to 12 bits = 0xEE1 = 3809
+  // This shows the WRONG behavior if we use CMP immediate for large values
+  emit_cmp_imm(mc, 9, 7905) // Will compare against 3809, not 7905!
+  mc.resolve_fixups()
+  // Note: The annotation says 7905 but the actual immediate is 3809 (0xEE1)
+  // This is why we must use load+cmp_reg for values > 4095
+  inspect(
+    mc.dump_disasm(),
+    content=(
+      #|  0000: 3f853bf1  cmp x9, #7905
+      #|
+    ),
+  )
+  // Verify the actual encoded immediate by checking the instruction bytes
+  // Bits [21:10] contain imm12. Let's decode 0xf13b853f:
+  // The instruction encodes imm12 = 0xEE1 = 3809, not 7905
+  let inst = mc.bytes[0] |
+    (mc.bytes[1] << 8) |
+    (mc.bytes[2] << 16) |
+    (mc.bytes[3] << 24)
+  let encoded_imm12 = (inst >> 10) & 0xFFF
+  inspect(encoded_imm12, content="3809") // This proves truncation happened!
+}

--- a/vcode/emit.mbt
+++ b/vcode/emit.mbt
@@ -1575,6 +1575,49 @@ pub fn emit_cbnz(mc : MachineCode, rt : Int, target_block : Int) -> Unit {
 }
 
 ///|
+/// Encode B.cond with a fixed byte offset (no fixup needed)
+/// Used for short forward branches like skipping a trap instruction
+/// offset_bytes must be a multiple of 4
+fn emit_b_cond_offset(mc : MachineCode, cond : Int, offset_bytes : Int) -> Unit {
+  let cond_name = match cond {
+    0 => "eq"
+    1 => "ne"
+    2 => "hs"
+    3 => "lo"
+    10 => "ge"
+    11 => "lt"
+    12 => "gt"
+    13 => "le"
+    _ => "?\{cond}"
+  }
+  mc.annotate("b.\{cond_name} .+\{offset_bytes}")
+  let imm19 = offset_bytes / 4 // Convert bytes to instruction count
+  // B.cond encoding: 0x54000000 | (imm19 << 5) | cond
+  let inst = 0x54000000 | ((imm19 & 0x7FFFF) << 5) | (cond & 0xF)
+  mc.emit_inst(
+    inst & 0xFF,
+    (inst >> 8) & 0xFF,
+    (inst >> 16) & 0xFF,
+    (inst >> 24) & 0xFF,
+  )
+}
+
+///|
+/// Encode BRK: BRK #imm16
+/// Used for trap/breakpoint instructions
+fn emit_brk(mc : MachineCode, imm16 : Int) -> Unit {
+  mc.annotate("brk #\{imm16}")
+  // BRK encoding: 0xD4200000 | (imm16 << 5)
+  let inst = 0xD4200000 | ((imm16 & 0xFFFF) << 5)
+  mc.emit_inst(
+    inst & 0xFF,
+    (inst >> 8) & 0xFF,
+    (inst >> 16) & 0xFF,
+    (inst >> 24) & 0xFF,
+  )
+}
+
+///|
 /// Encode RET: RET Xn
 /// Opcode: 0xD65F0000 (with Rn in bits [9:5])
 pub fn emit_ret(mc : MachineCode, rn : Int) -> Unit {
@@ -2524,6 +2567,18 @@ fn collect_used_callee_saved(
 /// Collect all callee-saved FPRs (D8-D15) that are defined in the function
 fn collect_used_callee_saved_fprs(func : VCodeFunction) -> Array[Int] {
   let used : @hashset.HashSet[Int] = @hashset.new()
+  // Check param_pregs: float parameters that cross calls are moved to callee-saved FPRs
+  // These are defined in the prologue via `fmov sN, wM` or `fmov dN, xM`
+  for preg in func.param_pregs {
+    match preg {
+      Some(p) =>
+        if (p.class is Float32 || p.class is Float64) &&
+          is_callee_saved_fpr(p.index) {
+          used.add(p.index)
+        }
+      None => ()
+    }
+  }
   for block in func.blocks {
     for inst in block.insts {
       for def in inst.defs {
@@ -4002,6 +4057,25 @@ fn emit_instruction(
       if total_stack_space > 0 {
         emit_add_imm(mc, 31, 31, total_stack_space) // ADD SP, SP, #total_stack_space
       }
+    }
+    TypeCheckIndirect(expected_type) => {
+      // Check if actual_type == expected_type, trap if not
+      // Uses: [actual_type_vreg]
+      // Emits: CMP actual, expected; B.EQ +8; BRK #2
+      let actual_type_reg = reg_num(inst.uses[0])
+      // CMP immediate can only handle 12-bit values (0-4095)
+      // For larger values, load into scratch register and use CMP register
+      if expected_type <= 4095 {
+        emit_cmp_imm(mc, actual_type_reg, expected_type)
+      } else {
+        // Load expected_type into x17 and compare
+        emit_load_imm64(mc, 17, expected_type.to_int64())
+        emit_cmp_reg(mc, actual_type_reg, 17)
+      }
+      // B.EQ +8: skip BRK (4 bytes) if types match
+      emit_b_cond_offset(mc, 0, 8) // cond=0 is EQ
+      // BRK #2: trap with code 2 for type mismatch
+      emit_brk(mc, 2)
     }
     StackLoad(offset) => {
       // Load from [SP + spill_base_offset + offset] into the def register

--- a/vcode/lower.mbt
+++ b/vcode/lower.mbt
@@ -357,7 +357,8 @@ fn lower_inst(
 
     // Function calls
     @ir.Opcode::Call(func_idx) => lower_call(ctx, inst, block, func_idx)
-    @ir.Opcode::CallIndirect(_type_idx) => lower_call_indirect(ctx, inst, block)
+    @ir.Opcode::CallIndirect(type_idx) =>
+      lower_call_indirect(ctx, inst, block, type_idx)
   }
 }
 
@@ -1727,6 +1728,7 @@ fn lower_call_indirect(
   ctx : LoweringContext,
   inst : @ir.Inst,
   block : VCodeBlock,
+  expected_type_idx : Int,
 ) -> Unit {
   // For call_indirect, the first operand is the table index (callee)
   // which we need to convert to a function pointer
@@ -1751,16 +1753,17 @@ fn lower_call_indirect(
   // Create temporaries for calculation
   let offset_vreg = ctx.vcode_func.new_vreg(Int)
   let func_ptr_vreg = ctx.vcode_func.new_vreg(Int)
+  let actual_type_vreg = ctx.vcode_func.new_vreg(Int)
 
-  // Step 1: Calculate offset = table_idx * 8
-  let const_8_vreg = ctx.vcode_func.new_vreg(Int)
-  let load_8 = VCodeInst::new(LoadConst(8L))
-  load_8.add_def({ reg: Virtual(const_8_vreg) })
-  block.add_inst(load_8)
+  // Step 1: Calculate offset = table_idx * 16 (each entry is 16 bytes: func_ptr + type_idx)
+  let const_16_vreg = ctx.vcode_func.new_vreg(Int)
+  let load_16 = VCodeInst::new(LoadConst(16L))
+  load_16.add_def({ reg: Virtual(const_16_vreg) })
+  block.add_inst(load_16)
   let mul_inst = VCodeInst::new(Mul)
   mul_inst.add_def({ reg: Virtual(offset_vreg) })
   mul_inst.add_use(Virtual(table_idx_vreg))
-  mul_inst.add_use(Virtual(const_8_vreg))
+  mul_inst.add_use(Virtual(const_16_vreg))
   block.add_inst(mul_inst)
 
   // Step 2: Calculate address = X24 + offset
@@ -1772,13 +1775,24 @@ fn lower_call_indirect(
   add_inst.add_use(Virtual(offset_vreg))
   block.add_inst(add_inst)
 
-  // Step 3: Load function pointer from address
-  let load_inst = VCodeInst::new(Load(I64, 0))
-  load_inst.add_def({ reg: Virtual(func_ptr_vreg) })
-  load_inst.add_use(Virtual(addr_vreg))
-  block.add_inst(load_inst)
+  // Step 3: Load function pointer from address (offset 0)
+  let load_func_inst = VCodeInst::new(Load(I64, 0))
+  load_func_inst.add_def({ reg: Virtual(func_ptr_vreg) })
+  load_func_inst.add_use(Virtual(addr_vreg))
+  block.add_inst(load_func_inst)
 
-  // Step 4: Emit CallIndirect instruction
+  // Step 4: Load actual type index from address + 8
+  let load_type_inst = VCodeInst::new(Load(I64, 8))
+  load_type_inst.add_def({ reg: Virtual(actual_type_vreg) })
+  load_type_inst.add_use(Virtual(addr_vreg))
+  block.add_inst(load_type_inst)
+
+  // Step 5: Emit type check instruction (traps if types don't match)
+  let type_check_inst = VCodeInst::new(TypeCheckIndirect(expected_type_idx))
+  type_check_inst.add_use(Virtual(actual_type_vreg))
+  block.add_inst(type_check_inst)
+
+  // Step 6: Emit CallIndirect instruction
   let call_inst = VCodeInst::new(CallIndirect(num_args, num_results))
   // Define all results
   for result in all_results {

--- a/vcode/pkg.generated.mbti
+++ b/vcode/pkg.generated.mbti
@@ -985,6 +985,7 @@ pub enum VCodeOpcode {
   Msub
   Mneg
   CallIndirect(Int, Int)
+  TypeCheckIndirect(Int)
   StackLoad(Int)
   StackStore(Int)
   LoadStackParam(Int, RegClass)

--- a/vcode/regalloc.mbt
+++ b/vcode/regalloc.mbt
@@ -1319,6 +1319,8 @@ fn has_side_effects(opcode : VCodeOpcode) -> Bool {
     Store(_, _) | StackStore(_) => true
     // Bounds check can trap
     BoundsCheck(_, _) => true
+    // Type check can trap
+    TypeCheckIndirect(_) => true
     // Function calls have side effects
     CallIndirect(_, _) => true
     // Everything else is pure computation

--- a/vcode/vcode.mbt
+++ b/vcode/vcode.mbt
@@ -399,6 +399,10 @@ pub enum VCodeOpcode {
   // Defs: [result0, result1, ...] (multiple results supported)
   // Parameters: num_args, num_results
   CallIndirect(Int, Int)
+  // TypeCheckIndirect: check if actual_type == expected_type, trap if not
+  // Uses: [actual_type_vreg], Parameters: expected_type (immediate)
+  // Emits: CMP actual, expected; B.EQ +8; BRK #2 (type mismatch trap)
+  TypeCheckIndirect(Int)
   // Stack operations for spilling
   // StackLoad(offset): Load from [SP + offset] into the def register
   // StackStore(offset): Store the use register to [SP + offset]
@@ -504,6 +508,7 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     Mneg => "mneg"
     CallIndirect(num_args, num_results) =>
       "call_indirect(\{num_args}) -> \{num_results} results"
+    TypeCheckIndirect(expected_type) => "type_check_indirect \{expected_type}"
     StackLoad(offset) => "stack_load [sp+\{offset}]"
     StackStore(offset) => "stack_store [sp+\{offset}]"
     LoadStackParam(param_idx, class) =>


### PR DESCRIPTION
## Summary
- Implement structural type equivalence using type hashing for `call_indirect` type checking
- Store type hash in indirect table entries (16 bytes per entry: func_ptr + type_hash)
- Fix CMP immediate truncation bug for type hashes > 4095 (use load + cmp reg instead)
- Add `emit_b_cond_offset` and `emit_brk` helper functions for type check code generation

## Test Results
- call_indirect.wast: **100 failures → 6 failures** (163/169 passing)
- Remaining 6 failures are related to multiple tables support (future work)

## Test plan
- [x] All existing tests pass
- [x] New disasm tests cover both CMP immediate and CMP register paths
- [x] call_indirect.wast shows significant improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)