### PR TITLE
fix(codegen): use 32-bit ADD/MUL instructions for i32 operations

### DIFF
--- a/testsuite/i32_mul_test.mbt
+++ b/testsuite/i32_mul_test.mbt
@@ -50,7 +50,7 @@ test "i32 mul" {
       #|vcode test(v0:int, v1:int, v2:int) -> int {
       #|block0:
       #|    v3 = ldi 3
-      #|    v4 = mul v2, v3
+      #|    v4 = mul32 v2, v3
       #|    ret v4
       #|}
       #|
@@ -63,7 +63,7 @@ test "i32 mul" {
       #|vcode test(v0:int, v1:int, v2:int) -> int {
       #|block0:
       #|    x8 = ldi 3
-      #|    x9 = mul x2, x8
+      #|    x9 = mul32 x2, x8
       #|    ret x9
       #|}
       #|
@@ -80,7 +80,7 @@ test "i32 mul" {
       #|  0010: f30300aa  mov x19, x0
       #|block0:
       #|  0014: 680080d2  movz x8, #3, lsl #0
-      #|  0018: 497c089b  mul x9, x2, x8
+      #|  0018: 497c081b  mul w9, w2, w8
       #|  001c: e00309aa  mov x0, x9
       #|  0020: ff430091  add sp, sp, #16
       #|  0024: f30741f8  ldr x19, [sp], #16

--- a/vcode/builder.mbt
+++ b/vcode/builder.mbt
@@ -79,9 +79,10 @@ pub fn VCodeBuilder::add(
   self : VCodeBuilder,
   a : @abi.VReg,
   b : @abi.VReg,
+  is_64? : Bool = true,
 ) -> @abi.VReg {
   let result = self.new_vreg(Int)
-  let inst = @instr.VCodeInst::new(Add)
+  let inst = @instr.VCodeInst::new(Add(is_64))
   inst.add_def({ reg: Virtual(result) })
   inst.add_use(Virtual(a))
   inst.add_use(Virtual(b))
@@ -110,9 +111,10 @@ pub fn VCodeBuilder::mul(
   self : VCodeBuilder,
   a : @abi.VReg,
   b : @abi.VReg,
+  is_64? : Bool = true,
 ) -> @abi.VReg {
   let result = self.new_vreg(Int)
-  let inst = @instr.VCodeInst::new(Mul)
+  let inst = @instr.VCodeInst::new(Mul(is_64))
   inst.add_def({ reg: Virtual(result) })
   inst.add_use(Virtual(a))
   inst.add_use(Virtual(b))

--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -326,16 +326,24 @@ fn MachineCode::emit_instruction(
   let spill_base_offset = stack_frame.spill_offset
   let frame_size = stack_frame.total_size
   match inst.opcode {
-    Add => {
+    Add(is_64) => {
       let rd = wreg_num(inst.defs[0])
       let rn = reg_num(inst.uses[0])
       let rm = reg_num(inst.uses[1])
-      self.emit_add_reg(rd, rn, rm)
+      if is_64 {
+        self.emit_add_reg(rd, rn, rm)
+      } else {
+        self.emit_add_reg32(rd, rn, rm)
+      }
     }
-    AddImm(imm) => {
+    AddImm(imm, is_64) => {
       let rd = wreg_num(inst.defs[0])
       let rn = reg_num(inst.uses[0])
-      self.emit_add_imm(rd, rn, imm)
+      if is_64 {
+        self.emit_add_imm(rd, rn, imm)
+      } else {
+        self.emit_add_imm32(rd, rn, imm)
+      }
     }
     Sub(is_64) => {
       let rd = wreg_num(inst.defs[0])
@@ -347,11 +355,15 @@ fn MachineCode::emit_instruction(
         self.emit_sub_reg32(rd, rn, rm)
       }
     }
-    Mul => {
+    Mul(is_64) => {
       let rd = wreg_num(inst.defs[0])
       let rn = reg_num(inst.uses[0])
       let rm = reg_num(inst.uses[1])
-      self.emit_mul(rd, rn, rm)
+      if is_64 {
+        self.emit_mul(rd, rn, rm)
+      } else {
+        self.emit_mul32(rd, rn, rm)
+      }
     }
     SDiv(is_64) => {
       let rd = wreg_num(inst.defs[0])

--- a/vcode/emit/disasm_wbtest.mbt
+++ b/vcode/emit/disasm_wbtest.mbt
@@ -647,6 +647,9 @@ test "32-bit instruction variants" {
   mc.emit_sdiv32(0, 1, 2) // SDIV W0, W1, W2
   mc.emit_udiv32(3, 4, 5) // UDIV W3, W4, W5
   mc.emit_sub_reg32(6, 7, 8) // SUB W6, W7, W8
+  mc.emit_add_reg32(0, 1, 2) // ADD W0, W1, W2
+  mc.emit_add_imm32(3, 4, 100) // ADD W3, W4, #100
+  mc.emit_mul32(5, 6, 7) // MUL W5, W6, W7
 
   // 32-bit shifts
   mc.emit_lsl_reg32(9, 10, 11) // LSL W9, W10, W11
@@ -671,15 +674,18 @@ test "32-bit instruction variants" {
       #|  0000: 200cc21a  sdiv w0, w1, w2
       #|  0004: 8308c51a  udiv w3, w4, w5
       #|  0008: e600084b  sub w6, w7, w8
-      #|  000c: 4921cb1a  lsl w9, w10, w11
-      #|  0010: ac25ce1a  lsr w12, w13, w14
-      #|  0014: 0f2ad11a  asr w15, w16, w17
-      #|  0018: 722ed41a  ror w18, w19, w20
-      #|  001c: d512c05a  clz w21, w22
-      #|  0020: 1703c05a  rbit w23, w24
-      #|  0024: 3f031a6b  cmp w25, w26
-      #|  0028: 7fab0071  cmp w27, #42
-      #|  002c: fc031d2a  mov w28, w29
+      #|  000c: 2000020b  add w0, w1, w2
+      #|  0010: 83900111  add w3, w4, #100
+      #|  0014: c57c071b  mul w5, w6, w7
+      #|  0018: 4921cb1a  lsl w9, w10, w11
+      #|  001c: ac25ce1a  lsr w12, w13, w14
+      #|  0020: 0f2ad11a  asr w15, w16, w17
+      #|  0024: 722ed41a  ror w18, w19, w20
+      #|  0028: d512c05a  clz w21, w22
+      #|  002c: 1703c05a  rbit w23, w24
+      #|  0030: 3f031a6b  cmp w25, w26
+      #|  0034: 7fab0071  cmp w27, #42
+      #|  0038: fc031d2a  mov w28, w29
       #|
     ),
   )

--- a/vcode/emit/instructions.mbt
+++ b/vcode/emit/instructions.mbt
@@ -35,6 +35,9 @@ enum Instruction {
   Sdiv32(Int, Int, Int) // 32-bit signed divide
   Udiv32(Int, Int, Int) // 32-bit unsigned divide
   SubReg32(Int, Int, Int) // 32-bit subtract
+  AddReg32(Int, Int, Int) // 32-bit add
+  AddImm32(Int, Int, Int) // 32-bit add immediate
+  Mul32(Int, Int, Int) // 32-bit multiply
   // Bitwise - Register
   AndReg(Int, Int, Int)
   AndShifted(Int, Int, Int, @instr.ShiftType, Int)
@@ -240,6 +243,9 @@ fn Instruction::annotate(self : Instruction) -> String {
     Sdiv32(rd, rn, rm) => "sdiv w\{rd}, w\{rn}, w\{rm}"
     Udiv32(rd, rn, rm) => "udiv w\{rd}, w\{rn}, w\{rm}"
     SubReg32(rd, rn, rm) => "sub w\{rd}, w\{rn}, w\{rm}"
+    AddReg32(rd, rn, rm) => "add w\{rd}, w\{rn}, w\{rm}"
+    AddImm32(rd, rn, imm) => "add w\{rd}, w\{rn}, #\{imm}"
+    Mul32(rd, rn, rm) => "mul w\{rd}, w\{rn}, w\{rm}"
     AndReg(rd, rn, rm) => "and x\{rd}, x\{rn}, x\{rm}"
     AndShifted(rd, rn, rm, shift, amount) => {
       let shift_name = match shift {
@@ -627,6 +633,29 @@ fn Instruction::instr_bytes(self : Instruction) -> (Int, Int, Int, Int) {
       let b1 = (rn >> 3) & 3
       let b2 = rm & 31
       let b3 = 0x4B // SUB 32-bit: sf=0
+      (b0, b1, b2, b3)
+    }
+    AddReg32(rd, rn, rm) => {
+      let b0 = (rd & 31) | ((rn & 7) << 5)
+      let b1 = (rn >> 3) & 3
+      let b2 = rm & 31
+      let b3 = 0x0B // ADD 32-bit: sf=0
+      (b0, b1, b2, b3)
+    }
+    AddImm32(rd, rn, imm) => {
+      // ADD Wd, Wn, #imm (32-bit)
+      let b0 = (rd & 31) | ((rn & 7) << 5)
+      let b1 = ((rn >> 3) & 3) | ((imm & 0x3F) << 2)
+      let b2 = (imm >> 6) & 0x3F
+      let b3 = 0x11 // ADD imm 32-bit: sf=0
+      (b0, b1, b2, b3)
+    }
+    Mul32(rd, rn, rm) => {
+      // MUL Wd, Wn, Wm (32-bit) = MADD Wd, Wn, Wm, WZR
+      let b0 = (rd & 31) | ((rn & 7) << 5)
+      let b1 = ((rn >> 3) & 3) | (0x1F << 2) // ra = 31 (WZR)
+      let b2 = (rm & 31) | (0 << 5)
+      let b3 = 0x1B // MADD 32-bit: sf=0
       (b0, b1, b2, b3)
     }
     AndReg(rd, rn, rm) => {
@@ -2047,6 +2076,36 @@ pub fn MachineCode::emit_sub_reg32(
   rm : Int,
 ) -> Unit {
   SubReg32(rd, rn, rm).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_add_reg32(
+  self : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+) -> Unit {
+  AddReg32(rd, rn, rm).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_add_imm32(
+  self : MachineCode,
+  rd : Int,
+  rn : Int,
+  imm : Int,
+) -> Unit {
+  AddImm32(rd, rn, imm).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_mul32(
+  self : MachineCode,
+  rd : Int,
+  rn : Int,
+  rm : Int,
+) -> Unit {
+  Mul32(rd, rn, rm).emit(self)
 }
 
 ///|

--- a/vcode/emit/pkg.generated.mbti
+++ b/vcode/emit/pkg.generated.mbti
@@ -89,7 +89,9 @@ pub fn MachineCode::current_pos(Self) -> Int
 pub fn MachineCode::define_label(Self, Int) -> Unit
 pub fn MachineCode::dump_disasm(Self) -> String
 pub fn MachineCode::emit_add_imm(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_add_imm32(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_add_reg(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_add_reg32(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_add_shifted(Self, Int, Int, Int, @instr.ShiftType, Int) -> Unit
 pub fn MachineCode::emit_addv_b(Self, Int, Int) -> Unit
 pub fn MachineCode::emit_adr(Self, Int, Int) -> Unit
@@ -194,6 +196,7 @@ pub fn MachineCode::emit_movk(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_movz(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_msub(Self, Int, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_mul(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_mul32(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_mvn(Self, Int, Int) -> Unit
 pub fn MachineCode::emit_nop(Self) -> Unit
 pub fn MachineCode::emit_orr_reg(Self, Int, Int, Int) -> Unit

--- a/vcode/emit_wbtest.mbt
+++ b/vcode/emit_wbtest.mbt
@@ -150,7 +150,7 @@ test "emit: full function" {
   let block = func.new_block()
 
   // X0 = X0 + X1 (assuming params in X0, X1)
-  let add_inst = @instr.VCodeInst::new(Add)
+  let add_inst = @instr.VCodeInst::new(Add(true))
   add_inst.add_def({ reg: @abi.Physical({ index: 0, class: Int }) })
   add_inst.add_use(@abi.Physical({ index: 0, class: Int }))
   add_inst.add_use(@abi.Physical({ index: 1, class: Int }))
@@ -577,14 +577,14 @@ test "emit: complete VCode instruction emission" {
   block.add_inst(ldi)
 
   // Add
-  let add = @instr.VCodeInst::new(Add)
+  let add = @instr.VCodeInst::new(Add(true))
   add.add_def({ reg: @abi.Physical({ index: 1, class: Int }) })
   add.add_use(@abi.Physical({ index: 0, class: Int }))
   add.add_use(@abi.Physical({ index: 0, class: Int }))
   block.add_inst(add)
 
   // Mul
-  let mul = @instr.VCodeInst::new(Mul)
+  let mul = @instr.VCodeInst::new(Mul(true))
   mul.add_def({ reg: @abi.Physical({ index: 2, class: Int }) })
   mul.add_use(@abi.Physical({ index: 1, class: Int }))
   mul.add_use(@abi.Physical({ index: 0, class: Int }))

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -105,10 +105,10 @@ pub impl Show for VCodeInst with output(self, logger) {
 /// VCode opcode - machine-level operation (target-independent subset)
 pub(all) enum VCodeOpcode {
   // Integer arithmetic (Bool = true for 64-bit, false for 32-bit)
-  Add
-  AddImm(Int) // ADD Xd, Xn, #imm (immediate add)
+  Add(Bool) // ADD with size: true = 64-bit, false = 32-bit
+  AddImm(Int, Bool) // ADD Xd, Xn, #imm with size: true = 64-bit, false = 32-bit
   Sub(Bool) // SUB with size: true = 64-bit, false = 32-bit
-  Mul
+  Mul(Bool) // MUL with size: true = 64-bit, false = 32-bit
   SDiv(Bool) // SDIV with size: true = 64-bit, false = 32-bit
   UDiv(Bool) // UDIV with size: true = 64-bit, false = 32-bit
   // Bitwise operations (Bool = true for 64-bit, false for 32-bit)
@@ -315,10 +315,10 @@ pub(all) enum VCodeOpcode {
 ///|
 fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
   match self {
-    Add => "add"
-    AddImm(imm) => "add #\{imm}"
+    Add(is_64) => if is_64 { "add" } else { "add32" }
+    AddImm(imm, is_64) => if is_64 { "add #\{imm}" } else { "add32 #\{imm}" }
     Sub(is_64) => if is_64 { "sub" } else { "sub32" }
-    Mul => "mul"
+    Mul(is_64) => if is_64 { "mul" } else { "mul32" }
     SDiv(is_64) => if is_64 { "sdiv" } else { "sdiv32" }
     UDiv(is_64) => if is_64 { "udiv" } else { "udiv32" }
     And => "and"

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -138,10 +138,10 @@ pub fn VCodeInst::new(VCodeOpcode) -> Self
 pub impl Show for VCodeInst
 
 pub(all) enum VCodeOpcode {
-  Add
-  AddImm(Int)
+  Add(Bool)
+  AddImm(Int, Bool)
   Sub(Bool)
-  Mul
+  Mul(Bool)
   SDiv(Bool)
   UDiv(Bool)
   And

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -284,7 +284,7 @@ fn lower_inst(
     // Integer arithmetic - with pattern matching for AArch64
     @ir.Opcode::Iadd => lower_iadd(ctx, inst, block)
     @ir.Opcode::Isub => lower_isub(ctx, inst, block)
-    @ir.Opcode::Imul => lower_binary_int(ctx, inst, block, Mul)
+    @ir.Opcode::Imul => lower_imul(ctx, inst, block)
     @ir.Opcode::Sdiv => lower_div(ctx, inst, block, signed=true)
     @ir.Opcode::Udiv => lower_div(ctx, inst, block, signed=false)
     @ir.Opcode::Srem => lower_rem(ctx, inst, block, true)
@@ -631,7 +631,27 @@ fn lower_iadd(
   // Default: regular add
   let lhs = ctx.get_vreg_for_use(lhs_val, block)
   let rhs = ctx.get_vreg_for_use(rhs_val, block)
-  let vcode_inst = @instr.VCodeInst::new(Add)
+  let is_64 = result.ty is @ir.Type::I64
+  let vcode_inst = @instr.VCodeInst::new(Add(is_64))
+  vcode_inst.add_def({ reg: Virtual(dst) })
+  vcode_inst.add_use(Virtual(lhs))
+  vcode_inst.add_use(Virtual(rhs))
+  block.add_inst(vcode_inst)
+}
+
+///|
+/// Lower integer multiply with proper 32/64-bit size
+fn lower_imul(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : @block.VCodeBlock,
+) -> Unit {
+  guard inst.result is Some(result) else { return }
+  let dst = ctx.get_vreg(result)
+  let lhs = ctx.get_vreg_for_use(inst.operands[0], block)
+  let rhs = ctx.get_vreg_for_use(inst.operands[1], block)
+  let is_64 = result.ty is @ir.Type::I64
+  let vcode_inst = @instr.VCodeInst::new(Mul(is_64))
   vcode_inst.add_def({ reg: Virtual(dst) })
   vcode_inst.add_use(Virtual(lhs))
   vcode_inst.add_use(Virtual(rhs))
@@ -1217,18 +1237,18 @@ fn emit_bounds_check(
   let end_addr = if end_offset > 0L {
     let result = ctx.vcode_func.new_vreg(Int)
     if end_offset <= 4095L {
-      // Use AddImm for small offsets
-      let add_inst = @instr.VCodeInst::new(AddImm(end_offset.to_int()))
+      // Use AddImm for small offsets (64-bit pointer arithmetic)
+      let add_inst = @instr.VCodeInst::new(AddImm(end_offset.to_int(), true))
       add_inst.add_def({ reg: Virtual(result) })
       add_inst.add_use(Virtual(zero_ext))
       block.add_inst(add_inst)
     } else {
-      // Load constant and use Add for large offsets
+      // Load constant and use Add for large offsets (64-bit pointer arithmetic)
       let const_vreg = ctx.vcode_func.new_vreg(Int)
       let load_const = @instr.VCodeInst::new(LoadConst(end_offset))
       load_const.add_def({ reg: Virtual(const_vreg) })
       block.add_inst(load_const)
-      let add_inst = @instr.VCodeInst::new(Add)
+      let add_inst = @instr.VCodeInst::new(Add(true))
       add_inst.add_def({ reg: Virtual(result) })
       add_inst.add_use(Virtual(zero_ext))
       add_inst.add_use(Virtual(const_vreg))
@@ -1329,9 +1349,9 @@ fn lower_load(
     emit_bounds_check(ctx, block, wasm_addr, offset, access_size)
     // Load memory_base from vmctx on-demand
     let memory_base = emit_load_memory_base(ctx, block)
-    // Compute effective address: memory_base + wasm_addr
+    // Compute effective address: memory_base + wasm_addr (64-bit pointer arithmetic)
     let effective_addr = ctx.vcode_func.new_vreg(Int)
-    let add_inst = @instr.VCodeInst::new(Add)
+    let add_inst = @instr.VCodeInst::new(Add(true))
     add_inst.add_def({ reg: Virtual(effective_addr) })
     add_inst.add_use(Virtual(memory_base))
     add_inst.add_use(Virtual(wasm_addr))
@@ -1346,9 +1366,9 @@ fn lower_load(
     }
     // If offset is not aligned or too large, add it to the address first
     if offset != 0 && (offset % alignment != 0 || offset > 4095 * alignment) {
-      // Add offset to effective_addr using immediate add
+      // Add offset to effective_addr using immediate add (64-bit pointer arithmetic)
       let addr_with_offset = ctx.vcode_func.new_vreg(Int)
-      let offset_add = @instr.VCodeInst::new(AddImm(offset))
+      let offset_add = @instr.VCodeInst::new(AddImm(offset, true))
       offset_add.add_def({ reg: Virtual(addr_with_offset) })
       offset_add.add_use(Virtual(effective_addr))
       block.add_inst(offset_add)
@@ -1388,9 +1408,9 @@ fn lower_store(
   emit_bounds_check(ctx, block, wasm_addr, offset, access_size)
   // Load memory_base from vmctx on-demand
   let memory_base = emit_load_memory_base(ctx, block)
-  // Compute effective address: memory_base + wasm_addr
+  // Compute effective address: memory_base + wasm_addr (64-bit pointer arithmetic)
   let effective_addr = ctx.vcode_func.new_vreg(Int)
-  let add_inst = @instr.VCodeInst::new(Add)
+  let add_inst = @instr.VCodeInst::new(Add(true))
   add_inst.add_def({ reg: Virtual(effective_addr) })
   add_inst.add_use(Virtual(memory_base))
   add_inst.add_use(Virtual(wasm_addr))
@@ -1405,9 +1425,9 @@ fn lower_store(
   }
   // If offset is not aligned or too large, add it to the address first
   if offset != 0 && (offset % alignment != 0 || offset > 4095 * alignment) {
-    // Add offset to effective_addr using immediate add
+    // Add offset to effective_addr using immediate add (64-bit pointer arithmetic)
     let addr_with_offset = ctx.vcode_func.new_vreg(Int)
-    let offset_add = @instr.VCodeInst::new(AddImm(offset))
+    let offset_add = @instr.VCodeInst::new(AddImm(offset, true))
     offset_add.add_def({ reg: Virtual(addr_with_offset) })
     offset_add.add_use(Virtual(effective_addr))
     block.add_inst(offset_add)
@@ -1451,9 +1471,9 @@ fn lower_load_narrow(
     emit_bounds_check(ctx, block, wasm_addr, offset, access_size)
     // Load memory_base from vmctx on-demand
     let memory_base = emit_load_memory_base(ctx, block)
-    // Compute effective address: memory_base + wasm_addr
+    // Compute effective address: memory_base + wasm_addr (64-bit pointer arithmetic)
     let effective_addr = ctx.vcode_func.new_vreg(Int)
-    let add_inst = @instr.VCodeInst::new(Add)
+    let add_inst = @instr.VCodeInst::new(Add(true))
     add_inst.add_def({ reg: Virtual(effective_addr) })
     add_inst.add_use(Virtual(memory_base))
     add_inst.add_use(Virtual(wasm_addr))
@@ -1465,9 +1485,9 @@ fn lower_load_narrow(
     let alignment = access_size
     // If offset is not aligned or too large, add it to the address first
     if offset != 0 && (offset % alignment != 0 || offset > 4095 * alignment) {
-      // Add offset to effective_addr using immediate add
+      // Add offset to effective_addr using immediate add (64-bit pointer arithmetic)
       let addr_with_offset = ctx.vcode_func.new_vreg(Int)
-      let offset_add = @instr.VCodeInst::new(AddImm(offset))
+      let offset_add = @instr.VCodeInst::new(AddImm(offset, true))
       offset_add.add_def({ reg: Virtual(addr_with_offset) })
       offset_add.add_use(Virtual(effective_addr))
       block.add_inst(offset_add)
@@ -1506,9 +1526,9 @@ fn lower_store_narrow(
   emit_bounds_check(ctx, block, wasm_addr, offset, access_size)
   // Load memory_base from vmctx on-demand
   let memory_base = emit_load_memory_base(ctx, block)
-  // Compute effective address: memory_base + wasm_addr
+  // Compute effective address: memory_base + wasm_addr (64-bit pointer arithmetic)
   let effective_addr = ctx.vcode_func.new_vreg(Int)
-  let add_inst = @instr.VCodeInst::new(Add)
+  let add_inst = @instr.VCodeInst::new(Add(true))
   add_inst.add_def({ reg: Virtual(effective_addr) })
   add_inst.add_use(Virtual(memory_base))
   add_inst.add_use(Virtual(wasm_addr))
@@ -1517,9 +1537,9 @@ fn lower_store_narrow(
   let alignment = access_size
   // If offset is not aligned or too large, add it to the address first
   if offset != 0 && (offset % alignment != 0 || offset > 4095 * alignment) {
-    // Add offset to effective_addr using immediate add
+    // Add offset to effective_addr using immediate add (64-bit pointer arithmetic)
     let addr_with_offset = ctx.vcode_func.new_vreg(Int)
-    let offset_add = @instr.VCodeInst::new(AddImm(offset))
+    let offset_add = @instr.VCodeInst::new(AddImm(offset, true))
     offset_add.add_def({ reg: Virtual(addr_with_offset) })
     offset_add.add_use(Virtual(effective_addr))
     block.add_inst(offset_add)
@@ -2318,20 +2338,21 @@ fn lower_call_indirect(
   let actual_type_vreg = ctx.vcode_func.new_vreg(Int)
 
   // Step 1: Calculate offset = elem_idx * 16 (each entry is 16 bytes: func_ptr + type_idx)
+  // Use 64-bit multiply since we're working with 64-bit pointers
   let const_16_vreg = ctx.vcode_func.new_vreg(Int)
   let load_16 = @instr.VCodeInst::new(LoadConst(16L))
   load_16.add_def({ reg: Virtual(const_16_vreg) })
   block.add_inst(load_16)
-  let mul_inst = @instr.VCodeInst::new(Mul)
+  let mul_inst = @instr.VCodeInst::new(Mul(true))
   mul_inst.add_def({ reg: Virtual(offset_vreg) })
   mul_inst.add_use(Virtual(elem_idx_vreg))
   mul_inst.add_use(Virtual(const_16_vreg))
   block.add_inst(mul_inst)
 
-  // Step 2: Calculate address = table_ptr + offset
+  // Step 2: Calculate address = table_ptr + offset (64-bit pointer arithmetic)
   // table_ptr is loaded on-demand from vmctx (following Cranelift's approach)
   let addr_vreg = ctx.vcode_func.new_vreg(Int)
-  let add_inst = @instr.VCodeInst::new(Add)
+  let add_inst = @instr.VCodeInst::new(Add(true))
   add_inst.add_def({ reg: Virtual(addr_vreg) })
   add_inst.add_use(Virtual(table_ptr_vreg))
   add_inst.add_use(Virtual(offset_vreg))

--- a/vcode/lower/lower_wbtest.mbt
+++ b/vcode/lower/lower_wbtest.mbt
@@ -15,14 +15,17 @@ test "lower simple add function" {
   // Lower to VCode
   let vcode_func = lower_function(builder.get_function())
   let output = vcode_func.print()
-  let expected =
-    #|vcode add(v0:int, v1:int) -> int {
-    #|block0:
-    #|    v2 = add v0, v1
-    #|    ret v2
-    #|}
-    #|
-  inspect(output, content=expected)
+  inspect(
+    output,
+    content=(
+      #|vcode add(v0:int, v1:int) -> int {
+      #|block0:
+      #|    v2 = add32 v0, v1
+      #|    ret v2
+      #|}
+      #|
+    ),
+  )
 }
 
 ///|
@@ -63,16 +66,19 @@ test "lower constants" {
   builder.return_([sum])
   let vcode_func = lower_function(builder.get_function())
   let output = vcode_func.print()
-  let expected =
-    #|vcode const_test() -> int {
-    #|block0:
-    #|    v0 = ldi 10
-    #|    v1 = ldi 20
-    #|    v2 = add v0, v1
-    #|    ret v2
-    #|}
-    #|
-  inspect(output, content=expected)
+  inspect(
+    output,
+    content=(
+      #|vcode const_test() -> int {
+      #|block0:
+      #|    v0 = ldi 10
+      #|    v1 = ldi 20
+      #|    v2 = add32 v0, v1
+      #|    ret v2
+      #|}
+      #|
+    ),
+  )
 }
 
 ///|
@@ -195,7 +201,7 @@ test "lower memory operations" {
       #|    v6 = add v5, v0
       #|    v1 = load.i32 +0 v6
       #|    v7 = ldi 1
-      #|    v8 = add v1, v7
+      #|    v8 = add32 v1, v7
       #|    v9 = extend.u32_64 v0
       #|    v10 = add #8 v9
       #|    v11 = load_ptr.i64 +8 x19
@@ -289,7 +295,7 @@ test "lower division operations" {
       #|    v2 = sdiv32 v0, v1
       #|    trap_if_zero32 #4 v1
       #|    v3 = udiv32 v0, v1
-      #|    v4 = add v2, v3
+      #|    v4 = add32 v2, v3
       #|    ret v4
       #|}
       #|

--- a/vcode/lower/patterns.mbt
+++ b/vcode/lower/patterns.mbt
@@ -733,9 +733,9 @@ fn lower_inst_default(
     @ir.Opcode::Fconst(val) => lower_fconst(ctx, inst, block, val)
 
     // Integer arithmetic
-    @ir.Opcode::Iadd => lower_binary_int(ctx, inst, block, @instr.Add)
+    @ir.Opcode::Iadd => lower_iadd(ctx, inst, block)
     @ir.Opcode::Isub => lower_isub(ctx, inst, block)
-    @ir.Opcode::Imul => lower_binary_int(ctx, inst, block, @instr.Mul)
+    @ir.Opcode::Imul => lower_imul(ctx, inst, block)
     @ir.Opcode::Sdiv => lower_div(ctx, inst, block, signed=true)
     @ir.Opcode::Udiv => lower_div(ctx, inst, block, signed=false)
 

--- a/vcode/lower/patterns_wbtest.mbt
+++ b/vcode/lower/patterns_wbtest.mbt
@@ -230,14 +230,17 @@ test "no pattern match: regular add" {
   let vcode_func = lower_function_optimized(builder.get_function())
   let output = vcode_func.print()
   // No optimization applies, so regular add is emitted
-  let expected =
-    #|vcode regular_add(v0:int, v1:int) -> int {
-    #|block0:
-    #|    v2 = add v0, v1
-    #|    ret v2
-    #|}
-    #|
-  inspect(output, content=expected)
+  inspect(
+    output,
+    content=(
+      #|vcode regular_add(v0:int, v1:int) -> int {
+      #|block0:
+      #|    v2 = add32 v0, v1
+      #|    ret v2
+      #|}
+      #|
+    ),
+  )
 }
 
 ///|
@@ -257,15 +260,18 @@ test "optimized vs non-optimized comparison" {
   let output_non_opt = vcode_non_opt.print()
 
   // Should have an 'add' instruction
-  let expected_non_opt =
-    #|vcode comparison(v0:int) -> int {
-    #|block0:
-    #|    v1 = ldi 0
-    #|    v2 = add v0, v1
-    #|    ret v2
-    #|}
-    #|
-  inspect(output_non_opt, content=expected_non_opt)
+  inspect(
+    output_non_opt,
+    content=(
+      #|vcode comparison(v0:int) -> int {
+      #|block0:
+      #|    v1 = ldi 0
+      #|    v2 = add32 v0, v1
+      #|    ret v2
+      #|}
+      #|
+    ),
+  )
 
   // Rebuild for optimized test (builders consume the function)
   let builder2 = @ir.IRBuilder::new("comparison")
@@ -444,13 +450,16 @@ test "no strength reduction: mul x, 3 (not power of 2)" {
   let vcode_func = lower_function_optimized(builder.get_function())
   let output = vcode_func.print()
   // 3 is not a power of 2, so regular mul is used
-  let expected =
-    #|vcode mul_non_pow2_test(v0:int) -> int {
-    #|block0:
-    #|    v1 = ldi 3
-    #|    v2 = mul v0, v1
-    #|    ret v2
-    #|}
-    #|
-  inspect(output, content=expected)
+  inspect(
+    output,
+    content=(
+      #|vcode mul_non_pow2_test(v0:int) -> int {
+      #|block0:
+      #|    v1 = ldi 3
+      #|    v2 = mul32 v0, v1
+      #|    ret v2
+      #|}
+      #|
+    ),
+  )
 }

--- a/vcode/lower/regalloc_wbtest.mbt
+++ b/vcode/lower/regalloc_wbtest.mbt
@@ -10,7 +10,7 @@ test "liveness: simple function" {
   let block = func.new_block()
 
   // v2 = add v0, v1
-  let add_inst = @instr.VCodeInst::new(@instr.Add)
+  let add_inst = @instr.VCodeInst::new(@instr.Add(true))
   let result_vreg = func.new_vreg(@abi.Int)
   add_inst.add_def({ reg: @abi.Virtual(result_vreg) })
   add_inst.add_use(@abi.Virtual(a))
@@ -49,7 +49,7 @@ test "regalloc: simple allocation" {
   let block = func.new_block()
 
   // v2 = add v0, v1
-  let add_inst = @instr.VCodeInst::new(@instr.Add)
+  let add_inst = @instr.VCodeInst::new(@instr.Add(true))
   let result_vreg = func.new_vreg(@abi.Int)
   add_inst.add_def({ reg: @abi.Virtual(result_vreg) })
   add_inst.add_use(@abi.Virtual(a))
@@ -90,7 +90,7 @@ test "regalloc: with spilling" {
 
   // All params live at the same time, need more than 2 registers
   // v4 = add v0, v1
-  let add1 = @instr.VCodeInst::new(@instr.Add)
+  let add1 = @instr.VCodeInst::new(@instr.Add(true))
   let t1 = func.new_vreg(@abi.Int)
   add1.add_def({ reg: @abi.Virtual(t1) })
   add1.add_use(@abi.Virtual(a))
@@ -98,7 +98,7 @@ test "regalloc: with spilling" {
   block.add_inst(add1)
 
   // v5 = add v2, v3
-  let add2 = @instr.VCodeInst::new(@instr.Add)
+  let add2 = @instr.VCodeInst::new(@instr.Add(true))
   let t2 = func.new_vreg(@abi.Int)
   add2.add_def({ reg: @abi.Virtual(t2) })
   add2.add_use(@abi.Virtual(c))
@@ -106,7 +106,7 @@ test "regalloc: with spilling" {
   block.add_inst(add2)
 
   // v6 = add v4, v5
-  let add3 = @instr.VCodeInst::new(@instr.Add)
+  let add3 = @instr.VCodeInst::new(@instr.Add(true))
   let result = func.new_vreg(@abi.Int)
   add3.add_def({ reg: @abi.Virtual(result) })
   add3.add_use(@abi.Virtual(t1))
@@ -181,7 +181,7 @@ test "apply_allocation: rewrites virtual to physical" {
   block.add_inst(const_inst)
 
   // v2 = add v0, v1
-  let add_inst = @instr.VCodeInst::new(@instr.Add)
+  let add_inst = @instr.VCodeInst::new(@instr.Add(true))
   let result_vreg = func.new_vreg(@abi.Int)
   add_inst.add_def({ reg: @abi.Virtual(result_vreg) })
   add_inst.add_use(@abi.Virtual(a))
@@ -256,7 +256,7 @@ test "regalloc: aarch64 convenience function" {
   let b = func.add_param(@abi.Int)
   func.add_result(@abi.Int)
   let block = func.new_block()
-  let add_inst = @instr.VCodeInst::new(@instr.Add)
+  let add_inst = @instr.VCodeInst::new(@instr.Add(true))
   let result_vreg = func.new_vreg(@abi.Int)
   add_inst.add_def({ reg: @abi.Virtual(result_vreg) })
   add_inst.add_use(@abi.Virtual(a))
@@ -572,7 +572,7 @@ test "liveness: complete output for linear function" {
   let block = func.new_block()
 
   // v2 = add v0, v1
-  let add_inst = @instr.VCodeInst::new(@instr.Add)
+  let add_inst = @instr.VCodeInst::new(@instr.Add(true))
   let sum = func.new_vreg(@abi.Int)
   add_inst.add_def({ reg: @abi.Virtual(sum) })
   add_inst.add_use(@abi.Virtual(a))
@@ -586,7 +586,7 @@ test "liveness: complete output for linear function" {
   block.add_inst(const_inst)
 
   // v4 = mul v2, v3
-  let mul_inst = @instr.VCodeInst::new(@instr.Mul)
+  let mul_inst = @instr.VCodeInst::new(@instr.Mul(true))
   let result = func.new_vreg(@abi.Int)
   mul_inst.add_def({ reg: @abi.Virtual(result) })
   mul_inst.add_use(@abi.Virtual(sum))
@@ -664,7 +664,7 @@ test "liveness: complete output for diamond CFG" {
   block0.set_terminator(@instr.Branch(@abi.Virtual(cond), block1.id, block2.id))
 
   // block1: v3 = add v1, v1
-  let add1 = @instr.VCodeInst::new(@instr.Add)
+  let add1 = @instr.VCodeInst::new(@instr.Add(true))
   add1.add_use(@abi.Virtual(v1))
   add1.add_use(@abi.Virtual(v1))
   add1.add_def({ reg: @abi.Virtual(v3) })
@@ -672,7 +672,7 @@ test "liveness: complete output for diamond CFG" {
   block1.set_terminator(@instr.Jump(block3.id))
 
   // block2: v3 = add v2, v2
-  let add2 = @instr.VCodeInst::new(@instr.Add)
+  let add2 = @instr.VCodeInst::new(@instr.Add(true))
   add2.add_use(@abi.Virtual(v2))
   add2.add_use(@abi.Virtual(v2))
   add2.add_def({ reg: @abi.Virtual(v3) })
@@ -719,7 +719,7 @@ test "regalloc: complete allocation output for simple function" {
   let block = func.new_block()
 
   // v2 = add v0, v1
-  let add_inst = @instr.VCodeInst::new(@instr.Add)
+  let add_inst = @instr.VCodeInst::new(@instr.Add(true))
   let result = func.new_vreg(@abi.Int)
   add_inst.add_def({ reg: @abi.Virtual(result) })
   add_inst.add_use(@abi.Virtual(a))
@@ -809,7 +809,7 @@ test "regalloc: same instruction use-def conflict" {
   block.add_inst(load_inst)
 
   // v1 = add v0, v0
-  let add_inst = @instr.VCodeInst::new(@instr.Add)
+  let add_inst = @instr.VCodeInst::new(@instr.Add(true))
   add_inst.add_use(@abi.Virtual(v0))
   add_inst.add_use(@abi.Virtual(v0))
   add_inst.add_def({ reg: @abi.Virtual(v1) })
@@ -875,7 +875,7 @@ test "regalloc: interval extension across blocks" {
   block0.set_terminator(@instr.Jump(block1.id))
 
   // block1
-  let add_inst = @instr.VCodeInst::new(@instr.Add)
+  let add_inst = @instr.VCodeInst::new(@instr.Add(true))
   add_inst.add_use(@abi.Virtual(v0))
   add_inst.add_use(@abi.Virtual(v0))
   add_inst.add_def({ reg: @abi.Virtual(v1) })
@@ -940,7 +940,7 @@ test "regalloc: float and int mixed allocation" {
   block.add_inst(inst1)
 
   // v2 = add v0, v0
-  let inst2 = @instr.VCodeInst::new(@instr.Add)
+  let inst2 = @instr.VCodeInst::new(@instr.Add(true))
   inst2.add_use(@abi.Virtual(v0))
   inst2.add_use(@abi.Virtual(v0))
   inst2.add_def({ reg: @abi.Virtual(v2) })
@@ -1040,12 +1040,12 @@ test "regalloc: spill and reload complete flow" {
   let inst2 = @instr.VCodeInst::new(@instr.LoadConst(3L))
   inst2.add_def({ reg: @abi.Virtual(v2) })
   block.add_inst(inst2)
-  let inst3 = @instr.VCodeInst::new(@instr.Add)
+  let inst3 = @instr.VCodeInst::new(@instr.Add(true))
   inst3.add_use(@abi.Virtual(v0))
   inst3.add_use(@abi.Virtual(v1))
   inst3.add_def({ reg: @abi.Virtual(v3) })
   block.add_inst(inst3)
-  let inst4 = @instr.VCodeInst::new(@instr.Add)
+  let inst4 = @instr.VCodeInst::new(@instr.Add(true))
   inst4.add_use(@abi.Virtual(v3))
   inst4.add_use(@abi.Virtual(v2))
   inst4.add_def({ reg: @abi.Virtual(v4) })
@@ -1366,7 +1366,7 @@ test "regalloc: mixed int, f32, f64 registers" {
   block.add_inst(inst2)
 
   // v3 = add v0, v0
-  let inst3 = @instr.VCodeInst::new(@instr.Add)
+  let inst3 = @instr.VCodeInst::new(@instr.Add(true))
   inst3.add_use(@abi.Virtual(v0))
   inst3.add_use(@abi.Virtual(v0))
   inst3.add_def({ reg: @abi.Virtual(v3) })

--- a/vcode/lower/stacklayout.mbt
+++ b/vcode/lower/stacklayout.mbt
@@ -390,8 +390,8 @@ pub fn AArch64StackFrame::gen_epilogue(
     insts.push(load_lr)
   }
 
-  // Restore stack pointer: ADD sp, sp, #frame_size
-  let add_sp = @instr.VCodeInst::new(Add)
+  // Restore stack pointer: ADD sp, sp, #frame_size (64-bit)
+  let add_sp = @instr.VCodeInst::new(Add(true))
   add_sp.add_def({ reg: Physical({ index: 31, class: Int }) }) // SP
   add_sp.add_use(Physical({ index: 31, class: Int })) // SP
   insts.push(add_sp)

--- a/vcode/pkg.generated.mbti
+++ b/vcode/pkg.generated.mbti
@@ -134,7 +134,7 @@ pub(all) struct VCodeBuilder {
   func : @lower.VCodeFunction
   mut current_block : @block.VCodeBlock?
 }
-pub fn VCodeBuilder::add(Self, @abi.VReg, @abi.VReg) -> @abi.VReg
+pub fn VCodeBuilder::add(Self, @abi.VReg, @abi.VReg, is_64? : Bool) -> @abi.VReg
 pub fn VCodeBuilder::add_param(Self, @abi.RegClass) -> @abi.VReg
 pub fn VCodeBuilder::add_result(Self, @abi.RegClass) -> Unit
 pub fn VCodeBuilder::ashr(Self, @abi.VReg, @abi.VReg, is_64? : Bool) -> @abi.VReg
@@ -157,7 +157,7 @@ pub fn VCodeBuilder::jump(Self, @block.VCodeBlock) -> Unit
 pub fn VCodeBuilder::load(Self, @instr.MemType, @abi.VReg, Int) -> @abi.VReg
 pub fn VCodeBuilder::lshr(Self, @abi.VReg, @abi.VReg, is_64? : Bool) -> @abi.VReg
 pub fn VCodeBuilder::mov(Self, @abi.VReg) -> @abi.VReg
-pub fn VCodeBuilder::mul(Self, @abi.VReg, @abi.VReg) -> @abi.VReg
+pub fn VCodeBuilder::mul(Self, @abi.VReg, @abi.VReg, is_64? : Bool) -> @abi.VReg
 pub fn VCodeBuilder::new(String) -> Self
 pub fn VCodeBuilder::print(Self) -> String
 pub fn VCodeBuilder::return_(Self, Array[@abi.VReg]) -> Unit


### PR DESCRIPTION
## Summary
- Fixed memory_trap.wast test failures (2/180 → 180/180 passing)
- Root cause: i32 operations were incorrectly using 64-bit ADD/MUL instructions, causing wrong results when 32-bit wraparound was needed
- Added size parameter to VCode opcodes: `Add(Bool)`, `AddImm(Int, Bool)`, `Mul(Bool)` where `true` = 64-bit, `false` = 32-bit
- Added 32-bit instruction emission: `emit_add_reg32`, `emit_add_imm32`, `emit_mul32`

## Test plan
- [x] memory_trap.wast: 180/180 passed (was 178/180)
- [x] moon test: 861/861 passed
- [x] moon check: 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)