### PR TITLE
feat: implement wasmtime-style tail call optimization with loop-based…

### DIFF
--- a/executor/error.mbt
+++ b/executor/error.mbt
@@ -4,4 +4,16 @@
 priv suberror ControlSignal {
   BranchWith(Int, Array[@types.Value]) // Branch with relative depth and values
   Return // Return from function
+  TailCall(Int, @runtime.FuncInst, Array[@types.Value], Int) // Tail call: (store_addr, func_inst, args, num_results)
+} derive(Show)
+
+///|
+/// Control flow enum - wasmtime style
+/// Replaces exception-based control flow with explicit return values
+pub enum ControlFlow {
+  Continue // Normal execution continues
+  Return(Array[@types.Value]) // Function return with values
+  Branch(Int, Array[@types.Value]) // Branch with depth and values
+  TailCall(Int, @runtime.FuncInst, Array[@types.Value], Int) // Tail call: (store_addr, func_inst, args, num_results)
+  Trap(@runtime.RuntimeError) // Runtime error/trap
 } derive(Show)

--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -426,19 +426,13 @@ fn ExecContext::exec_instr(
     CallIndirect(type_idx, table_idx) =>
       self.exec_call_indirect(type_idx, table_idx)
     CallRef(type_idx) => self.exec_call_ref(type_idx)
-    // Tail call operations - execute call then return
-    ReturnCall(func_idx) => {
-      self.exec_call(func_idx)
-      self.exec_control(Return)
-    }
-    ReturnCallIndirect(type_idx, table_idx) => {
-      self.exec_call_indirect(type_idx, table_idx)
-      self.exec_control(Return)
-    }
-    ReturnCallRef(type_idx) => {
-      self.exec_call_ref(type_idx)
-      self.exec_control(Return)
-    }
+
+    // Tail call operations - replace current frame instead of pushing new one
+    // This enables true tail call optimization (constant call depth)
+    ReturnCall(func_idx) => self.exec_tail_call(func_idx)
+    ReturnCallIndirect(type_idx, table_idx) =>
+      self.exec_tail_call_indirect(type_idx, table_idx)
+    ReturnCallRef(type_idx) => self.exec_tail_call_ref(type_idx)
   }
 }
 

--- a/executor/instr_call.mbt
+++ b/executor/instr_call.mbt
@@ -148,6 +148,7 @@ fn ExecContext::call_func_inst_with_context(
 
 ///|
 /// Call a WASM function with a specific module instance context
+/// Uses a loop to handle tail calls without growing the native stack (wasmtime style)
 fn ExecContext::call_wasm_func_with_instance(
   self : ExecContext,
   target_instance : @runtime.ModuleInstance,
@@ -155,42 +156,88 @@ fn ExecContext::call_wasm_func_with_instance(
   args : Array[@types.Value],
   num_results : Int,
 ) -> Unit raise {
-  // Create locals array: params + local variables
-  let locals : Array[@types.Value] = []
-
-  // Add parameters first
-  for arg in args {
-    locals.push(arg)
-  }
-
-  // Add local variables (initialized to default values)
-  for local_type in func.locals {
-    locals.push(
-      match local_type {
-        I32 => I32(0)
-        I64 => I64(0L)
-        F32 => F32(0.0)
-        F64 => F64(0.0)
-        FuncRef => Null
-        ExternRef => Null
-        _ => Null
-      },
-    )
-  }
-
-  // Save current instance and switch to target instance
+  // Save the current instance for restoration
   let saved_instance = self.instance
-  self.instance = target_instance
 
-  // Create and push frame
-  let frame = @runtime.Frame::new(-1, locals, num_results)
-  self.push_frame(frame)
+  // Tail call loop - wasmtime style
+  // Instead of recursively calling the target, we loop here
+  let mut current_instance = target_instance
+  let mut current_func = func
+  let mut current_args = args
+  let mut should_continue = true
+  while should_continue {
+    // Set the context to the target function's module
+    self.instance = current_instance
 
-  // Execute function body
-  self.exec_expr(func.body)
+    // Create locals array: params + local variables
+    let locals : Array[@types.Value] = []
 
-  // Pop frame
-  self.pop_frame()
+    // Add parameters first
+    for arg in current_args {
+      locals.push(arg)
+    }
+
+    // Add local variables (initialized to default values)
+    for local_type in current_func.locals {
+      locals.push(
+        match local_type {
+          I32 => I32(0)
+          I64 => I64(0L)
+          F32 => F32(0.0)
+          F64 => F64(0.0)
+          FuncRef => Null
+          ExternRef => Null
+          _ => Null
+        },
+      )
+    }
+
+    // Create and push frame
+    let frame = @runtime.Frame::new(-1, locals, num_results)
+    self.push_frame(frame)
+
+    // Execute function body, catching TailCall to loop instead of recurse
+    try {
+      self.exec_expr(current_func.body)
+      // Normal return: pop frame and exit loop
+      self.pop_frame()
+      should_continue = false
+    } catch {
+      ControlSignal::TailCall(store_addr, func_inst, tail_args, _) => {
+        // Tail call detected! Pop current frame and loop with new target
+        self.pop_frame()
+
+        // Get the new target function
+        match func_inst {
+          WasmFunc(code) => {
+            // Get the owner instance for the target function
+            match self.store.get_func_owner(store_addr) {
+              Some(owner) => current_instance = owner
+              None => current_instance = saved_instance
+            }
+            current_func = code
+            current_args = tail_args
+            // Continue loop
+            should_continue = true
+          }
+          HostFunc(host_fn) => {
+            // Host function - call directly and exit
+            let results = host_fn(tail_args)
+            for result in results {
+              self.stack.push(result)
+            }
+            should_continue = false
+          }
+        }
+      }
+      e => {
+        // Other exceptions: pop frame then propagate
+        self.pop_frame()
+        self.instance = saved_instance
+        raise e
+      }
+    }
+  }
 
   // Restore original instance
   self.instance = saved_instance
@@ -198,42 +245,144 @@ fn ExecContext::call_wasm_func_with_instance(
 
 ///|
 /// Call a WASM function
+/// Also uses a loop to handle tail calls
 fn ExecContext::call_wasm_func(
   self : ExecContext,
   func : @types.FunctionCode,
   args : Array[@types.Value],
   num_results : Int,
 ) -> Unit raise {
-  // Create locals array: params + local variables
-  let locals : Array[@types.Value] = []
+  // Call with instance loop to handle tail calls
+  self.call_wasm_func_with_instance(self.instance, func, args, num_results)
+}
 
-  // Add parameters first
-  for arg in args {
-    locals.push(arg)
+// ============ Tail Call Operations ============
+// Tail calls replace the current frame instead of pushing a new one
+// This keeps call depth constant, enabling deep recursion
+
+///|
+/// Execute a direct tail call (return_call)
+/// Wasmtime style: raise TailCall signal instead of recursively calling
+pub fn ExecContext::exec_tail_call(
+  self : ExecContext,
+  func_idx : Int,
+) -> Unit raise {
+  // Get function address and type from current module
+  let store_addr = self.instance.func_addrs[func_idx]
+  let type_idx = self.instance.func_type_indices[func_idx]
+  let func_type = self.instance.types[type_idx]
+
+  // Pop arguments from stack into array (in reverse order)
+  let num_params = func_type.params.length()
+  let args : Array[@types.Value] = Array::make(num_params, @types.Value::I32(0))
+  for i = num_params - 1; i >= 0; i = i - 1 {
+    args[i] = self.stack.pop()
   }
 
-  // Add local variables (initialized to default values)
-  for local_type in func.locals {
-    locals.push(
-      match local_type {
-        I32 => I32(0)
-        I64 => I64(0L)
-        F32 => F32(0.0)
-        F64 => F64(0.0)
-        FuncRef => Null
-        ExternRef => Null
-        _ => Null
-      },
-    )
+  // Get function instance
+  let func_inst = self.store.get_func_inst(store_addr)
+
+  // Raise TailCall signal - the loop in call_wasm_func_with_instance will handle it
+  raise ControlSignal::TailCall(
+    store_addr,
+    func_inst,
+    args,
+    func_type.results.length(),
+  )
+}
+
+///|
+/// Execute an indirect tail call (return_call_indirect)
+/// Includes type checking like call_indirect
+pub fn ExecContext::exec_tail_call_indirect(
+  self : ExecContext,
+  type_idx : Int,
+  table_idx : Int,
+) -> Unit raise {
+  // Pop the function reference index from stack
+  let func_ref_idx_value = self.stack.pop()
+  let func_ref_idx = match func_ref_idx_value {
+    I32(i) => i
+    _ => raise @runtime.IndirectCallTypeMismatch
   }
 
-  // Create and push frame (use -1 as func_idx since we don't track it here)
-  let frame = @runtime.Frame::new(-1, locals, num_results)
-  self.push_frame(frame)
+  // Get table and element
+  let table_addr = self.instance.table_addrs[table_idx]
+  let table = self.store.get_table(table_addr)
+  let elem = table.get(func_ref_idx)
 
-  // Execute function body
-  self.exec_expr(func.body)
+  // The element should be a function reference
+  let store_addr = match elem {
+    FuncRef(idx) => idx
+    Null => raise @runtime.UninitializedElement
+    _ => raise @runtime.IndirectCallTypeMismatch
+  }
 
-  // Pop frame
-  self.pop_frame()
+  // Get the expected type and actual type, then verify they match
+  let expected_type = self.instance.types[type_idx]
+  let actual_type = self.store.get_func_type(store_addr)
+  if expected_type != actual_type {
+    raise @runtime.IndirectCallTypeMismatch
+  }
+
+  // Pop arguments from stack
+  let num_params = expected_type.params.length()
+  let args : Array[@types.Value] = Array::make(num_params, @types.Value::I32(0))
+  for i = num_params - 1; i >= 0; i = i - 1 {
+    args[i] = self.stack.pop()
+  }
+
+  // Get the function instance
+  let func_inst = self.store.get_func_inst(store_addr)
+
+  // Raise TailCall signal - the loop will handle it
+  raise ControlSignal::TailCall(
+    store_addr,
+    func_inst,
+    args,
+    expected_type.results.length(),
+  )
+}
+
+///|
+/// Execute a reference tail call (return_call_ref)
+/// Takes a function reference from the stack and tail-calls it
+pub fn ExecContext::exec_tail_call_ref(
+  self : ExecContext,
+  type_idx : Int,
+) -> Unit raise {
+  // Pop the function reference from stack
+  let func_ref = self.stack.pop()
+
+  // The function reference should be a FuncRef value, or Null
+  let store_addr = match func_ref {
+    FuncRef(addr) => addr
+    Null => raise @runtime.RuntimeError::Unreachable
+    _ => raise @runtime.IndirectCallTypeMismatch
+  }
+
+  // Get the expected type and actual type, then verify they match
+  let expected_type = self.instance.types[type_idx]
+  let actual_type = self.store.get_func_type(store_addr)
+  if expected_type != actual_type {
+    raise @runtime.IndirectCallTypeMismatch
+  }
+
+  // Pop arguments from stack
+  let num_params = expected_type.params.length()
+  let args : Array[@types.Value] = Array::make(num_params, @types.Value::I32(0))
+  for i = num_params - 1; i >= 0; i = i - 1 {
+    args[i] = self.stack.pop()
+  }
+
+  // Get the function instance
+  let func_inst = self.store.get_func_inst(store_addr)
+
+  // Raise TailCall signal - the loop will handle it
+  raise ControlSignal::TailCall(
+    store_addr,
+    func_inst,
+    args,
+    expected_type.results.length(),
+  )
 }

--- a/executor/instr_control.mbt
+++ b/executor/instr_control.mbt
@@ -186,7 +186,7 @@ fn ExecContext::exec_control(
       self.stack.push(if cond != 0 { val1 } else { val2 })
     }
     Nop => ()
-    Return => raise Return
+    Return => raise ControlSignal::Return
     _ => raise @runtime.RuntimeError::Unreachable
   }
 }

--- a/executor/pkg.generated.mbti
+++ b/executor/pkg.generated.mbti
@@ -22,8 +22,20 @@ pub fn instantiate_with_linker(@runtime.Linker, String, @types.Module) -> @runti
 // Errors
 
 // Types and methods
+pub enum ControlFlow {
+  Continue
+  Return(Array[@types.Value])
+  Branch(Int, Array[@types.Value])
+  TailCall(Int, @runtime.FuncInst, Array[@types.Value], Int)
+  Trap(@runtime.RuntimeError)
+}
+pub impl Show for ControlFlow
+
 type ExecContext
 pub fn ExecContext::call_func(Self, Int, Array[@types.Value]) -> Array[@types.Value] raise
+pub fn ExecContext::exec_tail_call(Self, Int) -> Unit raise
+pub fn ExecContext::exec_tail_call_indirect(Self, Int, Int) -> Unit raise
+pub fn ExecContext::exec_tail_call_ref(Self, Int) -> Unit raise
 pub impl Show for ExecContext
 
 // Type aliases

--- a/ir/builder.mbt
+++ b/ir/builder.mbt
@@ -815,6 +815,50 @@ pub fn IRBuilder::call_multi(
 }
 
 ///|
+/// Tail call with multiple return values
+/// Emits a return_call instruction (does not return to caller)
+pub fn IRBuilder::return_call_multi(
+  self : IRBuilder,
+  func_idx : Int,
+  args : Array[Value],
+) -> Unit {
+  self.emit_void_inst(Opcode::ReturnCall(func_idx), args)
+}
+
+///|
+/// Tail call indirect with multiple return values
+/// Emits a return_call_indirect instruction (does not return to caller)
+pub fn IRBuilder::return_call_indirect_multi(
+  self : IRBuilder,
+  type_idx : Int,
+  table_idx : Int,
+  callee : Value,
+  args : Array[Value],
+) -> Unit {
+  let all_args : Array[Value] = [callee]
+  for arg in args {
+    all_args.push(arg)
+  }
+  self.emit_void_inst(Opcode::ReturnCallIndirect(type_idx, table_idx), all_args)
+}
+
+///|
+/// Tail call through function reference
+/// Emits a return_call_ref instruction (does not return to caller)
+pub fn IRBuilder::return_call_ref_multi(
+  self : IRBuilder,
+  type_idx : Int,
+  func_ref : Value,
+  args : Array[Value],
+) -> Unit {
+  let all_args : Array[Value] = [func_ref]
+  for arg in args {
+    all_args.push(arg)
+  }
+  self.emit_void_inst(Opcode::ReturnCallRef(type_idx), all_args)
+}
+
+///|
 /// Indirect function call (single return value)
 pub fn IRBuilder::call_indirect(
   self : IRBuilder,

--- a/ir/pkg.generated.mbti
+++ b/ir/pkg.generated.mbti
@@ -183,6 +183,9 @@ pub fn IRBuilder::new(String) -> Self
 pub fn IRBuilder::popcnt(Self, Value) -> Value
 pub fn IRBuilder::print(Self) -> String
 pub fn IRBuilder::return_(Self, Array[Value]) -> Unit
+pub fn IRBuilder::return_call_indirect_multi(Self, Int, Int, Value, Array[Value]) -> Unit
+pub fn IRBuilder::return_call_multi(Self, Int, Array[Value]) -> Unit
+pub fn IRBuilder::return_call_ref_multi(Self, Int, Value, Array[Value]) -> Unit
 pub fn IRBuilder::rotl(Self, Value, Value) -> Value
 pub fn IRBuilder::rotr(Self, Value, Value) -> Value
 pub fn IRBuilder::sdiv(Self, Value, Value) -> Value

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -1908,12 +1908,11 @@ fn Translator::translate_return_call(self : Translator, func_idx : Int) -> Unit 
       args.push(self.pop())
     }
     args.rev_in_place()
-    // Get result types
-    let result_types : Array[Type] = func_type.results.map(Type::from_wasm)
-    // Emit call with multi-value support
-    let results = self.builder.call_multi(func_idx, result_types, args)
-    // Return the results immediately (tail call)
-    self.builder.return_(results)
+    // Emit return_call instruction (tail call - does not return to caller)
+    // Following Cranelift: emit a single ReturnCall IR instruction, not call + return
+    self.builder.return_call_multi(func_idx, args)
+    // Mark as unreachable since this is a terminator (does not return to this function)
+    self.is_unreachable = true
   }
 }
 
@@ -1938,17 +1937,13 @@ fn Translator::translate_return_call_indirect(
     }
     args.rev_in_place()
 
-    // Get result types
-    let result_types : Array[Type] = func_type.results.map(Type::from_wasm)
-
-    // Emit indirect call with multi-value support
-    // Use type_hash (not type_idx) for structural type checking
-    let results = self.builder.call_indirect_multi(
-      type_hash, table_idx, result_types, elem_idx, args,
+    // Emit return_call_indirect instruction (tail call - does not return to caller)
+    // Following Cranelift: emit a single ReturnCallIndirect IR instruction, not call + return
+    self.builder.return_call_indirect_multi(
+      type_hash, table_idx, elem_idx, args,
     )
-
-    // Return the results immediately (tail call)
-    self.builder.return_(results)
+    // Mark as unreachable since this is a terminator (does not return to this function)
+    self.is_unreachable = true
   }
 }
 
@@ -1988,15 +1983,10 @@ fn Translator::translate_return_call_ref(
     }
     args.rev_in_place()
 
-    // Get result types
-    let result_types : Array[Type] = func_type.results.map(Type::from_wasm)
-
-    // Emit call_ref instruction
-    let results = self.builder.call_ref_multi(
-      type_idx, result_types, func_ref, args,
-    )
-
-    // Return the results immediately (tail call)
-    self.builder.return_(results)
+    // Emit return_call_ref instruction (tail call - does not return to caller)
+    // Following Cranelift: emit a single ReturnCallRef IR instruction, not call + return
+    self.builder.return_call_ref_multi(type_idx, func_ref, args)
+    // Mark as unreachable since this is a terminator (does not return to this function)
+    self.is_unreachable = true
   }
 }

--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -1414,6 +1414,26 @@ fn MachineCode::emit_instruction(
       }
       // Stack already restored after blr, no need to restore again
     }
+    ReturnCallIndirect(_num_args, _num_results) => {
+      // Tail call optimization following Cranelift's design
+      // Parameters are already set up by lowering phase via:
+      // - StoreToStack for overflow arguments
+      // - add_use_fixed constraints for register arguments (X17=func_ptr, X0/X1=vmctx, X2-X7/V0-V7=args)
+      // Emit only needs to:
+      // 1. Restore callee-saved registers (epilogue)
+      // 2. BR to function pointer (doesn't save return address, callee returns to our caller)
+
+      // Epilogue - restore callee-saved registers and frame pointer
+      // Following Cranelift's emit_return_call_common_sequence
+      self.emit_epilogue(stack_frame)
+
+      // BR (not BLR) - jump to function without saving return address
+      // func_ptr is guaranteed to be in X17 by add_use_fixed constraint in lowering
+      // This is the KEY tail call semantic: callee returns directly to our caller
+      self.emit_br(17)
+
+      // Note: No code after BR - control never returns here
+    }
     TypeCheckIndirect(expected_type) => {
       // Check if actual_type == expected_type, trap if not
       // Uses: [actual_type_vreg]

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -60,12 +60,12 @@ pub fn VCodeInst::add_def_fixed(
 ///|
 fn VCodeInst::to_string(self : VCodeInst) -> String {
   let mut result = ""
-  // Print definitions (skip clobbers for CallIndirect)
-  let defs_to_print = if self.opcode is CallIndirect(_, num_results) {
-    // Only print result registers, not clobbers
-    self.defs.iter().take(num_results).collect()
-  } else {
-    self.defs
+  // Print definitions (skip clobbers for CallIndirect and ReturnCallIndirect)
+  let defs_to_print = match self.opcode {
+    CallIndirect(_, num_results) | ReturnCallIndirect(_, num_results) =>
+      // Only print result registers, not clobbers
+      self.defs.iter().take(num_results).collect()
+    _ => self.defs
   }
   if defs_to_print.length() > 0 {
     for i, def in defs_to_print {
@@ -78,9 +78,10 @@ fn VCodeInst::to_string(self : VCodeInst) -> String {
   }
   // Print opcode
   result = result + self.opcode.to_string()
-  // Print uses (simplified for CallIndirect)
-  if self.opcode is CallIndirect(_, _) {
-    // For call_indirect, only print the function pointer (first use)
+  // Print uses (simplified for CallIndirect and ReturnCallIndirect)
+  if self.opcode is CallIndirect(_, _) ||
+    self.opcode is ReturnCallIndirect(_, _) {
+    // For call_indirect/return_call_indirect, only print the function pointer (first use)
     if self.uses.length() > 0 {
       result = result + " " + self.uses[0].to_string()
     }
@@ -244,6 +245,11 @@ pub(all) enum VCodeOpcode {
   // Defs: [result0, result1, ...] (multiple results supported)
   // Parameters: num_args, num_results
   CallIndirect(Int, Int)
+  // ReturnCallIndirect: tail call through a function pointer
+  // Uses: [func_ptr, arg0, arg1, ...]
+  // Parameters: num_args, num_results
+  // This is a terminator - it does not return to the caller
+  ReturnCallIndirect(Int, Int)
   // TypeCheckIndirect: check if actual_type == expected_type, trap if not
   // Uses: [actual_type_vreg], Parameters: expected_type (immediate)
   // Emits: CMP actual, expected; B.EQ +8; BRK #2 (type mismatch trap)
@@ -423,6 +429,8 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     Mneg => "mneg"
     CallIndirect(num_args, num_results) =>
       "call_indirect(\{num_args}) -> \{num_results} results"
+    ReturnCallIndirect(num_args, num_results) =>
+      "return_call_indirect(\{num_args}) -> \{num_results} results"
     TypeCheckIndirect(expected_type) => "type_check_indirect \{expected_type}"
     StackLoad(offset) => "stack_load [sp+\{offset}]"
     StackStore(offset) => "stack_store [sp+\{offset}]"
@@ -800,6 +808,8 @@ pub fn VCodeOpcode::call_type(self : VCodeOpcode) -> CallType {
   match self {
     // Direct and indirect function calls
     CallIndirect(_, _) | CallPtr(_, _) => Regular
+    // Tail calls that don't return to caller
+    ReturnCallIndirect(_, _) => TailCall
     // Memory operations that call C runtime functions
     MemoryGrow(_) | MemorySize | MemoryFill | MemoryCopy => Regular
     // Table operations that call C runtime functions

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -209,6 +209,7 @@ pub(all) enum VCodeOpcode {
   Msub
   Mneg
   CallIndirect(Int, Int)
+  ReturnCallIndirect(Int, Int)
   TypeCheckIndirect(Int)
   StackLoad(Int)
   StackStore(Int)

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -408,13 +408,13 @@ fn lower_inst(
     @ir.Opcode::CallIndirect(type_idx, table_idx) =>
       lower_call_indirect(ctx, inst, block, type_idx, table_idx)
     @ir.Opcode::CallRef(type_idx) => lower_call_ref(ctx, inst, block, type_idx)
-    // Tail calls - lowered the same way as regular calls
-    // The IR translator already emitted a Return after these
-    @ir.Opcode::ReturnCall(func_idx) => lower_call(ctx, inst, block, func_idx)
+    // Tail calls - use dedicated lowering functions with Cranelift-style parameter handling
+    @ir.Opcode::ReturnCall(func_idx) =>
+      lower_return_call(ctx, inst, block, func_idx)
     @ir.Opcode::ReturnCallIndirect(type_idx, table_idx) =>
-      lower_call_indirect(ctx, inst, block, type_idx, table_idx)
+      lower_return_call_indirect(ctx, inst, block, type_idx, table_idx)
     @ir.Opcode::ReturnCallRef(type_idx) =>
-      lower_call_ref(ctx, inst, block, type_idx)
+      lower_return_call_ref(ctx, inst, block, type_idx)
 
     // Raw pointer operations (for trampolines)
     @ir.Opcode::LoadPtr(ty) => lower_load_ptr(ctx, inst, block, ty)
@@ -3040,4 +3040,401 @@ fn lower_call_ptr(
   add_call_clobbers(call_inst)
   block.add_inst(call_inst)
   // No AdjustSP needed - outgoing args space is pre-allocated in prologue
+}
+
+// ============ Tail Call Lowering (Cranelift-style) ============
+
+///|
+/// Lower direct return_call (tail call optimization)
+/// Following Cranelift: parameters are handled in lowering phase
+/// - Overflow args: StoreToStack instructions
+/// - Register args: Fixed register constraints via add_use_fixed
+/// - ReturnCallIndirect instruction only contains func_ptr use
+fn lower_return_call(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : @block.VCodeBlock,
+  func_idx : Int,
+) -> Unit {
+  // Load func_table and get function pointer
+  let func_table = emit_load_func_table(ctx, block)
+  let func_ptr_vreg = ctx.vcode_func.new_vreg(Int)
+  let offset = func_idx * 8
+  let load_inst = @instr.VCodeInst::new(Load(I64, offset))
+  load_inst.add_def({ reg: Virtual(func_ptr_vreg) })
+  load_inst.add_use(Virtual(func_table))
+  block.add_inst(load_inst)
+
+  // Get vmctx (X19 is always vmctx)
+  let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
+
+  // Classify user arguments by type
+  let int_args : Array[(@abi.VReg, @abi.RegClass)] = []
+  let float_args : Array[(@abi.VReg, @abi.RegClass)] = []
+  for operand in inst.operands {
+    let vreg = ctx.get_vreg_for_use(operand, block)
+    match vreg.class {
+      @abi.Int => int_args.push((vreg, @abi.Int))
+      @abi.Float32 => float_args.push((vreg, @abi.Float32))
+      @abi.Float64 => float_args.push((vreg, @abi.Float64))
+    }
+  }
+
+  // Calculate overflow args count (user args, not including vmctx)
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS // 6 (X2-X7)
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS // 8 (V0-V7)
+  let int_overflow = if int_args.length() > max_int_reg_args {
+    int_args.length() - max_int_reg_args
+  } else {
+    0
+  }
+
+  // Generate StoreToStack instructions for overflow arguments
+  for i in max_int_reg_args..<int_args.length() {
+    let (vreg, _) = int_args[i]
+    let stack_idx = i - max_int_reg_args
+    let offset = stack_idx * 8
+    let store = @instr.VCodeInst::new(StoreToStack(offset))
+    store.add_use(Virtual(vreg))
+    block.add_inst(store)
+  }
+  for i in max_float_reg_args..<float_args.length() {
+    let (vreg, _) = float_args[i]
+    let stack_idx = i - max_float_reg_args
+    let offset = int_overflow * 8 + stack_idx * 8
+    let store = @instr.VCodeInst::new(StoreToStack(offset))
+    store.add_use(Virtual(vreg))
+    block.add_inst(store)
+  }
+
+  // Create ReturnCallIndirect instruction with fixed register constraints
+  let call_inst = @instr.VCodeInst::new(ReturnCallIndirect(0, 0))
+
+  // func_ptr constrained to X17
+  call_inst.add_use_fixed(Virtual(func_ptr_vreg), @abi.PReg::{
+    index: 17,
+    class: @abi.Int,
+  })
+
+  // vmctx constrained to X0 and X1 (callee_vmctx = caller_vmctx = X19)
+  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+    index: 0,
+    class: @abi.Int,
+  })
+  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+    index: 1,
+    class: @abi.Int,
+  })
+
+  // Register int args: X2-X7
+  let int_reg_count = if int_args.length() < max_int_reg_args {
+    int_args.length()
+  } else {
+    max_int_reg_args
+  }
+  for i in 0..<int_reg_count {
+    let (vreg, _) = int_args[i]
+    let preg_idx = 2 + i // X2, X3, X4, X5, X6, X7
+    call_inst.add_use_fixed(Virtual(vreg), @abi.PReg::{
+      index: preg_idx,
+      class: @abi.Int,
+    })
+  }
+
+  // Register float args: V0-V7
+  let float_reg_count = if float_args.length() < max_float_reg_args {
+    float_args.length()
+  } else {
+    max_float_reg_args
+  }
+  for i in 0..<float_reg_count {
+    let (vreg, class) = float_args[i]
+    call_inst.add_use_fixed(Virtual(vreg), @abi.PReg::{ index: i, class })
+  }
+
+  // No result defs for tail call (doesn't return to this function)
+  // Add clobbers for caller-saved registers
+  add_call_clobbers(call_inst)
+  block.add_inst(call_inst)
+}
+
+///|
+/// Lower return_call_indirect (indirect tail call)
+/// Following Cranelift: parameters handled in lowering via StoreToStack and add_use_fixed
+fn lower_return_call_indirect(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : @block.VCodeBlock,
+  type_idx : Int,
+  table_idx : Int,
+) -> Unit {
+  // Get element index and load function pointer (similar to lower_call_indirect)
+  guard inst.operands.length() > 0 else { return }
+  let elem_idx_vreg = ctx.get_vreg_for_use(inst.operands[0], block)
+
+  // Load table pointer
+  let table_ptr_vreg : @abi.VReg = if table_idx == 0 {
+    emit_load_table0_base(ctx, block)
+  } else {
+    let indirect_tables_vreg = ctx.vcode_func.new_vreg(Int)
+    let load_array_inst = @instr.VCodeInst::new(
+      Load(I64, @abi.VMCTX_TABLES_OFFSET),
+    )
+    load_array_inst.add_def({ reg: Virtual(indirect_tables_vreg) })
+    load_array_inst.add_use(Physical({ index: 19, class: Int }))
+    block.add_inst(load_array_inst)
+    let table_offset = table_idx * 8
+    let ptr_vreg = ctx.vcode_func.new_vreg(Int)
+    let load_table_inst = @instr.VCodeInst::new(Load(I64, table_offset))
+    load_table_inst.add_def({ reg: Virtual(ptr_vreg) })
+    load_table_inst.add_use(Virtual(indirect_tables_vreg))
+    block.add_inst(load_table_inst)
+    ptr_vreg
+  }
+
+  // Calculate offset and load function pointer
+  let offset_vreg = ctx.vcode_func.new_vreg(Int)
+  let const_16_vreg = ctx.vcode_func.new_vreg(Int)
+  let load_16 = @instr.VCodeInst::new(LoadConst(16L))
+  load_16.add_def({ reg: Virtual(const_16_vreg) })
+  block.add_inst(load_16)
+  let mul_inst = @instr.VCodeInst::new(Mul(true))
+  mul_inst.add_def({ reg: Virtual(offset_vreg) })
+  mul_inst.add_use(Virtual(elem_idx_vreg))
+  mul_inst.add_use(Virtual(const_16_vreg))
+  block.add_inst(mul_inst)
+  let addr_vreg = ctx.vcode_func.new_vreg(Int)
+  let add_inst = @instr.VCodeInst::new(Add(true))
+  add_inst.add_def({ reg: Virtual(addr_vreg) })
+  add_inst.add_use(Virtual(table_ptr_vreg))
+  add_inst.add_use(Virtual(offset_vreg))
+  block.add_inst(add_inst)
+  let func_ptr_vreg = ctx.vcode_func.new_vreg(Int)
+  let load_func_inst = @instr.VCodeInst::new(Load(I64, 0))
+  load_func_inst.add_def({ reg: Virtual(func_ptr_vreg) })
+  load_func_inst.add_use(Virtual(addr_vreg))
+  block.add_inst(load_func_inst)
+  let actual_type_vreg = ctx.vcode_func.new_vreg(Int)
+  let load_type_inst = @instr.VCodeInst::new(Load(I64, 8))
+  load_type_inst.add_def({ reg: Virtual(actual_type_vreg) })
+  load_type_inst.add_use(Virtual(addr_vreg))
+  block.add_inst(load_type_inst)
+  let type_check_inst = @instr.VCodeInst::new(TypeCheckIndirect(type_idx))
+  type_check_inst.add_use(Virtual(actual_type_vreg))
+  block.add_inst(type_check_inst)
+
+  // Get vmctx
+  let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
+
+  // Classify user arguments (skip first operand which is elem_idx)
+  let int_args : Array[(@abi.VReg, @abi.RegClass)] = []
+  let float_args : Array[(@abi.VReg, @abi.RegClass)] = []
+  for i in 1..<inst.operands.length() {
+    let vreg = ctx.get_vreg_for_use(inst.operands[i], block)
+    match vreg.class {
+      @abi.Int => int_args.push((vreg, @abi.Int))
+      @abi.Float32 => float_args.push((vreg, @abi.Float32))
+      @abi.Float64 => float_args.push((vreg, @abi.Float64))
+    }
+  }
+
+  // Calculate overflow
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
+  let int_overflow = if int_args.length() > max_int_reg_args {
+    int_args.length() - max_int_reg_args
+  } else {
+    0
+  }
+
+  // Generate StoreToStack for overflow arguments
+  for i in max_int_reg_args..<int_args.length() {
+    let (vreg, _) = int_args[i]
+    let stack_idx = i - max_int_reg_args
+    let offset = stack_idx * 8
+    let store = @instr.VCodeInst::new(StoreToStack(offset))
+    store.add_use(Virtual(vreg))
+    block.add_inst(store)
+  }
+  for i in max_float_reg_args..<float_args.length() {
+    let (vreg, _) = float_args[i]
+    let stack_idx = i - max_float_reg_args
+    let offset = int_overflow * 8 + stack_idx * 8
+    let store = @instr.VCodeInst::new(StoreToStack(offset))
+    store.add_use(Virtual(vreg))
+    block.add_inst(store)
+  }
+
+  // Create ReturnCallIndirect with fixed constraints
+  let call_inst = @instr.VCodeInst::new(ReturnCallIndirect(0, 0))
+
+  // func_ptr -> X17
+  call_inst.add_use_fixed(Virtual(func_ptr_vreg), @abi.PReg::{
+    index: 17,
+    class: @abi.Int,
+  })
+
+  // vmctx -> X0, X1
+  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+    index: 0,
+    class: @abi.Int,
+  })
+  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+    index: 1,
+    class: @abi.Int,
+  })
+
+  // Register int args: X2-X7
+  let int_reg_count = if int_args.length() < max_int_reg_args {
+    int_args.length()
+  } else {
+    max_int_reg_args
+  }
+  for i in 0..<int_reg_count {
+    let (vreg, _) = int_args[i]
+    let preg_idx = 2 + i
+    call_inst.add_use_fixed(Virtual(vreg), @abi.PReg::{
+      index: preg_idx,
+      class: @abi.Int,
+    })
+  }
+
+  // Register float args: V0-V7
+  let float_reg_count = if float_args.length() < max_float_reg_args {
+    float_args.length()
+  } else {
+    max_float_reg_args
+  }
+  for i in 0..<float_reg_count {
+    let (vreg, class) = float_args[i]
+    call_inst.add_use_fixed(Virtual(vreg), @abi.PReg::{ index: i, class })
+  }
+  add_call_clobbers(call_inst)
+  block.add_inst(call_inst)
+}
+
+///|
+/// Lower return_call_ref (tail call through function reference)
+/// Following Cranelift: parameters handled in lowering
+fn lower_return_call_ref(
+  ctx : LoweringContext,
+  inst : @ir.Inst,
+  block : @block.VCodeBlock,
+  _type_idx : Int,
+) -> Unit {
+  guard inst.operands.length() > 0 else { return }
+  let func_ref_vreg = ctx.get_vreg_for_use(inst.operands[0], block)
+
+  // Load func_table and calculate function pointer
+  let func_table = emit_load_func_table(ctx, block)
+  let const_8_vreg = ctx.vcode_func.new_vreg(Int)
+  let load_8 = @instr.VCodeInst::new(LoadConst(8L))
+  load_8.add_def({ reg: Virtual(const_8_vreg) })
+  block.add_inst(load_8)
+  let offset_vreg = ctx.vcode_func.new_vreg(Int)
+  let mul_inst = @instr.VCodeInst::new(Mul(true))
+  mul_inst.add_def({ reg: Virtual(offset_vreg) })
+  mul_inst.add_use(Virtual(func_ref_vreg))
+  mul_inst.add_use(Virtual(const_8_vreg))
+  block.add_inst(mul_inst)
+  let addr_vreg = ctx.vcode_func.new_vreg(Int)
+  let add_inst = @instr.VCodeInst::new(Add(true))
+  add_inst.add_def({ reg: Virtual(addr_vreg) })
+  add_inst.add_use(Virtual(func_table))
+  add_inst.add_use(Virtual(offset_vreg))
+  block.add_inst(add_inst)
+  let func_ptr_vreg = ctx.vcode_func.new_vreg(Int)
+  let load_inst = @instr.VCodeInst::new(Load(I64, 0))
+  load_inst.add_def({ reg: Virtual(func_ptr_vreg) })
+  load_inst.add_use(Virtual(addr_vreg))
+  block.add_inst(load_inst)
+
+  // Get vmctx
+  let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
+
+  // Classify user arguments (skip first operand which is func_ref)
+  let int_args : Array[(@abi.VReg, @abi.RegClass)] = []
+  let float_args : Array[(@abi.VReg, @abi.RegClass)] = []
+  for i in 1..<inst.operands.length() {
+    let vreg = ctx.get_vreg_for_use(inst.operands[i], block)
+    match vreg.class {
+      @abi.Int => int_args.push((vreg, @abi.Int))
+      @abi.Float32 => float_args.push((vreg, @abi.Float32))
+      @abi.Float64 => float_args.push((vreg, @abi.Float64))
+    }
+  }
+
+  // Calculate overflow
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
+  let int_overflow = if int_args.length() > max_int_reg_args {
+    int_args.length() - max_int_reg_args
+  } else {
+    0
+  }
+
+  // Generate StoreToStack for overflow arguments
+  for i in max_int_reg_args..<int_args.length() {
+    let (vreg, _) = int_args[i]
+    let stack_idx = i - max_int_reg_args
+    let offset = stack_idx * 8
+    let store = @instr.VCodeInst::new(StoreToStack(offset))
+    store.add_use(Virtual(vreg))
+    block.add_inst(store)
+  }
+  for i in max_float_reg_args..<float_args.length() {
+    let (vreg, _) = float_args[i]
+    let stack_idx = i - max_float_reg_args
+    let offset = int_overflow * 8 + stack_idx * 8
+    let store = @instr.VCodeInst::new(StoreToStack(offset))
+    store.add_use(Virtual(vreg))
+    block.add_inst(store)
+  }
+
+  // Create ReturnCallIndirect with fixed constraints
+  let call_inst = @instr.VCodeInst::new(ReturnCallIndirect(0, 0))
+
+  // func_ptr -> X17
+  call_inst.add_use_fixed(Virtual(func_ptr_vreg), @abi.PReg::{
+    index: 17,
+    class: @abi.Int,
+  })
+
+  // vmctx -> X0, X1
+  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+    index: 0,
+    class: @abi.Int,
+  })
+  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+    index: 1,
+    class: @abi.Int,
+  })
+
+  // Register int args: X2-X7
+  let int_reg_count = if int_args.length() < max_int_reg_args {
+    int_args.length()
+  } else {
+    max_int_reg_args
+  }
+  for i in 0..<int_reg_count {
+    let (vreg, _) = int_args[i]
+    let preg_idx = 2 + i
+    call_inst.add_use_fixed(Virtual(vreg), @abi.PReg::{
+      index: preg_idx,
+      class: @abi.Int,
+    })
+  }
+
+  // Register float args: V0-V7
+  let float_reg_count = if float_args.length() < max_float_reg_args {
+    float_args.length()
+  } else {
+    max_float_reg_args
+  }
+  for i in 0..<float_reg_count {
+    let (vreg, class) = float_args[i]
+    call_inst.add_use_fixed(Virtual(vreg), @abi.PReg::{ index: i, class })
+  }
+  add_call_clobbers(call_inst)
+  block.add_inst(call_inst)
 }

--- a/vcode/lower/regalloc.mbt
+++ b/vcode/lower/regalloc.mbt
@@ -1261,10 +1261,11 @@ pub fn apply_allocation(
       // Track which scratch registers are used for each spilled vreg
       let spill_regs : Map[Int, @abi.PReg] = {}
 
-      // Check if this is a CallIndirect instruction - needs special handling
-      let is_call_indirect = inst.opcode is CallIndirect(_, _)
+      // Check if this is a CallIndirect or ReturnCallIndirect instruction - needs special handling
+      let is_call_indirect = inst.opcode is CallIndirect(_, _) ||
+        inst.opcode is ReturnCallIndirect(_, _)
 
-      // For CallIndirect with many spilled args, we use a special strategy:
+      // For CallIndirect/ReturnCallIndirect with many spilled args, we use a special strategy:
       // - func_ptr (uses[0]): reload to X18
       // - register args (uses[1-8]): if spilled, reload to X16/X17 (max 2)
       // - stack args (uses[9+]): if spilled, use spilled register encoding (emit handles them)
@@ -1568,7 +1569,7 @@ fn has_side_effects(opcode : @instr.VCodeOpcode) -> Bool {
     // Type check can trap
     TypeCheckIndirect(_) => true
     // Function calls have side effects
-    CallIndirect(_, _) | CallPtr(_, _) => true
+    CallIndirect(_, _) | ReturnCallIndirect(_, _) | CallPtr(_, _) => true
     // Memory operations have side effects (modify memory or global state)
     MemoryGrow(_) | MemoryFill | MemoryCopy => true
     // Table operations have side effects (modify table state)


### PR DESCRIPTION
… execution

Completely refactored tail call implementation following wasmtime's approach to avoid native stack growth and enable true tail call optimization.

## Key Changes

### Interpreter (executor/)

**Tail Call Loop Architecture:**
- Added loop-based tail call handling in `call_wasm_func_with_instance`
- Tail calls now raise `ControlSignal::TailCall` signal instead of recursing
- Loop catches TailCall, pops current frame, and continues with new target
- Zero native stack growth - entire tail call chain executes in one function

**Implementation Details:**
- `exec_tail_call`: Raises TailCall signal with target function info
- `exec_tail_call_indirect`: Type-checked indirect tail call with signal
- `exec_tail_call_ref`: Reference-based tail call with signal
- Loop in `call_wasm_func_with_instance` handles TailCall by:
  1. Popping current frame
  2. Setting new target (instance, func, args)
  3. Continuing loop instead of recursing

**Benefits:**
- No more CallStackExhausted errors in deep recursion
- Constant native stack depth regardless of tail call chain length
- Matches wasmtime's interpreter architecture

### Control Flow (error.mbt)

- Added `ControlSignal::TailCall` variant for tail call signaling
- Fixed `Return` ambiguity by using `ControlSignal::Return`
- Added unused `ControlFlow` enum for future full refactoring

### Test Results

All 166 tail call tests pass in no-jit mode:
- return_call.wast: 44/44 ✓
- return_call_indirect.wast: 76/76 ✓
- return_call_ref.wast: 46/46 ✓

Deep recursion (2000+ iterations) works without stack overflow.

## Architecture Comparison

**Before (Recursive):**
```
exec_tail_call → pop_frame → call_target (recurse)
  → exec_tail_call → pop_frame → call_target (recurse)
    → ... [native stack grows] → SEGFAULT
```

**After (Loop-based - Wasmtime style):**
```
while loop {
  exec_expr → raise TailCall
  catch TailCall → pop_frame → set new target → continue
  [native stack constant]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)