### PR TITLE
fix: add SelectTyped instruction support and validation

### DIFF
--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -361,6 +361,14 @@ fn Translator::translate_instruction(
       let result = self.builder.select(c, val1, val2)
       self.push(result)
     }
+    SelectTyped(_) => {
+      // Same as Select - type annotation is for validation only
+      let c = self.pop() // condition
+      let val2 = self.pop() // false value
+      let val1 = self.pop() // true value
+      let result = self.builder.select(c, val1, val2)
+      self.push(result)
+    }
 
     // i32 arithmetic
     I32Add => self.translate_binary_i32(fn(b, a, v) { b.iadd(a, v) })

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -1768,6 +1768,10 @@ fn validate_instr(
       stack.push(t1)
     }
     SelectTyped(types) => {
+      // Select must have exactly one result type
+      if types.length() != 1 {
+        raise TypeMismatch("invalid result arity")
+      }
       // Validate type indices
       let num_types = ctx.types.length()
       for ty in types {


### PR DESCRIPTION
## Summary
- Implement `SelectTyped` instruction in IR translator (same semantics as `Select`, type annotation is for validation)
- Add arity validation: `select (result ...)` must have exactly one result type

## Test plan
- [x] `./wasmoon test spec/select.wast` passes (154 tests, JIT mode)
- [x] `./wasmoon test --no-jit spec/select.wast` passes (154 tests, interpreter mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)