### PR TITLE
refactor(jit): expand float-to-int conversions in lower phase

### DIFF
--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -806,332 +806,37 @@ fn MachineCode::emit_instruction(
       let rn = reg_num(inst.uses[0])
       self.emit_mov_reg32(rd, rn)
     }
-    FloatToInt(kind) => {
-      let rd = wreg_num(inst.defs[0])
-      let rn = reg_num(inst.uses[0])
-      // f32 values are stored as raw bits in S registers
-      // f64 values are stored in D registers
+    FloatToInt(kind) =>
+      // Both trapping and saturating FloatToInt are now expanded in lower phase.
+      // Trapping: FpuCmp + TrapIf + FcvtToInt
+      // Saturating: FcvtToInt directly (AArch64 handles saturation)
       match kind {
-        F32ToI32S => {
-          // i32.trunc_f32_s: trap on NaN or overflow
-          // Check for NaN: rn != rn
-          self.emit_fcmp_s(rn, rn)
-          self.emit_b_cond_offset(7, 8) // VC (no overflow): skip trap if ordered
-          self.emit_brk(3) // Trap: invalid conversion to integer
-          // Check for underflow: rn < INT32_MIN (-2147483648.0 = 0xCF000000)
-          // Note: f32 precision means -2147483648.9 rounds to -2147483648.0
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0xCF00, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fcmp_s(rn, 16)
-          self.emit_b_cond_offset(10, 8) // GE: skip trap if rn >= INT32_MIN
-          self.emit_brk(3) // Trap: integer overflow
-          // Check for overflow: rn >= INT32_MAX (2147483648.0 = 0x4F000000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0x4F00, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fcmp_s(rn, 16)
-          self.emit_b_cond_offset(4, 8) // MI: skip trap if < max
-          self.emit_brk(3) // Trap: integer overflow
-          // Convert
-          self.emit_fcvtzs(rd, rn, int64=false, double=false)
-        }
-        F32ToI32U => {
-          // i32.trunc_f32_u: trap on NaN or overflow
-          self.emit_fcmp_s(rn, rn)
-          self.emit_b_cond_offset(7, 8) // VC
-          self.emit_brk(3)
-          // Check for underflow: rn <= -1.0 (values <= -1.0 are invalid)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0xBF80, 16) // -1.0 = 0xBF800000
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fcmp_s(rn, 16)
-          self.emit_b_cond_offset(12, 8) // GT: skip trap if > -1.0
-          self.emit_brk(3)
-          // Check for overflow: rn >= UINT32_MAX (4294967296.0 = 0x4F800000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0x4F80, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fcmp_s(rn, 16)
-          self.emit_b_cond_offset(4, 8) // MI: skip trap if < max
-          self.emit_brk(3)
-          self.emit_fcvtzu(rd, rn, int64=false, double=false)
-        }
-        F32ToI64S => {
-          // i64.trunc_f32_s: trap on NaN or overflow
-          self.emit_fcmp_s(rn, rn)
-          self.emit_b_cond_offset(7, 8) // VC
-          self.emit_brk(3)
-          // Check for underflow: rn < INT64_MIN (-2^63 = 0xDF000000)
-          // Note: f32 precision means fractional parts are lost
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0xDF00, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fcmp_s(rn, 16)
-          self.emit_b_cond_offset(10, 8) // GE: skip trap if rn >= INT64_MIN
-          self.emit_brk(3)
-          // Check for overflow: rn >= INT64_MAX (2^63 = 0x5F000000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0x5F00, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fcmp_s(rn, 16)
-          self.emit_b_cond_offset(4, 8) // MI: skip trap if < max
-          self.emit_brk(3)
-          self.emit_fcvtzs(rd, rn, int64=true, double=false)
-        }
-        F32ToI64U => {
-          // i64.trunc_f32_u: trap on NaN or overflow
-          self.emit_fcmp_s(rn, rn)
-          self.emit_b_cond_offset(7, 8) // VC
-          self.emit_brk(3)
-          // Check for underflow: rn <= -1.0
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0xBF80, 16) // -1.0
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fcmp_s(rn, 16)
-          self.emit_b_cond_offset(12, 8) // GT
-          self.emit_brk(3)
-          // Check for overflow: rn >= UINT64_MAX (2^64 = 0x5F800000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0x5F80, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fcmp_s(rn, 16)
-          self.emit_b_cond_offset(4, 8) // MI
-          self.emit_brk(3)
-          self.emit_fcvtzu(rd, rn, int64=true, double=false)
-        }
-        F64ToI32S => {
-          // i32.trunc_f64_s: trap on NaN or overflow
-          self.emit_fcmp_d(rn, rn)
-          self.emit_b_cond_offset(7, 8) // VC
-          self.emit_brk(3)
-          // Check for underflow: rn <= INT32_MIN-1 (-2^31-1 = 0xC1E0000000200000)
-          self.emit_load_imm64(16, 0xC1E0000000200000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fcmp_d(rn, 16)
-          self.emit_b_cond_offset(12, 8) // GT: skip trap if rn > INT32_MIN-1
-          self.emit_brk(3)
-          // Check for overflow: rn >= INT32_MAX (2^31 = 0x41E0000000000000)
-          self.emit_load_imm64(16, 0x41E0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fcmp_d(rn, 16)
-          self.emit_b_cond_offset(4, 8) // MI
-          self.emit_brk(3)
-          self.emit_fcvtzs(rd, rn, int64=false, double=true)
-        }
-        F64ToI32U => {
-          // i32.trunc_f64_u: trap on NaN or overflow
-          self.emit_fcmp_d(rn, rn)
-          self.emit_b_cond_offset(7, 8) // VC
-          self.emit_brk(3)
-          // Check for underflow: rn <= -1.0
-          self.emit_load_imm64(16, 0xBFF0000000000000L) // -1.0
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fcmp_d(rn, 16)
-          self.emit_b_cond_offset(12, 8) // GT
-          self.emit_brk(3)
-          // Check for overflow: rn >= UINT32_MAX (2^32 = 0x41F0000000000000)
-          self.emit_load_imm64(16, 0x41F0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fcmp_d(rn, 16)
-          self.emit_b_cond_offset(4, 8) // MI
-          self.emit_brk(3)
-          self.emit_fcvtzu(rd, rn, int64=false, double=true)
-        }
-        F64ToI64S => {
-          // i64.trunc_f64_s: trap on NaN or overflow
-          self.emit_fcmp_d(rn, rn)
-          self.emit_b_cond_offset(7, 8) // VC
-          self.emit_brk(3)
-          // Check for underflow: rn < INT64_MIN (-2^63 = 0xC3E0000000000000)
-          // Note: f64 precision is limited for 64-bit integers
-          self.emit_load_imm64(16, 0xC3E0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fcmp_d(rn, 16)
-          self.emit_b_cond_offset(10, 8) // GE: skip trap if rn >= INT64_MIN
-          self.emit_brk(3)
-          // Check for overflow: rn >= INT64_MAX (2^63 = 0x43E0000000000000)
-          self.emit_load_imm64(16, 0x43E0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fcmp_d(rn, 16)
-          self.emit_b_cond_offset(4, 8) // MI
-          self.emit_brk(3)
-          self.emit_fcvtzs(rd, rn, int64=true, double=true)
-        }
-        F64ToI64U => {
-          // i64.trunc_f64_u: trap on NaN or overflow
-          self.emit_fcmp_d(rn, rn)
-          self.emit_b_cond_offset(7, 8) // VC
-          self.emit_brk(3)
-          // Check for underflow: rn <= -1.0
-          self.emit_load_imm64(16, 0xBFF0000000000000L) // -1.0
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fcmp_d(rn, 16)
-          self.emit_b_cond_offset(12, 8) // GT
-          self.emit_brk(3)
-          // Check for overflow: rn >= UINT64_MAX (2^64 = 0x43F0000000000000)
-          self.emit_load_imm64(16, 0x43F0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fcmp_d(rn, 16)
-          self.emit_b_cond_offset(4, 8) // MI
-          self.emit_brk(3)
-          self.emit_fcvtzu(rd, rn, int64=true, double=true)
-        }
-        // Saturating conversions
-        // Implements proper saturation: NaN → 0, overflow → clamp to min/max
-        // Strategy: use FCSEL for NaN, FMAX/FMIN for clamping, then convert
-        F32ToI32SSat => {
-          // i32.trunc_sat_f32_s: NaN→0, clamp to [-2^31, 2^31-1]
-          // Step 1: Handle NaN → replace with 0.0
-          self.emit_movz(16, 0, 0)
-          self.emit_fmov_w_to_s(16, 16) // S16 = 0.0
-          self.emit_fcmp_s(rn, rn)
-          self.emit_fcsel_s(17, rn, 16, 7) // VC: S17 = ordered ? rn : 0.0
-          // Step 2: Clamp to [INT32_MIN, INT32_MAX]
-          // Load INT32_MIN as f32 (-2^31 = 0xCF000000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0xCF00, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fmaxnm_s(17, 17, 16) // S17 = max(S17, INT32_MIN)
-          // Load INT32_MAX as f32 (2^31-1 ≈ 0x4F000000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0x4F00, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fminnm_s(17, 17, 16) // S17 = min(S17, INT32_MAX)
-          // Convert to integer
-          self.emit_fcvtzs(rd, 17, int64=false, double=false)
-        }
-        F32ToI32USat => {
-          // i32.trunc_sat_f32_u: NaN→0, clamp to [0, 2^32-1]
-          // Step 1: Handle NaN → replace with 0.0
-          self.emit_movz(16, 0, 0)
-          self.emit_fmov_w_to_s(16, 16) // S16 = 0.0
-          self.emit_fcmp_s(rn, rn)
-          self.emit_fcsel_s(17, rn, 16, 7) // VC: S17 = ordered ? rn : 0.0
-          // Step 2: Clamp lower bound (negative → 0.0)
-          self.emit_fmaxnm_s(17, 17, 16) // S17 = max(S17, 0.0)
-          // Step 3: Clamp upper bound
-          // Load UINT32_MAX as f32 (2^32 = 0x4F800000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0x4F80, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fminnm_s(17, 17, 16) // S17 = min(S17, UINT32_MAX)
-          // Convert to integer
-          self.emit_fcvtzu(rd, 17, int64=false, double=false)
-        }
-        F32ToI64SSat => {
-          // i64.trunc_sat_f32_s: NaN→0, clamp to [-2^63, 2^63-1]
-          // Step 1: Handle NaN → replace with 0.0
-          self.emit_movz(16, 0, 0)
-          self.emit_fmov_w_to_s(16, 16) // S16 = 0.0
-          self.emit_fcmp_s(rn, rn)
-          self.emit_fcsel_s(17, rn, 16, 7) // VC: S17 = ordered ? rn : 0.0
-          // Step 2: Clamp to [INT64_MIN, INT64_MAX]
-          // Load INT64_MIN as f32 (-2^63 = 0xDF000000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0xDF00, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fmaxnm_s(17, 17, 16) // S17 = max(S17, INT64_MIN)
-          // Load INT64_MAX as f32 (2^63 = 0x5F000000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0x5F00, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fminnm_s(17, 17, 16) // S17 = min(S17, INT64_MAX)
-          // Convert to integer
-          self.emit_fcvtzs(rd, 17, int64=true, double=false)
-        }
-        F32ToI64USat => {
-          // i64.trunc_sat_f32_u: NaN→0, clamp to [0, 2^64-1]
-          // Step 1: Handle NaN → replace with 0.0
-          self.emit_movz(16, 0, 0)
-          self.emit_fmov_w_to_s(16, 16) // S16 = 0.0
-          self.emit_fcmp_s(rn, rn)
-          self.emit_fcsel_s(17, rn, 16, 7) // VC: S17 = ordered ? rn : 0.0
-          // Step 2: Clamp lower bound (negative → 0.0)
-          self.emit_fmaxnm_s(17, 17, 16) // S17 = max(S17, 0.0)
-          // Step 3: Clamp upper bound
-          // Load UINT64_MAX as f32 (2^64 = 0x5F800000)
-          self.emit_movz(16, 0x0000, 0)
-          self.emit_movk(16, 0x5F80, 16)
-          self.emit_fmov_w_to_s(16, 16)
-          self.emit_fminnm_s(17, 17, 16) // S17 = min(S17, UINT64_MAX)
-          // Convert to integer
-          self.emit_fcvtzu(rd, 17, int64=true, double=false)
-        }
-        F64ToI32SSat => {
-          // i32.trunc_sat_f64_s: NaN→0, clamp to [-2^31, 2^31-1]
-          // Step 1: Handle NaN → replace with 0.0
-          self.emit_movz(16, 0, 0)
-          self.emit_fmov_x_to_d(16, 16) // D16 = 0.0
-          self.emit_fcmp_d(rn, rn)
-          self.emit_fcsel_d(17, rn, 16, 7) // VC: D17 = ordered ? rn : 0.0
-          // Step 2: Clamp to [INT32_MIN, INT32_MAX]
-          // Load INT32_MIN as f64 (-2^31 = 0xC1E0000000000000)
-          self.emit_load_imm64(16, 0xC1E0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fmaxnm_d(17, 17, 16) // D17 = max(D17, INT32_MIN)
-          // Load INT32_MAX as f64 (2^31 = 0x41E0000000000000)
-          self.emit_load_imm64(16, 0x41E0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fminnm_d(17, 17, 16) // D17 = min(D17, INT32_MAX)
-          // Convert to integer
-          self.emit_fcvtzs(rd, 17, int64=false, double=true)
-        }
-        F64ToI32USat => {
-          // i32.trunc_sat_f64_u: NaN→0, clamp to [0, 2^32-1]
-          // Step 1: Handle NaN → replace with 0.0
-          self.emit_movz(16, 0, 0)
-          self.emit_fmov_x_to_d(16, 16) // D16 = 0.0
-          self.emit_fcmp_d(rn, rn)
-          self.emit_fcsel_d(17, rn, 16, 7) // VC: D17 = ordered ? rn : 0.0
-          // Step 2: Clamp lower bound (negative → 0.0)
-          self.emit_fmaxnm_d(17, 17, 16) // D17 = max(D17, 0.0)
-          // Step 3: Clamp upper bound
-          // Load UINT32_MAX as f64 (2^32 = 0x41F0000000000000)
-          self.emit_load_imm64(16, 0x41F0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fminnm_d(17, 17, 16) // D17 = min(D17, UINT32_MAX)
-          // Convert to integer
-          self.emit_fcvtzu(rd, 17, int64=false, double=true)
-        }
-        F64ToI64SSat => {
-          // i64.trunc_sat_f64_s: NaN→0, clamp to [-2^63, 2^63-1]
-          // Step 1: Handle NaN → replace with 0.0
-          self.emit_movz(16, 0, 0)
-          self.emit_fmov_x_to_d(16, 16) // D16 = 0.0
-          self.emit_fcmp_d(rn, rn)
-          self.emit_fcsel_d(17, rn, 16, 7) // VC: D17 = ordered ? rn : 0.0
-          // Step 2: Clamp to [INT64_MIN, INT64_MAX]
-          // Load INT64_MIN as f64 (-2^63 = 0xC3E0000000000000)
-          self.emit_load_imm64(16, 0xC3E0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fmaxnm_d(17, 17, 16) // D17 = max(D17, INT64_MIN)
-          // Load INT64_MAX as f64 (2^63 = 0x43E0000000000000)
-          self.emit_load_imm64(16, 0x43E0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fminnm_d(17, 17, 16) // D17 = min(D17, INT64_MAX)
-          // Convert to integer
-          self.emit_fcvtzs(rd, 17, int64=true, double=true)
-        }
-        F64ToI64USat => {
-          // i64.trunc_sat_f64_u: NaN→0, clamp to [0, 2^64-1]
-          // Step 1: Handle NaN → replace with 0.0
-          self.emit_movz(16, 0, 0)
-          self.emit_fmov_x_to_d(16, 16) // D16 = 0.0
-          self.emit_fcmp_d(rn, rn)
-          self.emit_fcsel_d(17, rn, 16, 7) // VC: D17 = ordered ? rn : 0.0
-          // Step 2: Clamp lower bound (negative → 0.0)
-          self.emit_fmaxnm_d(17, 17, 16) // D17 = max(D17, 0.0)
-          // Step 3: Clamp upper bound
-          // Load UINT64_MAX as f64 (2^64 = 0x43F0000000000000)
-          self.emit_load_imm64(16, 0x43F0000000000000L)
-          self.emit_fmov_x_to_d(16, 16)
-          self.emit_fminnm_d(17, 17, 16) // D17 = min(D17, UINT64_MAX)
-          // Convert to integer
-          self.emit_fcvtzu(rd, 17, int64=true, double=true)
-        }
+        // Trapping conversions - should never reach emit phase
+        F32ToI32S
+        | F32ToI32U
+        | F32ToI64S
+        | F32ToI64U
+        | F64ToI32S
+        | F64ToI32U
+        | F64ToI64S
+        | F64ToI64U =>
+          abort(
+            "Trapping FloatToInt should be expanded in lower phase to FpuCmp + TrapIf + FcvtToInt",
+          )
+        // Saturating conversions (now handled by FcvtToInt directly)
+        // AArch64 FCVTZS/FCVTZU already implements WebAssembly saturating semantics
+        F32ToI32SSat
+        | F32ToI32USat
+        | F32ToI64SSat
+        | F32ToI64USat
+        | F64ToI32SSat
+        | F64ToI32USat
+        | F64ToI64SSat
+        | F64ToI64USat =>
+          abort(
+            "Saturating FloatToInt should use FcvtToInt directly in lower phase",
+          )
       }
-    }
     IntToFloat(kind) => {
       let rd = wreg_num(inst.defs[0])
       let rn = reg_num(inst.uses[0])
@@ -1164,6 +869,92 @@ fn MachineCode::emit_instruction(
       self.emit_b_cond_offset(9, 8)
       // BRK #trap_code
       self.emit_brk(trap_code)
+    }
+    FpuCmp(is_f32) => {
+      // Floating-point compare (sets NZCV flags)
+      // Uses: [lhs, rhs], Defs: []
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      if is_f32 {
+        self.emit_fcmp_s(rn, rm)
+      } else {
+        self.emit_fcmp_d(rn, rm)
+      }
+    }
+    TrapIf(cond, trap_code) => {
+      // Conditional trap based on flags
+      // B.!cond skip; BRK #trap_code
+      // We need to branch OVER the trap if condition is NOT met
+      // So we use the inverted condition for the branch
+      let skip_cond = match cond {
+        Eq => 1 // NE
+        Ne => 0 // EQ
+        Hs => 3 // LO
+        Lo => 2 // HS
+        Mi => 5 // PL
+        Pl => 4 // MI
+        Vs => 7 // VC
+        Vc => 6 // VS
+        Hi => 9 // LS
+        Ls => 8 // HI
+        Ge => 11 // LT
+        Lt => 10 // GE
+        Gt => 13 // LE
+        Le => 12 // GT
+        Al => 15 // NV (never - will always trap)
+      }
+      // B.!cond +8 (skip BRK)
+      self.emit_b_cond_offset(skip_cond, 8)
+      // BRK #trap_code
+      self.emit_brk(trap_code)
+    }
+    FcvtToInt(is_f32, is_i64, is_signed) => {
+      // Raw float-to-int conversion (no checks)
+      // Uses: [src_fp], Defs: [dst_int]
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      if is_signed {
+        self.emit_fcvtzs(rd, rn, int64=is_i64, double=!is_f32)
+      } else {
+        self.emit_fcvtzu(rd, rn, int64=is_i64, double=!is_f32)
+      }
+    }
+    FpuSel(is_f32, cond) => {
+      // Floating-point conditional select
+      // Uses: [true_val, false_val], Defs: [result]
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      let cond_bits = cond.to_bits()
+      if is_f32 {
+        self.emit_fcsel_s(rd, rn, rm, cond_bits)
+      } else {
+        self.emit_fcsel_d(rd, rn, rm, cond_bits)
+      }
+    }
+    FpuMaxnm(is_f32) => {
+      // Floating-point maximum (NaN-propagating)
+      // Uses: [lhs, rhs], Defs: [result]
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      if is_f32 {
+        self.emit_fmaxnm_s(rd, rn, rm)
+      } else {
+        self.emit_fmaxnm_d(rd, rn, rm)
+      }
+    }
+    FpuMinnm(is_f32) => {
+      // Floating-point minimum (NaN-propagating)
+      // Uses: [lhs, rhs], Defs: [result]
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      let rm = reg_num(inst.uses[1])
+      if is_f32 {
+        self.emit_fminnm_s(rd, rn, rm)
+      } else {
+        self.emit_fminnm_d(rd, rn, rm)
+      }
     }
     BoundsCheck(_offset, _access_size) =>
       // DEPRECATED: BoundsCheck is now expanded in lower phase to:

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -169,6 +169,45 @@ pub(all) enum VCodeOpcode {
   // TrapIfUgt(trap_code): CMP rn, rm; B.LS skip; BRK #trap_code
   // Uses: [lhs, rhs], traps if lhs > rhs (unsigned)
   TrapIfUgt(Int)
+
+  // Floating-point compare (sets NZCV flags, no result value)
+  // FpuCmp(is_f32): FCMP Sn, Sm or FCMP Dn, Dm
+  // Uses: [lhs, rhs], Defs: [] (only sets flags)
+  // Used for NaN check (compare with self) and bound checks
+  FpuCmp(Bool)
+
+  // Conditional trap based on condition flags
+  // TrapIf(cond, trap_code): B.cond skip; BRK #trap_code
+  // Uses: [], Defs: [] (uses flags from previous compare)
+  // trap_code: 1=out_of_bounds, 2=type_mismatch, 3=bad_conversion, 4=integer_overflow
+  TrapIf(Cond, Int)
+
+  // Raw float-to-int conversion (FCVTZS/FCVTZU without NaN/overflow checks)
+  // FcvtToInt(is_f32, is_i64, is_signed): FCVTZS/FCVTZU Wd/Xd, Sn/Dn
+  // Uses: [src_fp], Defs: [dst_int]
+  // The trapping FloatToInt opcodes are expanded in lower phase to:
+  //   FpuCmp + TrapIf(Vs) + LoadConstF32/F64 + FpuCmp + TrapIf + ... + FcvtToInt
+  FcvtToInt(Bool, Bool, Bool)
+
+  // Floating-point conditional select (for saturating conversions)
+  // FpuSel(is_f32, cond): FCSEL Sd, Sn, Sm, cond or FCSEL Dd, Dn, Dm, cond
+  // Uses: [true_val, false_val], Defs: [result]
+  // Selects true_val if condition is true, false_val otherwise
+  // Used for NaN handling: select 0.0 if NaN, original value otherwise
+  FpuSel(Bool, Cond)
+
+  // Floating-point maximum (NaN-propagating)
+  // FpuMaxnm(is_f32): FMAXNM Sd, Sn, Sm or FMAXNM Dd, Dn, Dm
+  // Uses: [lhs, rhs], Defs: [result]
+  // Returns the larger value; if one is NaN, returns the other
+  FpuMaxnm(Bool)
+
+  // Floating-point minimum (NaN-propagating)
+  // FpuMinnm(is_f32): FMINNM Sd, Sn, Sm or FMINNM Dd, Dn, Dm
+  // Uses: [lhs, rhs], Defs: [result]
+  // Returns the smaller value; if one is NaN, returns the other
+  FpuMinnm(Bool)
+
   // Memory bounds check (for WASM linear memory safety) - DEPRECATED
   // Use TrapIfUgt with pre-computed end_addr and memory_size instead
   // BoundsCheck(offset, access_size): checks wasm_addr + offset + access_size <= memory_size
@@ -332,6 +371,22 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     Rbit => "rbit"
     Nop => "nop"
     TrapIfUgt(trap_code) => "trap_if_ugt #\{trap_code}"
+    FpuCmp(is_f32) => if is_f32 { "fcmp.s" } else { "fcmp.d" }
+    TrapIf(cond, trap_code) => "trap_if.\{cond} #\{trap_code}"
+    FcvtToInt(is_f32, is_i64, is_signed) => {
+      let src = if is_f32 { "f32" } else { "f64" }
+      let dst = if is_i64 { "i64" } else { "i32" }
+      let sign = if is_signed { "s" } else { "u" }
+      "fcvt.\{src}_\{dst}_\{sign}"
+    }
+    FpuSel(is_f32, cond) =>
+      if is_f32 {
+        "fcsel.s.\{cond}"
+      } else {
+        "fcsel.d.\{cond}"
+      }
+    FpuMaxnm(is_f32) => if is_f32 { "fmaxnm.s" } else { "fmaxnm.d" }
+    FpuMinnm(is_f32) => if is_f32 { "fminnm.s" } else { "fminnm.d" }
     BoundsCheck(offset, size) => "bounds_check +\{offset}, \{size}"
     // AArch64-specific
     AddShifted(shift, amount) => "add.\{shift} #\{amount}"
@@ -590,6 +645,75 @@ fn IntToFloatKind::to_string(self : IntToFloatKind) -> String {
 ///|
 pub impl Show for IntToFloatKind with output(self, logger) {
   logger.write_string(self.to_string())
+}
+
+///|
+/// AArch64 condition codes (for conditional branches and traps)
+/// Following Cranelift's Cond enum
+pub(all) enum Cond {
+  Eq // Equal (Z=1)
+  Ne // Not equal (Z=0)
+  Hs // Unsigned higher or same (C=1), also known as CS
+  Lo // Unsigned lower (C=0), also known as CC
+  Mi // Minus/negative (N=1)
+  Pl // Plus/positive or zero (N=0)
+  Vs // Overflow (V=1) - used for NaN check in float compare
+  Vc // No overflow (V=0)
+  Hi // Unsigned higher (C=1 && Z=0)
+  Ls // Unsigned lower or same (C=0 || Z=1)
+  Ge // Signed greater or equal (N=V)
+  Lt // Signed less than (N!=V)
+  Gt // Signed greater than (Z=0 && N=V)
+  Le // Signed less or equal (Z=1 || N!=V)
+  Al // Always (unconditional)
+}
+
+///|
+fn Cond::to_string(self : Cond) -> String {
+  match self {
+    Eq => "eq"
+    Ne => "ne"
+    Hs => "hs"
+    Lo => "lo"
+    Mi => "mi"
+    Pl => "pl"
+    Vs => "vs"
+    Vc => "vc"
+    Hi => "hi"
+    Ls => "ls"
+    Ge => "ge"
+    Lt => "lt"
+    Gt => "gt"
+    Le => "le"
+    Al => "al"
+  }
+}
+
+///|
+pub impl Show for Cond with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+///|
+/// Get the condition code value for AArch64 encoding
+pub fn Cond::to_bits(self : Cond) -> Int {
+  match self {
+    Eq => 0
+    Ne => 1
+    Hs => 2
+    Lo => 3
+    Mi => 4
+    Pl => 5
+    Vs => 6
+    Vc => 7
+    Hi => 8
+    Ls => 9
+    Ge => 10
+    Lt => 11
+    Gt => 12
+    Le => 13
+    Al => 14
+  }
 }
 
 ///|

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -24,6 +24,26 @@ pub(all) enum CmpKind {
 }
 pub impl Show for CmpKind
 
+pub(all) enum Cond {
+  Eq
+  Ne
+  Hs
+  Lo
+  Mi
+  Pl
+  Vs
+  Vc
+  Hi
+  Ls
+  Ge
+  Lt
+  Gt
+  Le
+  Al
+}
+pub fn Cond::to_bits(Self) -> Int
+pub impl Show for Cond
+
 pub(all) enum ExtendKind {
   Signed8To32
   Signed8To64
@@ -170,6 +190,12 @@ pub(all) enum VCodeOpcode {
   Rbit
   Nop
   TrapIfUgt(Int)
+  FpuCmp(Bool)
+  TrapIf(Cond, Int)
+  FcvtToInt(Bool, Bool, Bool)
+  FpuSel(Bool, Cond)
+  FpuMaxnm(Bool)
+  FpuMinnm(Bool)
   BoundsCheck(Int, Int)
   AddShifted(ShiftType, Int)
   SubShifted(ShiftType, Int)

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -1494,67 +1494,170 @@ fn lower_truncate(
 }
 
 ///|
-/// Lower float to int conversion
+/// Lower float to int conversion (trapping version)
+/// Cranelift-style lowering: expand to multiple primitive instructions
+///
+/// Generated sequence:
+/// 1. FpuCmp(src, src) - compare with self to check for NaN
+/// 2. TrapIf(Vs, 3) - trap if NaN (V flag set for unordered)
+/// 3. tmp_min = LoadConstF32/F64(min_bound)
+/// 4. FpuCmp(src, tmp_min) - compare with minimum
+/// 5. TrapIf(Le/Lt, 3) - trap if underflow
+/// 6. tmp_max = LoadConstF32/F64(max_bound)
+/// 7. FpuCmp(src, tmp_max) - compare with maximum
+/// 8. TrapIf(Ge, 3) - trap if overflow
+/// 9. dst = FcvtToInt(src) - raw conversion
 fn lower_float_to_int(
   ctx : LoweringContext,
   inst : @ir.Inst,
   block : @block.VCodeBlock,
   signed~ : Bool,
 ) -> Unit {
-  if inst.result is Some(result) {
-    let dst = ctx.get_vreg(result)
-    let src = ctx.get_vreg_for_use(inst.operands[0], block)
-    // Determine conversion kind based on source/dest types and signedness
-    let src_ty = inst.operands[0].ty
-    let dst_ty = result.ty
-    let kind : @instr.FloatToIntKind = match (src_ty, dst_ty, signed) {
-      (@ir.Type::F32, @ir.Type::I32, true) => F32ToI32S
-      (@ir.Type::F32, @ir.Type::I32, false) => F32ToI32U
-      (@ir.Type::F32, @ir.Type::I64, true) => F32ToI64S
-      (@ir.Type::F32, @ir.Type::I64, false) => F32ToI64U
-      (@ir.Type::F64, @ir.Type::I32, true) => F64ToI32S
-      (@ir.Type::F64, @ir.Type::I32, false) => F64ToI32U
-      (@ir.Type::F64, @ir.Type::I64, true) => F64ToI64S
-      (@ir.Type::F64, @ir.Type::I64, false) => F64ToI64U
-      _ => F64ToI64S // Default fallback
-    }
-    let vcode_inst = @instr.VCodeInst::new(FloatToInt(kind))
-    vcode_inst.add_def({ reg: Virtual(dst) })
-    vcode_inst.add_use(Virtual(src))
-    block.add_inst(vcode_inst)
+  guard inst.result is Some(result) else { return }
+  let dst = ctx.get_vreg(result)
+  let src = ctx.get_vreg_for_use(inst.operands[0], block)
+  let src_ty = inst.operands[0].ty
+  let dst_ty = result.ty
+  let is_f32 = src_ty is @ir.Type::F32
+  let is_i64 = dst_ty is @ir.Type::I64
+  let float_class : @abi.RegClass = if is_f32 { Float32 } else { Float64 }
+
+  // Step 1: NaN check - FpuCmp(src, src)
+  // NaN != NaN sets V flag (unordered)
+  let nan_check = @instr.VCodeInst::new(FpuCmp(is_f32))
+  nan_check.add_use(Virtual(src))
+  nan_check.add_use(Virtual(src))
+  block.add_inst(nan_check)
+
+  // Step 2: TrapIf(Vs) - trap if NaN
+  let trap_nan = @instr.VCodeInst::new(TrapIf(@instr.Vs, 3))
+  block.add_inst(trap_nan)
+
+  // Get bounds based on conversion type
+  let (min_bits, max_bits, use_le_for_min) = get_float_to_int_bounds(
+    is_f32, is_i64, signed,
+  )
+
+  // Step 3: Load minimum bound
+  let tmp_min = ctx.vcode_func.new_vreg(float_class)
+  let load_min = if is_f32 {
+    @instr.VCodeInst::new(LoadConstF32(min_bits.to_int()))
+  } else {
+    @instr.VCodeInst::new(LoadConstF64(min_bits))
+  }
+  load_min.add_def({ reg: Virtual(tmp_min) })
+  block.add_inst(load_min)
+
+  // Step 4: FpuCmp(src, tmp_min)
+  let cmp_min = @instr.VCodeInst::new(FpuCmp(is_f32))
+  cmp_min.add_use(Virtual(src))
+  cmp_min.add_use(Virtual(tmp_min))
+  block.add_inst(cmp_min)
+
+  // Step 5: TrapIf for underflow
+  // For signed: trap if src < min (Lt)
+  // For unsigned: trap if src <= -1.0 (Le)
+  let trap_min_cond = if use_le_for_min {
+    @instr.Cond::Le
+  } else {
+    @instr.Cond::Lt
+  }
+  let trap_min = @instr.VCodeInst::new(TrapIf(trap_min_cond, 3))
+  block.add_inst(trap_min)
+
+  // Step 6: Load maximum bound
+  let tmp_max = ctx.vcode_func.new_vreg(float_class)
+  let load_max = if is_f32 {
+    @instr.VCodeInst::new(LoadConstF32(max_bits.to_int()))
+  } else {
+    @instr.VCodeInst::new(LoadConstF64(max_bits))
+  }
+  load_max.add_def({ reg: Virtual(tmp_max) })
+  block.add_inst(load_max)
+
+  // Step 7: FpuCmp(src, tmp_max)
+  let cmp_max = @instr.VCodeInst::new(FpuCmp(is_f32))
+  cmp_max.add_use(Virtual(src))
+  cmp_max.add_use(Virtual(tmp_max))
+  block.add_inst(cmp_max)
+
+  // Step 8: TrapIf(Ge) for overflow - trap if src >= max
+  let trap_max = @instr.VCodeInst::new(TrapIf(@instr.Cond::Ge, 3))
+  block.add_inst(trap_max)
+
+  // Step 9: FcvtToInt - raw conversion (no checks)
+  let fcvt = @instr.VCodeInst::new(FcvtToInt(is_f32, is_i64, signed))
+  fcvt.add_def({ reg: Virtual(dst) })
+  fcvt.add_use(Virtual(src))
+  block.add_inst(fcvt)
+}
+
+///|
+/// Get bounds for float-to-int conversion
+/// Returns (min_bits, max_bits, use_le_for_min)
+/// - min_bits: bit representation of minimum bound
+/// - max_bits: bit representation of maximum bound
+/// - use_le_for_min: true if should use Le (<=) for underflow check, false for Lt (<)
+fn get_float_to_int_bounds(
+  is_f32 : Bool,
+  is_i64 : Bool,
+  signed : Bool,
+) -> (Int64, Int64, Bool) {
+  match (is_f32, is_i64, signed) {
+    // F32 conversions
+    (true, false, true) =>
+      // F32ToI32S: min = -2^31 = 0xCF000000, max = 2^31 = 0x4F000000
+      (0xCF000000L, 0x4F000000L, false)
+    (true, false, false) =>
+      // F32ToI32U: min = -1.0 = 0xBF800000 (trap if <= -1), max = 2^32 = 0x4F800000
+      (0xBF800000L, 0x4F800000L, true)
+    (true, true, true) =>
+      // F32ToI64S: min = -2^63 = 0xDF000000, max = 2^63 = 0x5F000000
+      (0xDF000000L, 0x5F000000L, false)
+    (true, true, false) =>
+      // F32ToI64U: min = -1.0 = 0xBF800000 (trap if <= -1), max = 2^64 = 0x5F800000
+      (0xBF800000L, 0x5F800000L, true)
+    // F64 conversions
+    (false, false, true) =>
+      // F64ToI32S: min = -2^31-1 = 0xC1E0000000200000, max = 2^31 = 0x41E0000000000000
+      (0xC1E0000000200000L, 0x41E0000000000000L, true)
+    (false, false, false) =>
+      // F64ToI32U: min = -1.0 = 0xBFF0000000000000 (trap if <= -1), max = 2^32 = 0x41F0000000000000
+      (0xBFF0000000000000L, 0x41F0000000000000L, true)
+    (false, true, true) =>
+      // F64ToI64S: min = -2^63 = 0xC3E0000000000000, max = 2^63 = 0x43E0000000000000
+      (0xC3E0000000000000L, 0x43E0000000000000L, false)
+    (false, true, false) =>
+      // F64ToI64U: min = -1.0 = 0xBFF0000000000000 (trap if <= -1), max = 2^64 = 0x43F0000000000000
+      (0xBFF0000000000000L, 0x43F0000000000000L, true)
   }
 }
 
 ///|
 /// Lower saturating float to int conversion
+/// AArch64 FCVTZS/FCVTZU already handles saturation correctly:
+/// - NaN → 0
+/// - Overflow → clamp to min/max
+/// So we just emit a single FcvtToInt instruction.
 fn lower_float_to_int_sat(
   ctx : LoweringContext,
   inst : @ir.Inst,
   block : @block.VCodeBlock,
   signed~ : Bool,
 ) -> Unit {
-  if inst.result is Some(result) {
-    let dst = ctx.get_vreg(result)
-    let src = ctx.get_vreg_for_use(inst.operands[0], block)
-    // Determine conversion kind based on source/dest types and signedness
-    let src_ty = inst.operands[0].ty
-    let dst_ty = result.ty
-    let kind : @instr.FloatToIntKind = match (src_ty, dst_ty, signed) {
-      (@ir.Type::F32, @ir.Type::I32, true) => F32ToI32SSat
-      (@ir.Type::F32, @ir.Type::I32, false) => F32ToI32USat
-      (@ir.Type::F32, @ir.Type::I64, true) => F32ToI64SSat
-      (@ir.Type::F32, @ir.Type::I64, false) => F32ToI64USat
-      (@ir.Type::F64, @ir.Type::I32, true) => F64ToI32SSat
-      (@ir.Type::F64, @ir.Type::I32, false) => F64ToI32USat
-      (@ir.Type::F64, @ir.Type::I64, true) => F64ToI64SSat
-      (@ir.Type::F64, @ir.Type::I64, false) => F64ToI64USat
-      _ => F64ToI64SSat // Default fallback
-    }
-    let vcode_inst = @instr.VCodeInst::new(FloatToInt(kind))
-    vcode_inst.add_def({ reg: Virtual(dst) })
-    vcode_inst.add_use(Virtual(src))
-    block.add_inst(vcode_inst)
-  }
+  guard inst.result is Some(result) else { return }
+  let dst = ctx.get_vreg(result)
+  let src = ctx.get_vreg_for_use(inst.operands[0], block)
+  let src_ty = inst.operands[0].ty
+  let dst_ty = result.ty
+  let is_f32 = src_ty is @ir.Type::F32
+  let is_i64 = dst_ty is @ir.Type::I64
+
+  // AArch64 FCVTZS/FCVTZU already implements WebAssembly saturating semantics
+  let fcvt = @instr.VCodeInst::new(FcvtToInt(is_f32, is_i64, signed))
+  fcvt.add_def({ reg: Virtual(dst) })
+  fcvt.add_use(Virtual(src))
+  block.add_inst(fcvt)
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Move float-to-int conversion logic from emit phase to lower phase (Cranelift-style)
- Trapping conversions expand to: FpuCmp + TrapIf + LoadConst + FpuCmp + TrapIf + FcvtToInt
- Saturating conversions simplified to single FcvtToInt (AArch64 handles saturation natively)
- Eliminates hardcoded X16/S16/S17 register usage in emit phase
- ~300 lines removed from codegen.mbt

## New VCode opcodes
- `FpuCmp(Bool)`: FCMP sets NZCV flags
- `TrapIf(Cond, Int)`: Conditional trap based on flags
- `FcvtToInt(Bool, Bool, Bool)`: Raw FCVTZS/FCVTZU
- `FpuSel(Bool, Cond)`: FCSEL conditional select
- `FpuMaxnm(Bool)`: FMAXNM NaN-propagating max
- `FpuMinnm(Bool)`: FMINNM NaN-propagating min
- `Cond` enum for AArch64 condition codes

## Test plan
- [x] `moon test` - 852/852 passed
- [x] `conversions.wast` - 618/618 passed
- [x] `f32.wast` - 2513/2513 passed
- [x] `f64.wast` - 2513/2513 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)