### PR TITLE
refactor: use idiomatic MoonBit patterns

### DIFF
--- a/main/run.mbt
+++ b/main/run.mbt
@@ -209,14 +209,9 @@ fn run_wasm(
         println(result_strs.join(" "))
       }
     }
-  } else {
     // No exported function found, check if there's a start function
-    match invoke {
-      Some(name) => println("Error: function '\{name}' not found")
-      None =>
-        // Module was already initialized with start function if present
-        ()
-    }
+  } else if invoke is Some(name) {
+    println("Error: function '\{name}' not found")
   }
 }
 

--- a/main/wast.mbt
+++ b/main/wast.mbt
@@ -290,11 +290,10 @@ fn has_unsupported_instructions(mod_ : @types.Module) -> Bool {
 fn has_unsupported_elem_init(mod_ : @types.Module) -> Bool {
   for elem in mod_.elems {
     for init_expr in elem.init {
-      match init_expr {
-        // GlobalGet in elem init is not supported by JIT
-        // because it may reference imported funcref globals (cross-module)
-        [GlobalGet(_)] => return true
-        _ => ()
+      // GlobalGet in elem init is not supported by JIT
+      // because it may reference imported funcref globals (cross-module)
+      if init_expr is [GlobalGet(_)] {
+        return true
       }
     }
   }
@@ -353,9 +352,8 @@ fn has_cross_module_imports(mod_ : @types.Module) -> Bool {
 /// These might be imported by other modules, and JIT can't share the backing storage
 fn exports_shared_resources(mod_ : @types.Module) -> Bool {
   for exp in mod_.exports {
-    match exp.desc {
-      Memory(_) | Table(_) => return true
-      _ => ()
+    if exp.desc is (Memory(_) | Table(_)) {
+      return true
     }
   }
   false

--- a/vcode/lower/regalloc.mbt
+++ b/vcode/lower/regalloc.mbt
@@ -915,21 +915,16 @@ pub fn LinearScanAllocator::allocate(
 
     // Try to allocate a register
     let assigned = self.try_allocate_reg(interval, avail_regs)
-    match assigned {
-      Some(preg) => {
-        // Preserve the original vreg's class when storing the assignment
-        // This is important for Bitcast to distinguish f32 vs f64 operations
-        let assigned_preg : @abi.PReg = {
-          index: preg.index,
-          class: interval.vreg.class,
-        }
-        interval.assigned = Some(assigned_preg)
-        self.active.push(interval)
-        result.assignments.set(interval.vreg.id, assigned_preg)
+    if assigned is Some(preg) {
+      let assigned_preg : @abi.PReg = {
+        index: preg.index,
+        class: interval.vreg.class,
       }
-      None =>
-        // Need to spill
-        self.spill_interval(func, interval, result)
+      interval.assigned = Some(assigned_preg)
+      self.active.push(interval)
+      result.assignments.set(interval.vreg.id, assigned_preg)
+    } else {
+      self.spill_interval(func, interval, result)
     }
   }
   result.num_spill_slots = self.next_spill_slot

--- a/wat/lexer_wbtest.mbt
+++ b/wat/lexer_wbtest.mbt
@@ -160,7 +160,7 @@ test "LocatedToken: lparen position tracking" {
 ///|
 test "LocatedToken: keyword position tracking" {
   let lexer = Lexer::new("(module)")
-  let _ = lexer.next_token() catch { _ => fail("unexpected error") }
+  (lexer.next_token() catch { _ => fail("unexpected error") }) |> ignore
   let tok = lexer.next_token() catch { _ => fail("unexpected error") }
   inspect(tok.token, content="Keyword(\"module\")")
   inspect(tok.span.start_line, content="1")


### PR DESCRIPTION
## Summary
- Use `if x is Pattern` instead of `match x { Pattern => ... _ => () }` for single-arm matches
- Use `expr |> ignore` instead of `let _ = expr`

## Test plan
- [x] `moon check` passes
- [x] No functional changes, only style improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)