### PR TITLE
feat(jit): implement table.grow, table.size with multi-table support

### DIFF
--- a/ir/builder.mbt
+++ b/ir/builder.mbt
@@ -714,6 +714,24 @@ pub fn IRBuilder::table_set(
 }
 
 ///|
+/// Get current size of table (number of elements)
+pub fn IRBuilder::table_size(self : IRBuilder, table_idx : Int) -> Value {
+  self.emit_inst(Type::I32, Opcode::TableSize(table_idx), [])
+}
+
+///|
+/// Grow table by delta elements, initializing new elements with init_value
+/// Returns previous size (as i32), or -1 if grow failed
+pub fn IRBuilder::table_grow(
+  self : IRBuilder,
+  table_idx : Int,
+  delta : Value,
+  init_value : Value,
+) -> Value {
+  self.emit_inst(Type::I32, Opcode::TableGrow(table_idx), [delta, init_value])
+}
+
+///|
 /// Get global variable value
 pub fn IRBuilder::global_get(
   self : IRBuilder,

--- a/ir/ir.mbt
+++ b/ir/ir.mbt
@@ -223,6 +223,8 @@ pub enum Opcode {
   // Table operations (for reference types)
   TableGet(Int) // Get element from table (table index)
   TableSet(Int) // Set element in table (table index)
+  TableSize(Int) // Get current size of table (table index)
+  TableGrow(Int) // Grow table, returns previous size or -1 (table index)
 
   // Global operations
   GlobalGet(Int) // Get global variable value (global index)

--- a/ir/optimize.mbt
+++ b/ir/optimize.mbt
@@ -112,6 +112,8 @@ fn has_side_effects(inst : Inst) -> Bool {
     Call(_) | CallIndirect(_) => true
     // Memory operations that modify global state
     MemoryGrow(_) | MemoryFill | MemoryCopy => true
+    // Table operations that modify global state
+    TableGrow(_) => true
     // Global operations: GlobalGet reads mutable state, GlobalSet modifies it
     // Mark both as having side effects to prevent incorrect CSE
     GlobalGet(_) | GlobalSet(_) => true

--- a/ir/pkg.generated.mbti
+++ b/ir/pkg.generated.mbti
@@ -200,7 +200,9 @@ pub fn IRBuilder::store8(Self, Value, Value, Int) -> Unit
 pub fn IRBuilder::store_ptr(Self, Type, Value, Value, Value) -> Unit
 pub fn IRBuilder::switch_to_block(Self, Block) -> Unit
 pub fn IRBuilder::table_get(Self, Int, Value) -> Value
+pub fn IRBuilder::table_grow(Self, Int, Value, Value) -> Value
 pub fn IRBuilder::table_set(Self, Int, Value, Value) -> Unit
+pub fn IRBuilder::table_size(Self, Int) -> Value
 pub fn IRBuilder::trap(Self, String) -> Unit
 pub fn IRBuilder::udiv(Self, Value, Value) -> Value
 pub fn IRBuilder::uextend(Self, Type, Value) -> Value
@@ -310,6 +312,8 @@ pub enum Opcode {
   Copy
   TableGet(Int)
   TableSet(Int)
+  TableSize(Int)
+  TableGrow(Int)
   GlobalGet(Int)
   GlobalSet(Int)
   Call(Int)

--- a/ir/printer.mbt
+++ b/ir/printer.mbt
@@ -171,6 +171,8 @@ fn format_opcode(
     // Table operations
     TableGet(idx) => "table_get \{idx} \{ops}"
     TableSet(idx) => "table_set \{idx} \{ops}"
+    TableSize(idx) => "table_size \{idx}"
+    TableGrow(idx) => "table_grow \{idx} \{ops}"
 
     // Global operations
     GlobalGet(idx) => "global_get \{idx}"

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -868,6 +868,19 @@ fn Translator::translate_instruction(
       let elem_idx = self.pop()
       self.builder.table_set(table_idx, elem_idx, value)
     }
+    TableSize(table_idx) => {
+      // Get current size of table
+      let result = self.builder.table_size(table_idx)
+      self.push(result)
+    }
+    TableGrow(table_idx) => {
+      // Grow table by delta elements
+      // Stack: [init_value, delta] -> [result]
+      let delta = self.pop()
+      let init_value = self.pop()
+      let result = self.builder.table_grow(table_idx, delta, init_value)
+      self.push(result)
+    }
     GlobalGet(idx) => {
       // Get global variable value
       let global_type = self.global_types[idx]

--- a/ir/validator.mbt
+++ b/ir/validator.mbt
@@ -308,6 +308,18 @@ fn validate_instruction(
           "TableSet expects 2 operands (elem_idx, value), got \{inst.operands.length()}",
         )
       }
+    TableSize(_) =>
+      if inst.operands.length() != 0 {
+        result.add_error(
+          "TableSize expects 0 operands, got \{inst.operands.length()}",
+        )
+      }
+    TableGrow(_) =>
+      if inst.operands.length() != 2 {
+        result.add_error(
+          "TableGrow expects 2 operands (delta, init_value), got \{inst.operands.length()}",
+        )
+      }
 
     // Global operations
     GlobalGet(_) =>

--- a/jit/ffi_jit.mbt
+++ b/jit/ffi_jit.mbt
@@ -183,17 +183,29 @@ fn JITContext::set_table_pointers(
   if jit_tables.is_empty() {
     return
   }
-  // Convert Array[JITTable?] to FixedArray[Int64] of table pointers
+  // Convert Array[JITTable?] to FixedArray[Int64] of table pointers, sizes, and max sizes
   let table_ptrs = FixedArray::make(jit_tables.length(), 0L)
+  let table_sizes = FixedArray::make(jit_tables.length(), 0)
+  let table_max_sizes = FixedArray::make(jit_tables.length(), -1) // -1 = unlimited
   for i, jit_table_opt in jit_tables {
     match jit_table_opt {
-      Some(jit_table) => table_ptrs[i] = jit_table.table_ptr
-      None => table_ptrs[i] = 0L // Null table pointer
+      Some(jit_table) => {
+        table_ptrs[i] = jit_table.table_ptr
+        table_sizes[i] = jit_table.size
+        table_max_sizes[i] = jit_table.max.unwrap_or(-1) // -1 = unlimited
+      }
+      None => {
+        table_ptrs[i] = 0L // Null table pointer
+        table_sizes[i] = 0
+        table_max_sizes[i] = -1
+      }
     }
   }
   @jit_ffi.c_jit_ctx_set_table_pointers(
     self.ptr(),
     table_ptrs,
+    table_sizes,
+    table_max_sizes,
     jit_tables.length(),
   )
 }
@@ -254,11 +266,15 @@ struct JITTable {
 
 ///|
 /// Create a new shared JIT table
+/// Note: size 0 is valid (empty table that can grow later)
 pub fn JITTable::new(size : Int, max : Int?) -> JITTable? {
-  if size <= 0 {
+  if size < 0 {
     return None
   }
-  let table_ptr = @jit_ffi.c_jit_alloc_shared_indirect_table(size)
+  // For size 0, allocate with capacity 1 to avoid null pointer issues
+  // The actual size is tracked separately
+  let alloc_size = if size == 0 { 1 } else { size }
+  let table_ptr = @jit_ffi.c_jit_alloc_shared_indirect_table(alloc_size)
   if table_ptr == 0L {
     return None
   }

--- a/jit/jit_ffi/ffi.mbt
+++ b/jit/jit_ffi/ffi.mbt
@@ -91,6 +91,11 @@ pub extern "c" fn c_jit_get_memory_fill_ptr() -> Int64 = "wasmoon_jit_get_memory
 pub extern "c" fn c_jit_get_memory_copy_ptr() -> Int64 = "wasmoon_jit_get_memory_copy_ptr"
 
 ///|
+/// Get table_grow function pointer for JIT
+/// Signature: table_grow(table_idx: i32, delta: i64, init_value: i64) -> i32
+pub extern "c" fn c_jit_get_table_grow_ptr() -> Int64 = "wasmoon_jit_get_table_grow_ptr"
+
+///|
 /// Get current memory base from v2 context (for proper cleanup after memory.grow)
 pub extern "c" fn c_jit_get_current_memory_base() -> Int64 = "wasmoon_jit_get_memory_base"
 
@@ -152,11 +157,15 @@ pub extern "c" fn c_jit_ctx_use_shared_table(
 ///|
 /// Configure JIT context with multiple indirect tables (for multi-table support)
 /// table_ptrs: FixedArray of Int64 (table pointers from Store.jit_tables)
+/// table_sizes: FixedArray of Int (table sizes for bounds checking)
+/// table_max_sizes: FixedArray of Int (max sizes, -1 = unlimited)
 /// table_count: Number of tables
-#borrow(table_ptrs)
+#borrow(table_ptrs, table_sizes, table_max_sizes)
 pub extern "c" fn c_jit_ctx_set_table_pointers(
   ctx_ptr : Int64,
   table_ptrs : FixedArray[Int64],
+  table_sizes : FixedArray[Int],
+  table_max_sizes : FixedArray[Int],
   table_count : Int,
 ) -> Unit = "wasmoon_jit_ctx_set_table_pointers"
 

--- a/jit/jit_ffi/jit_ffi.h
+++ b/jit/jit_ffi/jit_ffi.h
@@ -37,6 +37,8 @@ typedef struct {
     void ***tables;           // +48: Array of table pointers (for table_idx != 0)
     int table_count;          // +56: Number of tables
     int func_count;           // +60: Number of entries in func_table
+    size_t *table_sizes;      // +64: Array of table current sizes for all tables
+    size_t *table_max_sizes;  // +72: Array of table max sizes (-1 = unlimited)
 
     // Additional fields (not accessed by JIT code directly)
     int owns_indirect_table;  // Whether this context owns table0_base (should free it)

--- a/jit/jit_ffi/pkg.generated.mbti
+++ b/jit/jit_ffi/pkg.generated.mbti
@@ -36,7 +36,7 @@ pub fn c_jit_ctx_set_indirect(Int64, Int, Int, Int) -> Unit
 
 pub fn c_jit_ctx_set_memory(Int64, Int64, Int64) -> Unit
 
-pub fn c_jit_ctx_set_table_pointers(Int64, FixedArray[Int64], Int) -> Unit
+pub fn c_jit_ctx_set_table_pointers(Int64, FixedArray[Int64], FixedArray[Int], FixedArray[Int], Int) -> Unit
 
 pub fn c_jit_ctx_use_shared_table(Int64, Int64, Int) -> Unit
 
@@ -97,6 +97,8 @@ pub fn c_jit_get_spectest_print_i32_ptr() -> Int64
 pub fn c_jit_get_spectest_print_i64_ptr() -> Int64
 
 pub fn c_jit_get_spectest_print_ptr() -> Int64
+
+pub fn c_jit_get_table_grow_ptr() -> Int64
 
 pub fn c_jit_get_trap_code() -> Int
 

--- a/vcode/abi/abi.mbt
+++ b/vcode/abi/abi.mbt
@@ -54,6 +54,10 @@ pub const VMCTX_TABLES_OFFSET : Int = 48
 /// Offset of table_count in VMContext
 pub const VMCTX_TABLE_COUNT_OFFSET : Int = 56
 
+///|
+/// Offset of table_sizes array in VMContext
+pub const VMCTX_TABLE_SIZES_OFFSET : Int = 64
+
 // ============ Reserved Registers ============
 
 ///|

--- a/vcode/abi/pkg.generated.mbti
+++ b/vcode/abi/pkg.generated.mbti
@@ -50,6 +50,8 @@ pub const VMCTX_TABLES_OFFSET : Int = 48
 
 pub const VMCTX_TABLE_COUNT_OFFSET : Int = 56
 
+pub const VMCTX_TABLE_SIZES_OFFSET : Int = 64
+
 pub fn aapcs64_arg_fprs() -> Array[PReg]
 
 pub fn aapcs64_arg_gprs() -> Array[PReg]

--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -883,6 +883,20 @@ fn MachineCode::emit_instruction(
       // BRK #trap_code
       self.emit_brk(trap_code)
     }
+    TrapIfUge(trap_code) => {
+      // Trap if lhs >= rhs (unsigned comparison)
+      // Uses: [lhs, rhs]
+      // Emits: CMP lhs, rhs; B.LO skip; BRK #trap_code
+      let lhs = reg_num(inst.uses[0])
+      let rhs = reg_num(inst.uses[1])
+      // CMP lhs, rhs
+      self.emit_cmp_reg(lhs, rhs)
+      // B.LO +8 (skip BRK if lhs < rhs)
+      // LO condition code = 3
+      self.emit_b_cond_offset(3, 8)
+      // BRK #trap_code
+      self.emit_brk(trap_code)
+    }
     FpuCmp(is_f32) => {
       // Floating-point compare (sets NZCV flags)
       // Uses: [lhs, rhs], Defs: []
@@ -1611,6 +1625,34 @@ fn MachineCode::emit_instruction(
       self.emit_add_shifted(16, 17, elem_idx_reg, @instr.ShiftType::Lsl, 4)
       // STR value, [X16]
       self.emit_str_imm(value_reg, 16, 0)
+    }
+    TableGrow(table_idx) => {
+      // Grow table by delta elements (Cranelift-style runtime call)
+      // Uses: [delta, init_value], Defs: [result]
+      // Calls: wasmoon_jit_table_grow(table_idx: i32, delta: i64, init_value: i64) -> i32
+      let delta_reg = reg_num(inst.uses[0])
+      let init_value_reg = reg_num(inst.uses[1])
+      let result_reg = wreg_num(inst.defs[0])
+
+      // Set up arguments:
+      // X0 = table_idx (immediate)
+      // X1 = delta (from uses[0])
+      // X2 = init_value (from uses[1])
+      self.emit_movz(0, table_idx & 0xFFFF, 0) // MOV W0, #table_idx
+      self.emit_mov_reg(1, delta_reg) // MOV X1, delta
+      self.emit_mov_reg(2, init_value_reg) // MOV X2, init_value
+
+      // Load table_grow function pointer into X16
+      let grow_ptr = @jit_ffi.c_jit_get_table_grow_ptr()
+      self.emit_load_imm64(16, grow_ptr)
+
+      // Call the function
+      self.emit_blr(16)
+
+      // Move result from X0 to destination
+      if result_reg != 0 {
+        self.emit_mov_reg(result_reg, 0) // MOV result, X0
+      }
     }
     GlobalGet(global_idx) => {
       // Load global variable value

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -174,6 +174,10 @@ pub(all) enum VCodeOpcode {
   // TrapIfUgt(trap_code): CMP rn, rm; B.LS skip; BRK #trap_code
   // Uses: [lhs, rhs], traps if lhs > rhs (unsigned)
   TrapIfUgt(Int)
+  // Trap if first operand is unsigned greater than or equal to second operand
+  // TrapIfUge(trap_code): CMP rn, rm; B.LO skip; BRK #trap_code
+  // Uses: [lhs, rhs], traps if lhs >= rhs (unsigned)
+  TrapIfUge(Int)
 
   // Floating-point compare (sets NZCV flags, no result value)
   // FpuCmp(is_f32): FCMP Sn, Sm or FCMP Dn, Dm
@@ -276,6 +280,9 @@ pub(all) enum VCodeOpcode {
   // TableSet(table_idx): store to indirect table at index
   // Uses: [elem_idx, value], Defs: []
   TableSet(Int)
+  // TableGrow(table_idx): grow table, returns previous size or -1
+  // Uses: [delta, init_value], Defs: [result]
+  TableGrow(Int)
   // Global operations
   // GlobalGet(global_idx): load global variable value
   // Uses: [], Defs: [result]
@@ -376,6 +383,7 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     Rbit(is_64) => if is_64 { "rbit" } else { "rbit32" }
     Nop => "nop"
     TrapIfUgt(trap_code) => "trap_if_ugt #\{trap_code}"
+    TrapIfUge(trap_code) => "trap_if_uge #\{trap_code}"
     FpuCmp(is_f32) => if is_f32 { "fcmp.s" } else { "fcmp.d" }
     TrapIf(cond, trap_code) => "trap_if.\{cond} #\{trap_code}"
     TrapIfZero(is_64, trap_code) =>
@@ -431,6 +439,7 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     MemoryCopy => "memory_copy"
     TableGet(table_idx) => "table_get \{table_idx}"
     TableSet(table_idx) => "table_set \{table_idx}"
+    TableGrow(table_idx) => "table_grow \{table_idx}"
     GlobalGet(global_idx) => "global_get \{global_idx}"
     GlobalSet(global_idx) => "global_set \{global_idx}"
     LoadPtr(ty, offset) => "load_ptr.\{ty} +\{offset}"
@@ -793,6 +802,8 @@ pub fn VCodeOpcode::call_type(self : VCodeOpcode) -> CallType {
     CallIndirect(_, _) | CallPtr(_, _) => Regular
     // Memory operations that call C runtime functions
     MemoryGrow(_) | MemorySize | MemoryFill | MemoryCopy => Regular
+    // Table operations that call C runtime functions
+    TableGrow(_) => Regular
     // Everything else is not a call
     _ => None
   }

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -191,6 +191,7 @@ pub(all) enum VCodeOpcode {
   Rbit(Bool)
   Nop
   TrapIfUgt(Int)
+  TrapIfUge(Int)
   FpuCmp(Bool)
   TrapIf(Cond, Int)
   TrapIfZero(Bool, Int)
@@ -218,6 +219,7 @@ pub(all) enum VCodeOpcode {
   MemoryCopy
   TableGet(Int)
   TableSet(Int)
+  TableGrow(Int)
   GlobalGet(Int)
   GlobalSet(Int)
   LoadPtr(MemType, Int)

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -392,6 +392,10 @@ fn lower_inst(
       lower_table_get(ctx, inst, block, table_idx)
     @ir.Opcode::TableSet(table_idx) =>
       lower_table_set(ctx, inst, block, table_idx)
+    @ir.Opcode::TableSize(table_idx) =>
+      lower_table_size(ctx, inst, block, table_idx)
+    @ir.Opcode::TableGrow(table_idx) =>
+      lower_table_grow(ctx, inst, block, table_idx)
 
     // Global operations
     @ir.Opcode::GlobalGet(global_idx) =>
@@ -2182,16 +2186,18 @@ fn lower_memory_copy(
 /// instead of deferring to emit phase with hardcoded registers.
 ///
 /// Generated sequence:
-/// 1. table_base = LoadPtr(I64, VMCTX_TABLE0_BASE_OFFSET) from vmctx (X19)
-/// 2. addr = AddShifted(table_base, elem_idx, Lsl, 4)  // addr = table_base + elem_idx * 16
-/// 3. result = LoadPtr(I64, 0) from addr
+/// 1. elem_idx_64 = Extend(elem_idx, Unsigned32To64) // zero-extend 32->64
+/// 2. table_size = LoadPtr(I64, VMCTX_TABLE0_ELEMENTS_OFFSET) from vmctx
+/// 3. TrapIfUge(elem_idx_64, table_size, 1) // trap if out of bounds
+/// 4. table_base = LoadPtr(I64, VMCTX_TABLE0_BASE_OFFSET) from vmctx (X19)
+/// 5. addr = AddShifted(table_base, elem_idx_64, Lsl, 4)  // addr = table_base + elem_idx * 16
+/// 6. result = LoadPtr(I64, 0) from addr
 fn lower_table_get(
   ctx : LoweringContext,
   inst : @ir.Inst,
   block : @block.VCodeBlock,
   table_idx : Int,
 ) -> Unit {
-  ignore(table_idx) // Currently only table 0 is supported
   // Get the result vreg
   guard inst.result is Some(result) else { return }
   let result_vreg = ctx.get_vreg(result)
@@ -2200,26 +2206,83 @@ fn lower_table_get(
   guard inst.operands.length() > 0 else { return }
   let elem_idx = ctx.get_vreg_for_use(inst.operands[0], block)
 
-  // Step 1: Load table0_base from vmctx
+  // Step 1: Zero-extend elem_idx from 32-bit to 64-bit
+  let elem_idx_64 = ctx.new_vreg(@abi.Int)
+  let extend_inst = @instr.VCodeInst::new(Extend(Unsigned32To64))
+  extend_inst.add_def({ reg: Virtual(elem_idx_64) })
+  extend_inst.add_use(Virtual(elem_idx))
+  block.add_inst(extend_inst)
   let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
-  let table_base = ctx.new_vreg(@abi.Int)
-  let load_table = @instr.VCodeInst::new(
-    LoadPtr(@instr.I64, @abi.VMCTX_TABLE0_BASE_OFFSET),
-  )
-  load_table.add_use(Physical(vmctx_preg))
-  load_table.add_def({ reg: Virtual(table_base) })
-  block.add_inst(load_table)
 
-  // Step 2: Calculate address: addr = table_base + (elem_idx << 4)
+  // Load table_size and table_base depending on table_idx
+  let table_size = ctx.new_vreg(@abi.Int)
+  let table_base = ctx.new_vreg(@abi.Int)
+  if table_idx == 0 {
+    // Fast path for table 0
+    // Step 2: Load table_size from vmctx
+    let load_size = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLE0_ELEMENTS_OFFSET),
+    )
+    load_size.add_use(Physical(vmctx_preg))
+    load_size.add_def({ reg: Virtual(table_size) })
+    block.add_inst(load_size)
+
+    // Step 4: Load table0_base from vmctx
+    let load_table = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLE0_BASE_OFFSET),
+    )
+    load_table.add_use(Physical(vmctx_preg))
+    load_table.add_def({ reg: Virtual(table_base) })
+    block.add_inst(load_table)
+  } else {
+    // Multi-table path
+    // Load table_sizes array pointer
+    let table_sizes_ptr = ctx.new_vreg(@abi.Int)
+    let load_sizes_ptr = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLE_SIZES_OFFSET),
+    )
+    load_sizes_ptr.add_use(Physical(vmctx_preg))
+    load_sizes_ptr.add_def({ reg: Virtual(table_sizes_ptr) })
+    block.add_inst(load_sizes_ptr)
+
+    // Load table_size from table_sizes[table_idx]
+    let load_size = @instr.VCodeInst::new(LoadPtr(@instr.I64, table_idx * 8))
+    load_size.add_use(Virtual(table_sizes_ptr))
+    load_size.add_def({ reg: Virtual(table_size) })
+    block.add_inst(load_size)
+
+    // Load tables array pointer
+    let tables_ptr = ctx.new_vreg(@abi.Int)
+    let load_tables_ptr = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLES_OFFSET),
+    )
+    load_tables_ptr.add_use(Physical(vmctx_preg))
+    load_tables_ptr.add_def({ reg: Virtual(tables_ptr) })
+    block.add_inst(load_tables_ptr)
+
+    // Load table_base from tables[table_idx]
+    let load_table = @instr.VCodeInst::new(LoadPtr(@instr.I64, table_idx * 8))
+    load_table.add_use(Virtual(tables_ptr))
+    load_table.add_def({ reg: Virtual(table_base) })
+    block.add_inst(load_table)
+  }
+
+  // Step 3: Bounds check - trap if elem_idx >= table_size
+  let trap_inst = @instr.VCodeInst::new(TrapIfUge(1)) // trap code 1 = out of bounds
+  trap_inst.add_use(Virtual(elem_idx_64))
+  trap_inst.add_use(Virtual(table_size))
+  block.add_inst(trap_inst)
+
+  // Step 5: Calculate address: addr = table_base + (elem_idx << 4)
   // Each table element is 16 bytes (func_ptr + type_idx)
   let addr = ctx.new_vreg(@abi.Int)
   let calc_addr = @instr.VCodeInst::new(AddShifted(@instr.Lsl, 4))
   calc_addr.add_use(Virtual(table_base))
-  calc_addr.add_use(Virtual(elem_idx))
+  calc_addr.add_use(Virtual(elem_idx_64))
   calc_addr.add_def({ reg: Virtual(addr) })
   block.add_inst(calc_addr)
 
-  // Step 3: Load result from addr
+  // Step 6: Load result from addr
   let load_result = @instr.VCodeInst::new(LoadPtr(@instr.I64, 0))
   load_result.add_use(Virtual(addr))
   load_result.add_def({ reg: Virtual(result_vreg) })
@@ -2234,45 +2297,188 @@ fn lower_table_get(
 /// instead of deferring to emit phase with hardcoded registers.
 ///
 /// Generated sequence:
-/// 1. table_base = LoadPtr(I64, VMCTX_TABLE0_BASE_OFFSET) from vmctx (X19)
-/// 2. addr = AddShifted(table_base, elem_idx, Lsl, 4)  // addr = table_base + elem_idx * 16
-/// 3. StorePtr(I64, 0) value to addr
+/// 1. elem_idx_64 = Extend(elem_idx, Unsigned32To64) // zero-extend 32->64
+/// 2. table_size = LoadPtr(I64, VMCTX_TABLE0_ELEMENTS_OFFSET) from vmctx
+/// 3. TrapIfUge(elem_idx_64, table_size, 1) // trap if out of bounds
+/// 4. table_base = LoadPtr(I64, VMCTX_TABLE0_BASE_OFFSET) from vmctx (X19)
+/// 5. addr = AddShifted(table_base, elem_idx_64, Lsl, 4)  // addr = table_base + elem_idx * 16
+/// 6. StorePtr(I64, 0) value to addr
 fn lower_table_set(
   ctx : LoweringContext,
   inst : @ir.Inst,
   block : @block.VCodeBlock,
   table_idx : Int,
 ) -> Unit {
-  ignore(table_idx) // Currently only table 0 is supported
   // Get the operands: elem_idx and value
   guard inst.operands.length() >= 2 else { return }
   let elem_idx = ctx.get_vreg_for_use(inst.operands[0], block)
   let value = ctx.get_vreg_for_use(inst.operands[1], block)
 
-  // Step 1: Load table0_base from vmctx
+  // Step 1: Zero-extend elem_idx from 32-bit to 64-bit
+  let elem_idx_64 = ctx.new_vreg(@abi.Int)
+  let extend_inst = @instr.VCodeInst::new(Extend(Unsigned32To64))
+  extend_inst.add_def({ reg: Virtual(elem_idx_64) })
+  extend_inst.add_use(Virtual(elem_idx))
+  block.add_inst(extend_inst)
   let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
-  let table_base = ctx.new_vreg(@abi.Int)
-  let load_table = @instr.VCodeInst::new(
-    LoadPtr(@instr.I64, @abi.VMCTX_TABLE0_BASE_OFFSET),
-  )
-  load_table.add_use(Physical(vmctx_preg))
-  load_table.add_def({ reg: Virtual(table_base) })
-  block.add_inst(load_table)
 
-  // Step 2: Calculate address: addr = table_base + (elem_idx << 4)
+  // Load table_size and table_base depending on table_idx
+  let table_size = ctx.new_vreg(@abi.Int)
+  let table_base = ctx.new_vreg(@abi.Int)
+  if table_idx == 0 {
+    // Fast path for table 0
+    // Step 2: Load table_size from vmctx
+    let load_size = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLE0_ELEMENTS_OFFSET),
+    )
+    load_size.add_use(Physical(vmctx_preg))
+    load_size.add_def({ reg: Virtual(table_size) })
+    block.add_inst(load_size)
+
+    // Step 4: Load table0_base from vmctx
+    let load_table = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLE0_BASE_OFFSET),
+    )
+    load_table.add_use(Physical(vmctx_preg))
+    load_table.add_def({ reg: Virtual(table_base) })
+    block.add_inst(load_table)
+  } else {
+    // Multi-table path
+    // Load table_sizes array pointer
+    let table_sizes_ptr = ctx.new_vreg(@abi.Int)
+    let load_sizes_ptr = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLE_SIZES_OFFSET),
+    )
+    load_sizes_ptr.add_use(Physical(vmctx_preg))
+    load_sizes_ptr.add_def({ reg: Virtual(table_sizes_ptr) })
+    block.add_inst(load_sizes_ptr)
+
+    // Load table_size from table_sizes[table_idx]
+    let load_size = @instr.VCodeInst::new(LoadPtr(@instr.I64, table_idx * 8))
+    load_size.add_use(Virtual(table_sizes_ptr))
+    load_size.add_def({ reg: Virtual(table_size) })
+    block.add_inst(load_size)
+
+    // Load tables array pointer
+    let tables_ptr = ctx.new_vreg(@abi.Int)
+    let load_tables_ptr = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLES_OFFSET),
+    )
+    load_tables_ptr.add_use(Physical(vmctx_preg))
+    load_tables_ptr.add_def({ reg: Virtual(tables_ptr) })
+    block.add_inst(load_tables_ptr)
+
+    // Load table_base from tables[table_idx]
+    let load_table = @instr.VCodeInst::new(LoadPtr(@instr.I64, table_idx * 8))
+    load_table.add_use(Virtual(tables_ptr))
+    load_table.add_def({ reg: Virtual(table_base) })
+    block.add_inst(load_table)
+  }
+
+  // Step 3: Bounds check - trap if elem_idx >= table_size
+  let trap_inst = @instr.VCodeInst::new(TrapIfUge(1)) // trap code 1 = out of bounds
+  trap_inst.add_use(Virtual(elem_idx_64))
+  trap_inst.add_use(Virtual(table_size))
+  block.add_inst(trap_inst)
+
+  // Step 5: Calculate address: addr = table_base + (elem_idx << 4)
   // Each table element is 16 bytes (func_ptr + type_idx)
   let addr = ctx.new_vreg(@abi.Int)
   let calc_addr = @instr.VCodeInst::new(AddShifted(@instr.Lsl, 4))
   calc_addr.add_use(Virtual(table_base))
-  calc_addr.add_use(Virtual(elem_idx))
+  calc_addr.add_use(Virtual(elem_idx_64))
   calc_addr.add_def({ reg: Virtual(addr) })
   block.add_inst(calc_addr)
 
-  // Step 3: Store value to addr
+  // Step 6: Store value to addr
   let store_value = @instr.VCodeInst::new(StorePtr(@instr.I64, 0))
   store_value.add_use(Virtual(addr))
   store_value.add_use(Virtual(value))
   block.add_inst(store_value)
+}
+
+///|
+/// Lower table.size instruction
+/// Returns the current number of elements in the table
+///
+/// Generated sequence (for table 0):
+/// 1. result = LoadPtr(I64, VMCTX_TABLE0_ELEMENTS_OFFSET) from vmctx
+/// Generated sequence (for table N > 0):
+/// 1. table_sizes_ptr = LoadPtr(I64, VMCTX_TABLE_SIZES_OFFSET) from vmctx
+/// 2. result = LoadPtr(I64, table_idx * 8) from table_sizes_ptr
+/// Note: Result is returned as 64-bit but high 32 bits are always 0
+fn lower_table_size(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : @block.VCodeBlock,
+  table_idx : Int,
+) -> Unit {
+  // Get the result vreg
+  guard inst.result is Some(result) else { return }
+  let result_vreg = ctx.get_vreg(result)
+  let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
+  if table_idx == 0 {
+    // Fast path for table 0: load table0_elements from vmctx directly into result
+    let load_size = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLE0_ELEMENTS_OFFSET),
+    )
+    load_size.add_use(Physical(vmctx_preg))
+    load_size.add_def({ reg: Virtual(result_vreg) })
+    block.add_inst(load_size)
+  } else {
+    // Multi-table path: load from table_sizes array
+    // 1. Load table_sizes array pointer: [vmctx + VMCTX_TABLE_SIZES_OFFSET]
+    let table_sizes_ptr = ctx.new_vreg(@abi.Int)
+    let load_sizes = @instr.VCodeInst::new(
+      LoadPtr(@instr.I64, @abi.VMCTX_TABLE_SIZES_OFFSET),
+    )
+    load_sizes.add_use(Physical(vmctx_preg))
+    load_sizes.add_def({ reg: Virtual(table_sizes_ptr) })
+    block.add_inst(load_sizes)
+
+    // 2. Load size for this table: [table_sizes + table_idx * 8]
+    // Each size is 8 bytes (size_t)
+    let size_offset = table_idx * 8
+    let load_size = @instr.VCodeInst::new(LoadPtr(@instr.I64, size_offset))
+    load_size.add_use(Virtual(table_sizes_ptr))
+    load_size.add_def({ reg: Virtual(result_vreg) })
+    block.add_inst(load_size)
+  }
+}
+
+///|
+/// Lower table.grow instruction
+/// Grows the table by delta elements, initializing new elements with init_value
+/// Returns the previous size (as i32), or -1 if grow failed
+///
+/// This is a runtime call that goes through the C FFI
+fn lower_table_grow(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : @block.VCodeBlock,
+  table_idx : Int,
+) -> Unit {
+  // Get operands: delta, init_value
+  guard inst.operands.length() >= 2 else { return }
+  let delta = ctx.get_vreg_for_use(inst.operands[0], block)
+  let init_value = ctx.get_vreg_for_use(inst.operands[1], block)
+
+  // Get or create the result vreg
+  // Note: We must emit the call even if result is unused because table_grow has side effects
+  let result_vreg = match inst.result {
+    Some(result) => ctx.get_vreg(result)
+    None => ctx.vcode_func.new_vreg(@abi.Int) // Create a temp vreg for the unused result
+  }
+
+  // Create the TableGrow VCode instruction
+  // Uses: [delta, init_value], Defs: [result]
+  let grow_inst = @instr.VCodeInst::new(TableGrow(table_idx))
+  grow_inst.add_def({ reg: Virtual(result_vreg) })
+  grow_inst.add_use(Virtual(delta))
+  grow_inst.add_use(Virtual(init_value))
+  // Add clobbers for caller-saved registers (it's a call)
+  add_call_clobbers(grow_inst)
+  block.add_inst(grow_inst)
 }
 
 ///|

--- a/vcode/lower/regalloc.mbt
+++ b/vcode/lower/regalloc.mbt
@@ -1576,6 +1576,8 @@ fn has_side_effects(opcode : @instr.VCodeOpcode) -> Bool {
     CallIndirect(_, _) | CallPtr(_, _) => true
     // Memory operations have side effects (modify memory or global state)
     MemoryGrow(_) | MemoryFill | MemoryCopy => true
+    // Table operations have side effects (modify table state)
+    TableGrow(_) => true
     // Everything else is pure computation
     _ => false
   }


### PR DESCRIPTION
## Summary
- Implement `table.size` and `table.grow` WebAssembly instructions with full multi-table support
- Add `table_sizes` and `table_max_sizes` arrays to VMContext for proper bounds checking
- Fix DCE (Dead Code Elimination) to preserve side-effecting `TableGrow` instructions
- Fix `JITTable::new` to allow size 0 for tables that start empty but can grow

## Changes
### IR Layer
- Add `TableSize(Int)` and `TableGrow(Int)` opcodes
- Add builder methods `table_size()` and `table_grow()`
- Add translator support for WASM `table.size` and `table.grow`
- Mark `TableGrow` as having side effects in IR DCE

### VCode Layer  
- Add `TableGrow(Int)` VCode instruction
- Implement `lower_table_size` for both table 0 (fast path) and multi-table
- Implement `lower_table_grow` calling C runtime function
- Mark `TableGrow` as having side effects in VCode DCE
- Fix `lower_table_grow` to emit code even when result is unused

### C Runtime
- Add `wasmoon_jit_table_grow` function following Cranelift's pattern
- Add `table_sizes` and `table_max_sizes` to `jit_context_t`
- Update `wasmoon_jit_ctx_set_table_pointers` to accept max sizes

## Test Results
| Test | Result |
|------|--------|
| table_get.wast | 14/14 ✓ |
| table_set.wast | 25/25 ✓ |
| table_size.wast | 38/38 ✓ |
| table_grow.wast | 48/48 ✓ |
| moon test | 861/861 ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)