### PR TITLE
fix: implement F32Copysign and F64Copysign in JIT compiler

### DIFF
--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -433,6 +433,26 @@ fn Translator::translate_instruction(
     F32Div => self.translate_binary_f32(fn(b, a, v) { b.fdiv(a, v) })
     F32Min => self.translate_binary_f32(fn(b, a, v) { b.fmin(a, v) })
     F32Max => self.translate_binary_f32(fn(b, a, v) { b.fmax(a, v) })
+    F32Copysign => {
+      // copysign(x, y) = magnitude of x with sign of y
+      let y = self.pop() // sign source
+      let x = self.pop() // magnitude source
+      // Use bitwise operations to implement copysign
+      // result_bits = (x_bits & 0x7FFFFFFF) | (y_bits & 0x80000000)
+      let x_bits = self.builder.bitcast(Type::I32, x)
+      let y_bits = self.builder.bitcast(Type::I32, y)
+      let magnitude = self.builder.band(
+        x_bits,
+        self.builder.iconst_i32(0x7FFFFFFF),
+      )
+      let sign = self.builder.band(
+        y_bits,
+        self.builder.iconst_i32(0x80000000U.reinterpret_as_int()),
+      )
+      let result_bits = self.builder.bor(magnitude, sign)
+      let result = self.builder.bitcast(Type::F32, result_bits)
+      self.push(result)
+    }
 
     // f32 unary
     F32Neg => self.translate_unary_f32(fn(b, a) { b.fneg(a) })
@@ -458,6 +478,26 @@ fn Translator::translate_instruction(
     F64Div => self.translate_binary_f64(fn(b, a, v) { b.fdiv(a, v) })
     F64Min => self.translate_binary_f64(fn(b, a, v) { b.fmin(a, v) })
     F64Max => self.translate_binary_f64(fn(b, a, v) { b.fmax(a, v) })
+    F64Copysign => {
+      // copysign(x, y) = magnitude of x with sign of y
+      let y = self.pop() // sign source
+      let x = self.pop() // magnitude source
+      // Use bitwise operations to implement copysign
+      // result_bits = (x_bits & 0x7FFFFFFFFFFFFFFF) | (y_bits & 0x8000000000000000)
+      let x_bits = self.builder.bitcast(Type::I64, x)
+      let y_bits = self.builder.bitcast(Type::I64, y)
+      let magnitude = self.builder.band(
+        x_bits,
+        self.builder.iconst_i64(0x7FFFFFFFFFFFFFFFL),
+      )
+      let sign = self.builder.band(
+        y_bits,
+        self.builder.iconst_i64(0x8000000000000000UL.reinterpret_as_int64()),
+      )
+      let result_bits = self.builder.bor(magnitude, sign)
+      let result = self.builder.bitcast(Type::F64, result_bits)
+      self.push(result)
+    }
 
     // f64 unary
     F64Neg => self.translate_unary_f64(fn(b, a) { b.fneg(a) })


### PR DESCRIPTION
## Summary

- Implemented F32Copysign and F64Copysign instructions in the JIT compiler's IR translator
- Fixed 576 test failures (288 in f32_bitwise.wast + 288 in f64_bitwise.wast)

## Problem

The JIT compiler was skipping F32Copysign and F64Copysign instructions due to the catch-all `_ => ()` branch in ir/translator.mbt:791. This caused:
- Stack corruption (operands not consumed)
- Incorrect return values
- All 288 copysign tests to fail in both f32_bitwise.wast and f64_bitwise.wast

## Solution

Implemented both instructions using bitwise operations to copy the sign bit from one operand to the magnitude of another:

```moonbit
copysign(x, y) = (x_bits & magnitude_mask) | (y_bits & sign_mask)
```

- **F32**: Use i32 bitcast with masks 0x7FFFFFFF (magnitude) and 0x80000000 (sign)
- **F64**: Use i64 bitcast with masks 0x7FFFFFFFFFFFFFFF (magnitude) and 0x8000000000000000 (sign)

## Test Results

- **f32_bitwise.wast**: 363/363 passed ✅ (was 75/363 before)
- **f64_bitwise.wast**: 363/363 passed ✅ (was 75/363 before)

## Changes

- ir/translator.mbt: Added F32Copysign and F64Copysign implementations between the respective binary float operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)