### PR TITLE
fix(jit): correct type handling for global variables

### DIFF
--- a/main/run.mbt
+++ b/main/run.mbt
@@ -508,6 +508,7 @@ fn init_jit_globals(
     let global_inst = store.globals[global_addr]
     let value = global_inst.get()
     // Convert value to Int64 for storage
+    // Note: -1L is used as null sentinel in JIT
     let raw_value = match value {
       I32(n) => n.to_int64()
       I64(n) => n
@@ -515,7 +516,7 @@ fn init_jit_globals(
       F64(d) => d.reinterpret_as_int64()
       FuncRef(idx) => idx.to_int64()
       ExternRef(idx) => idx.to_int64()
-      Null => 0L
+      Null => -1L // null sentinel
     }
     // Write value at offset i * 16
     let offset = globals_ptr + (i * 16).to_int64()

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -111,7 +111,8 @@ fn ir_type_to_mem_type(ty : @ir.Type) -> @instr.MemType {
     @ir.Type::I64 => I64
     @ir.Type::F32 => F32
     @ir.Type::F64 => F64
-    _ => I32 // Fallback
+    // Reference types use 64-bit storage (-1L as null sentinel)
+    @ir.Type::FuncRef | @ir.Type::ExternRef => I64
   }
 }
 
@@ -2294,7 +2295,8 @@ fn lower_global_get(
   // Step 2: Load global value from globals array
   // Each global is 16 bytes (value + type tag)
   let offset = global_idx * 16
-  let load_value = @instr.VCodeInst::new(LoadPtr(@instr.I64, offset))
+  let mem_ty = ir_type_to_mem_type(result.ty)
+  let load_value = @instr.VCodeInst::new(LoadPtr(mem_ty, offset))
   load_value.add_use(Virtual(globals_ptr))
   load_value.add_def({ reg: Virtual(result_vreg) })
   block.add_inst(load_value)
@@ -2334,7 +2336,8 @@ fn lower_global_set(
   // Step 2: Store global value to globals array
   // Each global is 16 bytes (value + type tag)
   let offset = global_idx * 16
-  let store_value = @instr.VCodeInst::new(StorePtr(@instr.I64, offset))
+  let mem_ty = ir_type_to_mem_type(inst.operands[0].ty)
+  let store_value = @instr.VCodeInst::new(StorePtr(mem_ty, offset))
   store_value.add_use(Virtual(globals_ptr)) // base address
   store_value.add_use(Virtual(value)) // value to store
   block.add_inst(store_value)


### PR DESCRIPTION
## Summary
- Fix `lower_global_get`/`lower_global_set` to use correct MemType based on value type instead of always using I64
- Fix null reference storage in `init_jit_globals` to use -1L sentinel instead of 0L
- Add FuncRef/ExternRef handling to `ir_type_to_mem_type` as I64 (for proper null sentinel detection)

## Problem
`global.wast` had 10 failures:
- 8 failures: f32/f64 globals returning garbage values (loaded as 64-bit instead of proper float type)
- 2 failures: externref null globals returning `ExternRef(-1)` instead of `Null`

## Test plan
- [x] `global.wast`: 114/114 passed (was 104/114)
- [x] `f32.wast`: 2513/2513 passed
- [x] `f64.wast`: 2513/2513 passed
- [x] `conversions.wast`: 618/618 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)