### PR TITLE
fix(wat): reject invalid type index in call_indirect

### DIFF
--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -52,7 +52,7 @@ pub fn ValidationErrorContext::from_error(
     StackUnderflow(m) => "stack underflow: \{m}"
     StackHeightMismatch(m) => "stack height mismatch: \{m}"
     InvalidFunctionIndex(idx) => "invalid function index: \{idx}"
-    InvalidTypeIndex(idx) => "invalid type index: \{idx}"
+    InvalidTypeIndex(idx) => "unknown type: \{idx}"
     InvalidLocalIndex(idx) => "invalid local index: \{idx}"
     InvalidGlobalIndex(idx) => "invalid global index: \{idx}"
     InvalidTableIndex(idx) => "invalid table index: \{idx}"
@@ -429,7 +429,7 @@ pub fn validate_module(mod : @types.Module) -> Unit raise ValidationError {
 
   // Validate that all function type indices are valid
   for i, type_idx in ctx.funcs {
-    if type_idx >= ctx.types.length() {
+    if type_idx < 0 || type_idx >= ctx.types.length() {
       raise InvalidTypeIndex(type_idx)
     }
     ignore(i)
@@ -554,7 +554,7 @@ pub fn validate_module(mod : @types.Module) -> Unit raise ValidationError {
   for i, code in mod.codes {
     let func_idx = num_imports + i
     let type_idx = ctx.funcs[func_idx]
-    if type_idx >= ctx.types.length() {
+    if type_idx < 0 || type_idx >= ctx.types.length() {
       raise InvalidTypeIndex(type_idx)
     }
     let func_type = ctx.types[type_idx]
@@ -571,7 +571,7 @@ pub fn validate_module_with_context(
 
   // Validate that all function type indices are valid
   for i, type_idx in ctx.funcs {
-    if type_idx >= ctx.types.length() {
+    if type_idx < 0 || type_idx >= ctx.types.length() {
       raise WithContext(
         ValidationErrorContext::from_error(InvalidTypeIndex(type_idx)),
       )
@@ -676,7 +676,7 @@ pub fn validate_module_with_context(
   for i, code in mod.codes {
     let func_idx = num_imports + i
     let type_idx = ctx.funcs[func_idx]
-    if type_idx >= ctx.types.length() {
+    if type_idx < 0 || type_idx >= ctx.types.length() {
       raise WithContext(
         ValidationErrorContext::from_error(InvalidTypeIndex(type_idx)).with_func_idx(
           func_idx,
@@ -1590,7 +1590,7 @@ fn validate_instr(
       }
     }
     CallIndirect(type_idx, table_idx) => {
-      if table_idx >= ctx.tables.length() {
+      if table_idx < 0 || table_idx >= ctx.tables.length() {
         raise InvalidTableIndex(table_idx)
       }
       // call_indirect requires a funcref table
@@ -1600,7 +1600,7 @@ fn validate_instr(
           "call_indirect requires funcref table, got \{table_type.elem_type}",
         )
       }
-      if type_idx >= ctx.types.length() {
+      if type_idx < 0 || type_idx >= ctx.types.length() {
         raise InvalidTypeIndex(type_idx)
       }
       stack.pop(@types.ValueType::I32) // table index
@@ -1615,7 +1615,7 @@ fn validate_instr(
       }
     }
     CallRef(type_idx) => {
-      if type_idx >= ctx.types.length() {
+      if type_idx < 0 || type_idx >= ctx.types.length() {
         raise InvalidTypeIndex(type_idx)
       }
       let func_type = ctx.types[type_idx]

--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -2724,7 +2724,7 @@ fn Parser::parse_plain_instruction(
       // (call_indirect (param ...) (result ...) ...)
       // (call_indirect ...)  - empty type
       let mut table_idx = 0
-      let mut type_idx = -1
+      let mut type_idx : Int? = None
       let inline_params : Array[@types.ValueType] = []
       let inline_results : Array[@types.ValueType] = []
 
@@ -2753,7 +2753,12 @@ fn Parser::parse_plain_instruction(
         match self.current {
           Keyword("type") => {
             self.advance()
-            type_idx = self.parse_type_idx()
+            let idx = self.parse_type_idx()
+            // Validate type index is in range (0xffffffff becomes -1 after parsing)
+            if idx < 0 || idx >= self.types.length() {
+              raise ParseError("unknown type", self.loc())
+            }
+            type_idx = Some(idx)
             self.expect_rparen()
           }
           Keyword("param") => {
@@ -2788,11 +2793,13 @@ fn Parser::parse_plain_instruction(
           }
         }
       }
-      if type_idx < 0 {
-        // No explicit (type $t), need to find or create type from inline annotations
-        type_idx = self.find_or_create_func_type(inline_params, inline_results)
+      let final_type_idx = match type_idx {
+        Some(idx) => idx
+        None =>
+          // No explicit (type $t), find or create type from inline annotations
+          self.find_or_create_func_type(inline_params, inline_results)
       }
-      @types.Instruction::CallIndirect(type_idx, table_idx)
+      @types.Instruction::CallIndirect(final_type_idx, table_idx)
     }
 
     // Parametric


### PR DESCRIPTION
## Summary
- Fix `call_indirect (type 0xffffffff)` being silently accepted instead of rejected
- Use `Option[Int]` instead of `-1` as sentinel value for "no explicit type"
- Add negative index checks in validator for robustness

## Problem
When parsing `(type 0xffffffff)` in call_indirect, the value overflows to -1. The parser previously used -1 as a sentinel meaning "no type specified", causing the invalid index to be silently replaced with a newly created valid type.

## Solution
- Change `type_idx` from `Int` (with -1 sentinel) to `Int?` (with None sentinel)
- Validate type index immediately after parsing, before the sentinel check
- Also add `idx < 0` checks in validator for binary wasm validation

## Test plan
- [x] `./wasmoon test testsuite/data/call_indirect.wast` passes (169/169)
- [x] `moon test` passes (862/862)

🤖 Generated with [Claude Code](https://claude.com/claude-code)