### PR TITLE
fix(jit): preserve trapping instructions during DCE

### DIFF
--- a/ir/optimize.mbt
+++ b/ir/optimize.mbt
@@ -117,6 +117,10 @@ fn has_side_effects(inst : Inst) -> Bool {
     // Global operations: GlobalGet reads mutable state, GlobalSet modifies it
     // Mark both as having side effects to prevent incorrect CSE
     GlobalGet(_) | GlobalSet(_) => true
+    // Division/remainder can trap on divide-by-zero or overflow (INT_MIN / -1)
+    Sdiv | Udiv | Srem | Urem => true
+    // Float-to-int conversion can trap on NaN or out-of-range values
+    FcvtToSint | FcvtToUint => true
     // Other instructions are pure
     _ => false
   }

--- a/testsuite/call_test.mbt
+++ b/testsuite/call_test.mbt
@@ -196,36 +196,31 @@ test "call: as-memory-grow-value" {
   inspect(result, content="matched")
 }
 
-// TODO: This test is disabled due to ABI mismatch for functions with many params.
-// The issue: lower.mbt treats all first 8 params as register params regardless of type,
-// but CallIndirect emitter separates int/float args into different register pools.
-// For functions with >8 params of mixed types, the stack layout doesn't match.
-// Fix requires making lower.mbt track int/float params separately.
-// ///|
-// test "call: return-from-long-argument-list" {
-//   let source =
-//     #|(module
-//     #|  (func $return-from-long-argument-list-helper
-//     #|        (param f32 i32 i32 f64 f32 f32 f32 f64 f32 i32 i32 f32 f64 i64 i64 i32 i64 i64 f32 i64 i64 i64 i32 f32 f32 f32 f64 f32 i32 i64 f32 f64 f64 f32 i32 f32 f32 f64 i64 f64 i32 i64 f32 f64 i32 i32 i32 i64 f64 i32 i64 i64 f64 f64 f64 f64 f64 f64 i32 f32 f64 f64 i32 i64 f32 f32 f32 i32 f64 f64 f64 f64 f64 f32 i64 i64 i32 i32 i32 f32 f64 i32 i64 f32 f32 f32 i32 i32 f32 f64 i64 f32 f64 f32 f32 f32 i32 f32 i64 i32)
-//     #|        (result i32)
-//     #|    (local.get 99)
-//     #|  )
-//     #|  (func (export "return-from-long-argument-list") (param i32) (result i32)
-//     #|    (call $return-from-long-argument-list-helper
-//     #|      (f32.const 0) (i32.const 0) (i32.const 0) (f64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (i32.const 0)
-//     #|      (i32.const 0) (f32.const 0) (f64.const 0) (i64.const 0) (i64.const 0) (i32.const 0) (i64.const 0) (i64.const 0) (f32.const 0) (i64.const 0)
-//     #|      (i64.const 0) (i64.const 0) (i32.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (i32.const 0) (i64.const 0)
-//     #|      (f32.const 0) (f64.const 0) (f64.const 0) (f32.const 0) (i32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (i64.const 0) (f64.const 0)
-//     #|      (i32.const 0) (i64.const 0) (f32.const 0) (f64.const 0) (i32.const 0) (i32.const 0) (i32.const 0) (i64.const 0) (f64.const 0) (i32.const 0)
-//     #|      (i64.const 0) (i64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (i32.const 0) (f32.const 0)
-//     #|      (f64.const 0) (f64.const 0) (i32.const 0) (i64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (f64.const 0) (f64.const 0)
-//     #|      (f64.const 0) (f64.const 0) (f64.const 0) (f32.const 0) (i64.const 0) (i64.const 0) (i32.const 0) (i32.const 0) (i32.const 0) (f32.const 0)
-//     #|      (f64.const 0) (i32.const 0) (i64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (i32.const 0) (f32.const 0) (f64.const 0)
-//     #|      (i64.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (f32.const 0) (i64.const 0) (local.get 0))
-//     #|  )
-//     #|)
-//   let result = compare_jit_interp(source, "return-from-long-argument-list", [
-//     I32(42),
-//   ])
-//   inspect(result, content="matched")
-// }
+///|
+test "call: return-from-long-argument-list" {
+  let source =
+    #|(module
+    #|  (func $return-from-long-argument-list-helper
+    #|        (param f32 i32 i32 f64 f32 f32 f32 f64 f32 i32 i32 f32 f64 i64 i64 i32 i64 i64 f32 i64 i64 i64 i32 f32 f32 f32 f64 f32 i32 i64 f32 f64 f64 f32 i32 f32 f32 f64 i64 f64 i32 i64 f32 f64 i32 i32 i32 i64 f64 i32 i64 i64 f64 f64 f64 f64 f64 f64 i32 f32 f64 f64 i32 i64 f32 f32 f32 i32 f64 f64 f64 f64 f64 f32 i64 i64 i32 i32 i32 f32 f64 i32 i64 f32 f32 f32 i32 i32 f32 f64 i64 f32 f64 f32 f32 f32 i32 f32 i64 i32)
+    #|        (result i32)
+    #|    (local.get 99)
+    #|  )
+    #|  (func (export "return-from-long-argument-list") (param i32) (result i32)
+    #|    (call $return-from-long-argument-list-helper
+    #|      (f32.const 0) (i32.const 0) (i32.const 0) (f64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (i32.const 0)
+    #|      (i32.const 0) (f32.const 0) (f64.const 0) (i64.const 0) (i64.const 0) (i32.const 0) (i64.const 0) (i64.const 0) (f32.const 0) (i64.const 0)
+    #|      (i64.const 0) (i64.const 0) (i32.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (i32.const 0) (i64.const 0)
+    #|      (f32.const 0) (f64.const 0) (f64.const 0) (f32.const 0) (i32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (i64.const 0) (f64.const 0)
+    #|      (i32.const 0) (i64.const 0) (f32.const 0) (f64.const 0) (i32.const 0) (i32.const 0) (i32.const 0) (i64.const 0) (f64.const 0) (i32.const 0)
+    #|      (i64.const 0) (i64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (i32.const 0) (f32.const 0)
+    #|      (f64.const 0) (f64.const 0) (i32.const 0) (i64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (f64.const 0) (f64.const 0)
+    #|      (f64.const 0) (f64.const 0) (f64.const 0) (f32.const 0) (i64.const 0) (i64.const 0) (i32.const 0) (i32.const 0) (i32.const 0) (f32.const 0)
+    #|      (f64.const 0) (i32.const 0) (i64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (i32.const 0) (f32.const 0) (f64.const 0)
+    #|      (i64.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (f32.const 0) (i64.const 0) (local.get 0))
+    #|  )
+    #|)
+  let result = compare_jit_interp(source, "return-from-long-argument-list", [
+    I32(42),
+  ])
+  inspect(result, content="matched")
+}

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -490,24 +490,28 @@ fn lower_div(
   block : @block.VCodeBlock,
   signed~ : Bool,
 ) -> Unit {
+  let lhs = ctx.get_vreg_for_use(inst.operands[0], block)
+  let rhs = ctx.get_vreg_for_use(inst.operands[1], block)
+  let is_64 = inst.operands[0].ty is @ir.Type::I64
+
+  // Trap if divisor is zero (trap_code 4 = integer divide by zero)
+  // Must always emit even if result is unused (for side effect)
+  let trap_zero = @instr.VCodeInst::new(TrapIfZero(is_64, 4))
+  trap_zero.add_use(Virtual(rhs))
+  block.add_inst(trap_zero)
+
+  // For signed division, also trap if INT_MIN / -1 (would overflow)
+  // Use trap_code 5 = integer overflow
+  if signed {
+    let trap_overflow = @instr.VCodeInst::new(TrapIfDivOverflow(is_64, 5))
+    trap_overflow.add_use(Virtual(lhs))
+    trap_overflow.add_use(Virtual(rhs))
+    block.add_inst(trap_overflow)
+  }
+
+  // Only emit division if result is used
   if inst.result is Some(result) {
     let dst = ctx.get_vreg(result)
-    let lhs = ctx.get_vreg_for_use(inst.operands[0], block)
-    let rhs = ctx.get_vreg_for_use(inst.operands[1], block)
-    let is_64 = result.ty is @ir.Type::I64
-    // Trap if divisor is zero (trap_code 4 = integer divide by zero)
-    let trap_zero = @instr.VCodeInst::new(TrapIfZero(is_64, 4))
-    trap_zero.add_use(Virtual(rhs))
-    block.add_inst(trap_zero)
-    // For signed division, also trap if INT_MIN / -1 (would overflow)
-    // Use trap_code 5 = integer overflow
-    if signed {
-      let trap_overflow = @instr.VCodeInst::new(TrapIfDivOverflow(is_64, 5))
-      trap_overflow.add_use(Virtual(lhs))
-      trap_overflow.add_use(Virtual(rhs))
-      block.add_inst(trap_overflow)
-    }
-    // Emit division
     let opcode : @instr.VCodeOpcode = if signed {
       @instr.VCodeOpcode::SDiv(is_64)
     } else {
@@ -1073,35 +1077,43 @@ fn lower_rem(
   block : @block.VCodeBlock,
   signed : Bool,
 ) -> Unit {
-  guard inst.result is Some(result) else { return }
-  let dst = ctx.get_vreg(result)
   let lhs = ctx.get_vreg_for_use(inst.operands[0], block) // a (dividend)
   let rhs = ctx.get_vreg_for_use(inst.operands[1], block) // b (divisor)
-  let is_64 = result.ty is @ir.Type::I64
+  let is_64 = inst.operands[0].ty is @ir.Type::I64
 
-  // Trap if divisor is zero (trap_code 4 = integer_overflow)
+  // Trap if divisor is zero (trap_code 4 = integer divide by zero)
+  // Must always emit even if result is unused (for side effect)
   let trap_zero = @instr.VCodeInst::new(TrapIfZero(is_64, 4))
   trap_zero.add_use(Virtual(rhs))
   block.add_inst(trap_zero)
 
-  // Step 1: Compute quotient = a / b
-  let quotient = ctx.vcode_func.new_vreg(Int)
-  let div_opcode = if signed { @instr.SDiv(is_64) } else { @instr.UDiv(is_64) }
-  let div_inst = @instr.VCodeInst::new(div_opcode)
-  div_inst.add_def({ reg: Virtual(quotient) })
-  div_inst.add_use(Virtual(lhs))
-  div_inst.add_use(Virtual(rhs))
-  block.add_inst(div_inst)
+  // Only emit remainder computation if result is used
+  if inst.result is Some(result) {
+    let dst = ctx.get_vreg(result)
 
-  // Step 2: Compute remainder = a - quotient * b using MSUB
-  // MSUB rd, rn, rm, ra computes: ra - rn * rm
-  // We want: a - quotient * b, so: ra=a, rn=quotient, rm=b
-  let msub_inst = @instr.VCodeInst::new(Msub)
-  msub_inst.add_def({ reg: Virtual(dst) })
-  msub_inst.add_use(Virtual(lhs)) // accumulator (a)
-  msub_inst.add_use(Virtual(quotient)) // multiplicand
-  msub_inst.add_use(Virtual(rhs)) // multiplier (b)
-  block.add_inst(msub_inst)
+    // Step 1: Compute quotient = a / b
+    let quotient = ctx.vcode_func.new_vreg(Int)
+    let div_opcode = if signed {
+      @instr.SDiv(is_64)
+    } else {
+      @instr.UDiv(is_64)
+    }
+    let div_inst = @instr.VCodeInst::new(div_opcode)
+    div_inst.add_def({ reg: Virtual(quotient) })
+    div_inst.add_use(Virtual(lhs))
+    div_inst.add_use(Virtual(rhs))
+    block.add_inst(div_inst)
+
+    // Step 2: Compute remainder = a - quotient * b using MSUB
+    // MSUB rd, rn, rm, ra computes: ra - rn * rm
+    // We want: a - quotient * b, so: ra=a, rn=quotient, rm=b
+    let msub_inst = @instr.VCodeInst::new(Msub)
+    msub_inst.add_def({ reg: Virtual(dst) })
+    msub_inst.add_use(Virtual(lhs)) // accumulator (a)
+    msub_inst.add_use(Virtual(quotient)) // multiplicand
+    msub_inst.add_use(Virtual(rhs)) // multiplier (b)
+    block.add_inst(msub_inst)
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Mark division/remainder/float-to-int as having side effects in DCE
- Refactor lower_div/lower_rem to emit trap checks unconditionally
- Enable long argument list test that was previously disabled

## Problem
Instructions like `drop(i32.div_s(x, 0))` were being eliminated by DCE because the result was unused. However, these operations should still trap on divide-by-zero, overflow, or NaN conversion.

## Solution
1. **IR layer**: Add `Sdiv | Udiv | Srem | Urem | FcvtToSint | FcvtToUint => true` to `has_side_effects`
2. **VCode layer**: Refactor `lower_div` and `lower_rem` to always emit trap checks, only skip the actual computation when result is unused

## Test plan
- [x] `./wasmoon test testsuite/data/traps.wast` passes (32/32)
- [x] `moon test` passes (861/861)

🤖 Generated with [Claude Code](https://claude.com/claude-code)