### PR TITLE
refactor(regalloc): use CallType enum for call identification

### DIFF
--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -20,14 +20,9 @@ fn collect_used_callee_saved(
   for block in func.blocks {
     for inst in block.insts {
       // Check if this instruction is a function call
-      // MemoryGrow, MemorySize, MemoryFill, and MemoryCopy also use BLR internally to call C functions
-      if inst.opcode
-        is (CallIndirect(_, _)
-        | CallPtr(_, _)
-        | MemoryGrow(_)
-        | MemorySize
-        | MemoryFill
-        | MemoryCopy) {
+      // Following Cranelift's design: use call_type() to determine if an instruction
+      // behaves like a call (clobbers caller-saved registers)
+      if inst.opcode.call_type() is @instr.Regular {
         has_calls = true
       }
       for def in inst.defs {

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -1,4 +1,13 @@
 ///|
+/// Call type - classifies instructions that behave like calls
+/// Following Cranelift's CallType enum
+pub(all) enum CallType {
+  None // Not a call instruction
+  Regular // Regular call that returns to caller
+  TailCall // Tail call that doesn't return to caller
+}
+
+///|
 /// VCode instruction - a machine-level instruction with virtual registers
 /// Following Cranelift's design with operand constraints for fixed register allocation
 pub(all) struct VCodeInst {
@@ -772,6 +781,21 @@ fn VCodeTerminator::to_string(self : VCodeTerminator) -> String {
 ///|
 pub impl Show for VCodeTerminator with output(self, logger) {
   logger.write_string(self.to_string())
+}
+
+///|
+/// Get the call type for this opcode
+/// Following Cranelift's design: instructions that clobber caller-saved registers
+/// are classified as calls for register allocation purposes
+pub fn VCodeOpcode::call_type(self : VCodeOpcode) -> CallType {
+  match self {
+    // Direct and indirect function calls
+    CallIndirect(_, _) | CallPtr(_, _) => Regular
+    // Memory operations that call C runtime functions
+    MemoryGrow(_) | MemorySize | MemoryFill | MemoryCopy => Regular
+    // Everything else is not a call
+    _ => None
+  }
 }
 
 ///|

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -10,6 +10,12 @@ import(
 // Errors
 
 // Types and methods
+pub(all) enum CallType {
+  None
+  Regular
+  TailCall
+}
+
 pub(all) enum CmpKind {
   Eq
   Ne
@@ -220,6 +226,7 @@ pub(all) enum VCodeOpcode {
   AdjustSP(Int)
   StoreToStack(Int)
 }
+pub fn VCodeOpcode::call_type(Self) -> CallType
 pub impl Show for VCodeOpcode
 
 pub(all) enum VCodeTerminator {

--- a/vcode/lower/regalloc.mbt
+++ b/vcode/lower/regalloc.mbt
@@ -338,8 +338,9 @@ fn collect_defs_uses(func : VCodeFunction, result : LivenessResult) -> Unit {
     // Process instructions
     for inst_idx, inst in block.insts {
       // Record call points for caller-saved register handling
-      // Both CallIndirect and CallPtr clobber caller-saved registers
-      if inst.opcode is (CallIndirect(_, _) | CallPtr(_, _)) {
+      // Following Cranelift's design: use call_type() to determine if an instruction
+      // behaves like a call (clobbers caller-saved registers)
+      if inst.opcode.call_type() is @instr.Regular {
         result.call_points.push({ block: block_idx, inst: inst_idx, pos: After })
       }
 
@@ -1573,6 +1574,8 @@ fn has_side_effects(opcode : @instr.VCodeOpcode) -> Bool {
     TypeCheckIndirect(_) => true
     // Function calls have side effects
     CallIndirect(_, _) | CallPtr(_, _) => true
+    // Memory operations have side effects (modify memory or global state)
+    MemoryGrow(_) | MemoryFill | MemoryCopy => true
     // Everything else is pure computation
     _ => false
   }


### PR DESCRIPTION
## Summary

- Add `CallType` enum following Cranelift's design pattern for classifying instructions that clobber caller-saved registers
- Add `VCodeOpcode::call_type()` method to replace hardcoded opcode matching
- Update liveness analysis and codegen to use the new method

This fixes `memory_grow.wast` test failures (9 failures → 0) where values across `memory.grow` calls were incorrectly allocated to caller-saved registers.

## Test plan

- [x] `moon test` passes (861/861)
- [x] `memory_grow.wast` passes (96/96)
- [x] `linking.wast` passes (133/133)
- [x] `call.wast` passes (90/90)
- [x] `call_indirect.wast` passes (169/169)

🤖 Generated with [Claude Code](https://claude.com/claude-code)