### PR TITLE
fix(jit): preserve f32 signaling NaN bit patterns

### DIFF
--- a/ir/builder.mbt
+++ b/ir/builder.mbt
@@ -121,8 +121,12 @@ pub fn IRBuilder::fconst(self : IRBuilder, ty : Type, value : Double) -> Value {
 
 ///|
 /// Emit an f32 constant
+/// Note: We pack the f32 bits into the Double's bit representation to preserve
+/// NaN payloads. Using value.to_double() would go through the FPU and convert
+/// signaling NaNs to quiet NaNs.
 pub fn IRBuilder::fconst_f32(self : IRBuilder, value : Float) -> Value {
-  self.fconst(Type::F32, value.to_double())
+  let f32_bits = value.reinterpret_as_int().to_int64()
+  self.fconst(Type::F32, f32_bits.reinterpret_as_double())
 }
 
 ///|

--- a/ir/optimize.mbt
+++ b/ir/optimize.mbt
@@ -142,7 +142,13 @@ pub fn fold_constants(func : Function) -> OptResult {
           match inst.result {
             Some(r) =>
               if r.ty is F32 {
-                constants.set(r.id, ConstValue::F32(Float::from_double(v)))
+                // F32 bits are packed in the lower 32 bits of the Double's bit representation
+                // Extract them directly to preserve NaN payloads
+                let f32_bits = v.reinterpret_as_int64().to_int()
+                constants.set(
+                  r.id,
+                  ConstValue::F32(Float::reinterpret_from_int(f32_bits)),
+                )
               } else {
                 constants.set(r.id, ConstValue::F64(v))
               }
@@ -180,7 +186,11 @@ fn ConstValue::to_opcode(self : ConstValue) -> Opcode {
   match self {
     I32(v) => Opcode::Iconst(v.to_int64())
     I64(v) => Opcode::Iconst(v)
-    F32(v) => Opcode::Fconst(v.to_double())
+    F32(v) => {
+      // Pack F32 bits into Double's bit representation to preserve NaN payloads
+      let f32_bits = v.reinterpret_as_int().to_int64()
+      Opcode::Fconst(f32_bits.reinterpret_as_double())
+    }
     F64(v) => Opcode::Fconst(v)
   }
 }

--- a/ir/printer.mbt
+++ b/ir/printer.mbt
@@ -52,12 +52,25 @@ fn format_floatcc(cc : FloatCC) -> String {
 
 ///|
 /// Print an opcode with its operands
-fn format_opcode(opcode : Opcode, operands : Array[Value]) -> String {
+/// result_ty is needed for Fconst to correctly decode F32 bit-packed constants
+fn format_opcode(
+  opcode : Opcode,
+  operands : Array[Value],
+  result_ty : Type?,
+) -> String {
   let ops = operands.map(format_value).join(", ")
   match opcode {
     // Constants
     Iconst(n) => "iconst \{n}"
-    Fconst(n) => "fconst \{n}"
+    Fconst(n) =>
+      // For F32, the bits are packed in the lower 32 bits of the Double
+      if result_ty is Some(F32) {
+        let f32_bits = n.reinterpret_as_int64().to_int()
+        let f32_val = Float::reinterpret_from_int(f32_bits)
+        "fconst \{f32_val}"
+      } else {
+        "fconst \{n}"
+      }
 
     // Integer arithmetic
     Iadd => "iadd \{ops}"
@@ -168,7 +181,8 @@ fn format_opcode(opcode : Opcode, operands : Array[Value]) -> String {
 ///|
 /// Print an instruction
 fn format_inst(inst : Inst) -> String {
-  let opcode_str = format_opcode(inst.opcode, inst.operands)
+  let result_ty = inst.result.map(v => v.ty)
+  let opcode_str = format_opcode(inst.opcode, inst.operands, result_ty)
   if inst.result is Some(r) {
     // Check for extra results (multi-value returns)
     if inst.extra_results.length() > 0 {

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -394,9 +394,9 @@ fn lower_fconst(
     // Determine if this is an F32 or F64 constant based on the result type
     let opcode = match result.ty {
       @ir.Type::F32 => {
-        // Convert Double to Float, then get its 32-bit representation
-        let float_val = Float::from_double(val)
-        let bits = float_val.reinterpret_as_int()
+        // F32 bits are packed in the lower 32 bits of the Double's bit representation
+        // (see IRBuilder::fconst_f32). Extract them directly to preserve NaN payloads.
+        let bits = val.reinterpret_as_int64().to_int()
         @instr.LoadConstF32(bits)
       }
       _ => {

--- a/vcode/lower/patterns.mbt
+++ b/vcode/lower/patterns.mbt
@@ -169,7 +169,15 @@ fn match_pattern_impl(
     ConstFloat(expected) =>
       // Check if this is an fconst with the expected value
       if inst.opcode is @ir.Opcode::Fconst(val) {
-        val == expected
+        // For F32, bits are packed in the lower 32 bits of the Double
+        // For F64, the Double is the actual value
+        if inst.result is Some(r) && r.ty is @ir.Type::F32 {
+          let stored_bits = val.reinterpret_as_int64().to_int()
+          let expected_bits = Float::from_double(expected).reinterpret_as_int()
+          stored_bits == expected_bits
+        } else {
+          val == expected
+        }
       } else {
         false
       }
@@ -225,7 +233,16 @@ fn match_pattern_impl(
             match def_inst {
               Some(def) =>
                 if def.opcode is @ir.Opcode::Fconst(val) {
-                  if val != expected {
+                  // For F32, bits are packed in the lower 32 bits of the Double
+                  let matches = if def.result is Some(r) &&
+                    r.ty is @ir.Type::F32 {
+                    let stored_bits = val.reinterpret_as_int64().to_int()
+                    let expected_bits = Float::from_double(expected).reinterpret_as_int()
+                    stored_bits == expected_bits
+                  } else {
+                    val == expected
+                  }
+                  if !matches {
                     return false
                   }
                   result.add_float_const(val)


### PR DESCRIPTION
## Summary

- Fix f32 signaling NaN constants being incorrectly converted to quiet NaNs
- Use bit-level reinterpretation instead of FPU-based Float<->Double conversions
- Update IR builder, lowering, optimizer, pattern matching, and printer to handle f32 bits correctly

## Problem

F32 signaling NaN constants (e.g., `nan:0x200000`) were losing their bit patterns because:
1. `Float.to_double()` goes through FPU which sets the quiet NaN bit (bit 22)
2. `Float::from_double()` has the same issue

For example:
- `nan:0x200000` expected `0x7fa00000`, got `0x7fc00000`
- `nan:0x012345` expected `0x7f812345`, got `0x7fc12345`

## Solution

Pack f32 bits into Double's bit representation using `reinterpret` operations that bypass the FPU:
- Store: `value.reinterpret_as_int().to_int64().reinterpret_as_double()`
- Load: `double.reinterpret_as_int64().to_int()`

## Test plan

- [x] `float_literals.wast`: 177 passed (was 173 passed, 4 failed)
- [x] `f32.wast`: 2513 passed
- [x] `f64.wast`: 2513 passed  
- [x] Moon unit tests: 829 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)