### PR TITLE
refactor: abort on unimplemented instructions instead of silently skipping

### DIFF
--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -826,9 +826,7 @@ fn Translator::translate_instruction(
       let elem_idx = self.pop()
       self.builder.table_set(table_idx, elem_idx, value)
     }
-
-    // Not yet implemented
-    _ => () // Skip unimplemented instructions
+    inst => abort("unimplemented ir instruction \{inst}")
   }
 }
 

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -86,10 +86,7 @@ fn LoweringContext::get_block_id(
   self : LoweringContext,
   ir_block_id : Int,
 ) -> Int {
-  match self.block_map.get(ir_block_id) {
-    Some(id) => id
-    None => panic()
-  }
+  self.block_map.get(ir_block_id).unwrap()
 }
 
 ///|

--- a/vcode/lower/patterns.mbt
+++ b/vcode/lower/patterns.mbt
@@ -756,8 +756,6 @@ fn lower_inst_default(
     // Misc
     @ir.Opcode::Copy => lower_copy(ctx, inst, block)
     @ir.Opcode::Select => lower_select(ctx, inst, block)
-
-    // Unimplemented opcodes - emit nop for now
-    _ => ()
+    opcode => abort("unimplemented vcode lowering for opcode \{opcode}")
   }
 }


### PR DESCRIPTION
## Summary

- Changed default branches from `_ => ()` to abort with error messages in critical code paths
- Prevents silent failures like the copysign bug where instructions were skipped
- Modified ir/translator.mbt and vcode/lower/patterns.mbt

## Motivation

The previous copysign bug (#184) was caused by silently skipping unimplemented instructions with `_ => ()`, which led to:
- Stack corruption (operands not consumed)
- Incorrect results
- Hard-to-debug failures

## Changes

### Modified to abort:
1. **ir/translator.mbt**: Changed catch-all to `inst => abort("unimplemented ir instruction \{inst}")`
2. **vcode/lower/patterns.mbt**: Changed catch-all to `opcode => abort("unimplemented vcode lowering for opcode \{opcode}")`

### Unchanged (intentional partial handling):
- Config parsing (main/config.mbt)
- Optimization passes (ir/optimize.mbt)
- Test utilities (testsuite/compare.mbt, main/wast.mbt)
- Parser (wat/parser.mbt)

These legitimately handle only specific cases and should ignore unknown inputs.

## Test Results

- **f32_bitwise.wast**: 363/363 passed ✅
- **elem.wast**: 72/72 passed ✅
- No regressions detected

## Benefits

- **Early detection**: Unimplemented instructions now fail immediately with clear error messages
- **Easier debugging**: Stack traces point directly to missing implementations
- **Prevents corruption**: No more silent failures causing downstream issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)