### PR TITLE
refactor: consolidate bit conversion traits into types package

### DIFF
--- a/jit/ffi_jit.mbt
+++ b/jit/ffi_jit.mbt
@@ -74,35 +74,6 @@ pub fn get_current_memory_base() -> Int64 {
   @jit_ffi.c_jit_get_current_memory_base()
 }
 
-// ============ JIT Argument Trait ============
-
-///|
-/// Trait for types that can be passed as JIT function arguments
-/// All types are converted to Int64 bit patterns for the C FFI
-pub(open) trait JITArg {
-  to_jit_arg(Self) -> Int64
-}
-
-///|
-pub impl JITArg for Int64 with to_jit_arg(self) {
-  self
-}
-
-///|
-pub impl JITArg for Int with to_jit_arg(self) {
-  self.to_int64()
-}
-
-///|
-pub impl JITArg for Float with to_jit_arg(self) {
-  self.reinterpret_as_int().to_int64()
-}
-
-///|
-pub impl JITArg for Double with to_jit_arg(self) {
-  self.reinterpret_as_int64()
-}
-
 // ============ JIT Context Wrapper ============
 
 ///|

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -303,8 +303,8 @@ pub impl Show for Profiler
 pub(all) struct Single[A](A)
 #deprecated
 pub fn[A] Single::inner(Self[A]) -> A
-pub impl[A : ToInt64] DynamicArgs for Single[A]
-pub impl[A : FromInt64] DynamicReturn for Single[A]
+pub impl[A : @types.ToInt64] DynamicArgs for Single[A]
+pub impl[A : @types.FromInt64] DynamicReturn for Single[A]
 
 pub(all) struct SourceLocation {
   func_idx : Int
@@ -376,39 +376,15 @@ pub trait DynamicArgs {
   to_int64_array(Self) -> Array[Int64]
 }
 pub impl DynamicArgs for Unit
-pub impl[A : ToInt64, B : ToInt64] DynamicArgs for (A, B)
-pub impl[A : ToInt64, B : ToInt64, C : ToInt64] DynamicArgs for (A, B, C)
-pub impl[A : ToInt64, B : ToInt64, C : ToInt64, D : ToInt64] DynamicArgs for (A, B, C, D)
+pub impl[A : @types.ToInt64, B : @types.ToInt64] DynamicArgs for (A, B)
+pub impl[A : @types.ToInt64, B : @types.ToInt64, C : @types.ToInt64] DynamicArgs for (A, B, C)
+pub impl[A : @types.ToInt64, B : @types.ToInt64, C : @types.ToInt64, D : @types.ToInt64] DynamicArgs for (A, B, C, D)
 
 pub trait DynamicReturn {
   from_int64_array(Array[Int64]) -> Self
 }
 pub impl DynamicReturn for Unit
-pub impl[A : FromInt64, B : FromInt64] DynamicReturn for (A, B)
-pub impl[A : FromInt64, B : FromInt64, C : FromInt64] DynamicReturn for (A, B, C)
-pub impl[A : FromInt64, B : FromInt64, C : FromInt64, D : FromInt64] DynamicReturn for (A, B, C, D)
-
-pub trait FromInt64 {
-  from_int64_bits(Int64) -> Self
-}
-pub impl FromInt64 for Int
-pub impl FromInt64 for Int64
-pub impl FromInt64 for Float
-pub impl FromInt64 for Double
-
-pub(open) trait JITArg {
-  to_jit_arg(Self) -> Int64
-}
-pub impl JITArg for Int
-pub impl JITArg for Int64
-pub impl JITArg for Float
-pub impl JITArg for Double
-
-pub trait ToInt64 {
-  to_int64_bits(Self) -> Int64
-}
-pub impl ToInt64 for Int
-pub impl ToInt64 for Int64
-pub impl ToInt64 for Float
-pub impl ToInt64 for Double
+pub impl[A : @types.FromInt64, B : @types.FromInt64] DynamicReturn for (A, B)
+pub impl[A : @types.FromInt64, B : @types.FromInt64, C : @types.FromInt64] DynamicReturn for (A, B, C)
+pub impl[A : @types.FromInt64, B : @types.FromInt64, C : @types.FromInt64, D : @types.FromInt64] DynamicReturn for (A, B, C, D)
 

--- a/jit/polycall.mbt
+++ b/jit/polycall.mbt
@@ -21,31 +21,6 @@ impl Show for PolycallError with output(self, logger) {
 pub(all) struct Single[A](A)
 
 ///|
-pub trait ToInt64 {
-  to_int64_bits(Self) -> Int64
-}
-
-///|
-pub impl ToInt64 for Int64 with to_int64_bits(self) {
-  self
-}
-
-///|
-pub impl ToInt64 for Int with to_int64_bits(self) {
-  self.to_int64()
-}
-
-///|
-pub impl ToInt64 for Double with to_int64_bits(self) {
-  self.reinterpret_as_int64()
-}
-
-///|
-pub impl ToInt64 for Float with to_int64_bits(self) {
-  self.reinterpret_as_int().to_int64()
-}
-
-///|
 pub trait DynamicArgs {
   to_int64_array(Self) -> Array[Int64]
 }
@@ -56,68 +31,43 @@ pub impl DynamicArgs for Unit with to_int64_array(_self) {
 }
 
 ///|
-pub impl[A : ToInt64] DynamicArgs for Single[A] with to_int64_array(self) {
+pub impl[A : @types.ToInt64] DynamicArgs for Single[A] with to_int64_array(self) {
   [self.0.to_int64_bits()]
 }
 
 ///|
-pub impl[A : ToInt64, B : ToInt64] DynamicArgs for (A, B) with to_int64_array(
+pub impl[A : @types.ToInt64, B : @types.ToInt64] DynamicArgs for (A, B) with to_int64_array(
   self,
 ) {
-  [ToInt64::to_int64_bits(self.0), ToInt64::to_int64_bits(self.1)]
+  [@types.ToInt64::to_int64_bits(self.0), @types.ToInt64::to_int64_bits(self.1)]
 }
 
 ///|
-pub impl[A : ToInt64, B : ToInt64, C : ToInt64] DynamicArgs for (A, B, C) with to_int64_array(
-  self,
-) {
-  [
-    ToInt64::to_int64_bits(self.0),
-    ToInt64::to_int64_bits(self.1),
-    ToInt64::to_int64_bits(self.2),
-  ]
-}
-
-///|
-pub impl[A : ToInt64, B : ToInt64, C : ToInt64, D : ToInt64] DynamicArgs for (
+pub impl[A : @types.ToInt64, B : @types.ToInt64, C : @types.ToInt64] DynamicArgs for (
   A,
   B,
   C,
-  D,
 ) with to_int64_array(self) {
   [
-    ToInt64::to_int64_bits(self.0),
-    ToInt64::to_int64_bits(self.1),
-    ToInt64::to_int64_bits(self.2),
-    ToInt64::to_int64_bits(self.3),
+    @types.ToInt64::to_int64_bits(self.0),
+    @types.ToInt64::to_int64_bits(self.1),
+    @types.ToInt64::to_int64_bits(self.2),
   ]
 }
 
 ///|
-pub trait FromInt64 {
-  from_int64_bits(Int64) -> Self
-}
-
-///|
-pub impl FromInt64 for Int64 with from_int64_bits(v) {
-  v
-}
-
-///|
-pub impl FromInt64 for Int with from_int64_bits(v) {
-  v.to_int()
-}
-
-///|
-pub impl FromInt64 for Double with from_int64_bits(v) {
-  v.reinterpret_as_double()
-}
-
-///|
-pub impl FromInt64 for Float with from_int64_bits(v) {
-  // f32 values are returned in S0 register (lower 32 bits of the 64-bit return)
-  // Extract lower 32 bits and reinterpret as f32 bit pattern
-  Float::reinterpret_from_int(v.to_int())
+pub impl[
+  A : @types.ToInt64,
+  B : @types.ToInt64,
+  C : @types.ToInt64,
+  D : @types.ToInt64,
+] DynamicArgs for (A, B, C, D) with to_int64_array(self) {
+  [
+    @types.ToInt64::to_int64_bits(self.0),
+    @types.ToInt64::to_int64_bits(self.1),
+    @types.ToInt64::to_int64_bits(self.2),
+    @types.ToInt64::to_int64_bits(self.3),
+  ]
 }
 
 ///|
@@ -131,42 +81,47 @@ pub impl DynamicReturn for Unit with from_int64_array(_arr) {
 }
 
 ///|
-pub impl[A : FromInt64] DynamicReturn for Single[A] with from_int64_array(arr) {
+pub impl[A : @types.FromInt64] DynamicReturn for Single[A] with from_int64_array(
+  arr,
+) {
   Single(arr[0] |> A::from_int64_bits())
 }
 
 ///|
-pub impl[A : FromInt64, B : FromInt64] DynamicReturn for (A, B) with from_int64_array(
+pub impl[A : @types.FromInt64, B : @types.FromInt64] DynamicReturn for (A, B) with from_int64_array(
   arr,
 ) {
-  (FromInt64::from_int64_bits(arr[0]), FromInt64::from_int64_bits(arr[1]))
-}
-
-///|
-pub impl[A : FromInt64, B : FromInt64, C : FromInt64] DynamicReturn for (
-  A,
-  B,
-  C,
-) with from_int64_array(arr) {
   (
-    FromInt64::from_int64_bits(arr[0]),
-    FromInt64::from_int64_bits(arr[1]),
-    FromInt64::from_int64_bits(arr[2]),
+    @types.FromInt64::from_int64_bits(arr[0]),
+    @types.FromInt64::from_int64_bits(arr[1]),
   )
 }
 
 ///|
-pub impl[A : FromInt64, B : FromInt64, C : FromInt64, D : FromInt64] DynamicReturn for (
+pub impl[A : @types.FromInt64, B : @types.FromInt64, C : @types.FromInt64] DynamicReturn for (
   A,
   B,
   C,
-  D,
 ) with from_int64_array(arr) {
   (
-    FromInt64::from_int64_bits(arr[0]),
-    FromInt64::from_int64_bits(arr[1]),
-    FromInt64::from_int64_bits(arr[2]),
-    FromInt64::from_int64_bits(arr[3]),
+    @types.FromInt64::from_int64_bits(arr[0]),
+    @types.FromInt64::from_int64_bits(arr[1]),
+    @types.FromInt64::from_int64_bits(arr[2]),
+  )
+}
+
+///|
+pub impl[
+  A : @types.FromInt64,
+  B : @types.FromInt64,
+  C : @types.FromInt64,
+  D : @types.FromInt64,
+] DynamicReturn for (A, B, C, D) with from_int64_array(arr) {
+  (
+    @types.FromInt64::from_int64_bits(arr[0]),
+    @types.FromInt64::from_int64_bits(arr[1]),
+    @types.FromInt64::from_int64_bits(arr[2]),
+    @types.FromInt64::from_int64_bits(arr[3]),
   )
 }
 

--- a/main/run.mbt
+++ b/main/run.mbt
@@ -470,10 +470,10 @@ fn init_jit_globals(
     // For FuncRef, we need to convert store address to module function index
     // because JIT func_table is indexed by module function index
     let raw_value = match value {
-      I32(n) => n.to_int64()
-      I64(n) => n
-      F32(f) => f.reinterpret_as_int().to_int64()
-      F64(d) => d.reinterpret_as_int64()
+      I32(n) => @types.ToInt64::to_int64_bits(n)
+      I64(n) => @types.ToInt64::to_int64_bits(n)
+      F32(f) => @types.ToInt64::to_int64_bits(f)
+      F64(d) => @types.ToInt64::to_int64_bits(d)
       FuncRef(store_addr) =>
         store_addr_to_module_func_idx(store_addr, instance).to_int64()
       ExternRef(idx) => idx.to_int64()
@@ -559,10 +559,10 @@ fn run_with_jit(
               let i64_args : Array[Int64] = []
               for arg in args {
                 let v = match arg {
-                  I32(n) => n.to_int64()
-                  I64(n) => n
-                  F32(n) => n.reinterpret_as_int().to_int64()
-                  F64(n) => n.reinterpret_as_int64()
+                  I32(n) => @types.ToInt64::to_int64_bits(n)
+                  I64(n) => @types.ToInt64::to_int64_bits(n)
+                  F32(n) => @types.ToInt64::to_int64_bits(n)
+                  F64(n) => @types.ToInt64::to_int64_bits(n)
                   FuncRef(idx) => idx.to_int64()
                   ExternRef(idx) => idx.to_int64()
                   ExnRef(idx) => idx.to_int64()
@@ -590,14 +590,19 @@ fn run_with_jit(
                     )
                   }
                   let v = match f.result_types[i] {
-                    I32 => @types.Value::I32(r.to_int())
-                    I64 => @types.Value::I64(r)
+                    I32 =>
+                      @types.Value::I32(@types.FromInt64::from_int64_bits(r))
+                    I64 =>
+                      @types.Value::I64(@types.FromInt64::from_int64_bits(r))
                     F32 => {
                       // r contains bits of f64, convert to f32
-                      let f64_val = r.reinterpret_as_double()
+                      let f64_val : Double = @types.FromInt64::from_int64_bits(
+                        r,
+                      )
                       @types.Value::F32(Float::from_double(f64_val))
                     }
-                    F64 => @types.Value::F64(r.reinterpret_as_double())
+                    F64 =>
+                      @types.Value::F64(@types.FromInt64::from_int64_bits(r))
                     FuncRef
                     | RefFunc
                     | RefFuncTyped(_)

--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -29,10 +29,10 @@ fn jit_results_to_values(
   for i, ty in result_types {
     let raw = results[i]
     let value : @types.Value = match ty {
-      I32 => I32(@jit.FromInt64::from_int64_bits(raw))
-      I64 => I64(@jit.FromInt64::from_int64_bits(raw))
-      F32 => F32(@jit.FromInt64::from_int64_bits(raw))
-      F64 => F64(@jit.FromInt64::from_int64_bits(raw))
+      I32 => I32(@types.FromInt64::from_int64_bits(raw))
+      I64 => I64(@types.FromInt64::from_int64_bits(raw))
+      F32 => F32(@types.FromInt64::from_int64_bits(raw))
+      F64 => F64(@types.FromInt64::from_int64_bits(raw))
       // Reference types: -1L is null sentinel
       FuncRef | RefFunc | RefFuncTyped(_) | RefNullFuncTyped(_) | NullFuncRef =>
         if raw == -1L {
@@ -59,10 +59,10 @@ fn jit_results_to_values(
 /// Convert @types.Value to Int64 for JIT call
 fn value_to_jit_arg(value : @types.Value) -> Int64 {
   match value {
-    I32(n) => n.to_int64()
-    I64(n) => n
-    F32(f) => f.reinterpret_as_int().to_int64()
-    F64(d) => d.reinterpret_as_int64()
+    I32(n) => @types.ToInt64::to_int64_bits(n)
+    I64(n) => @types.ToInt64::to_int64_bits(n)
+    F32(f) => @types.ToInt64::to_int64_bits(f)
+    F64(d) => @types.ToInt64::to_int64_bits(d)
     FuncRef(idx) => idx.to_int64()
     ExternRef(idx) => idx.to_int64()
     ExnRef(idx) => idx.to_int64()

--- a/types/bit_conversion.mbt
+++ b/types/bit_conversion.mbt
@@ -1,0 +1,52 @@
+// Bit conversion traits for converting between numeric types and Int64 bit patterns
+// Used for JIT calls, FFI, and low-level bit manipulation
+
+///|
+pub trait ToInt64 {
+  to_int64_bits(Self) -> Int64
+}
+
+///|
+pub impl ToInt64 for Int64 with to_int64_bits(self) {
+  self
+}
+
+///|
+pub impl ToInt64 for Int with to_int64_bits(self) {
+  self.to_int64()
+}
+
+///|
+pub impl ToInt64 for Double with to_int64_bits(self) {
+  self.reinterpret_as_int64()
+}
+
+///|
+pub impl ToInt64 for Float with to_int64_bits(self) {
+  self.reinterpret_as_int().to_int64()
+}
+
+///|
+pub trait FromInt64 {
+  from_int64_bits(Int64) -> Self
+}
+
+///|
+pub impl FromInt64 for Int64 with from_int64_bits(v) {
+  v
+}
+
+///|
+pub impl FromInt64 for Int with from_int64_bits(v) {
+  v.to_int()
+}
+
+///|
+pub impl FromInt64 for Double with from_int64_bits(v) {
+  v.reinterpret_as_double()
+}
+
+///|
+pub impl FromInt64 for Float with from_int64_bits(v) {
+  Float::reinterpret_from_int(v.to_int())
+}

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -434,4 +434,19 @@ pub impl Show for ValueType
 // Type aliases
 
 // Traits
+pub trait FromInt64 {
+  from_int64_bits(Int64) -> Self
+}
+pub impl FromInt64 for Int
+pub impl FromInt64 for Int64
+pub impl FromInt64 for Float
+pub impl FromInt64 for Double
+
+pub trait ToInt64 {
+  to_int64_bits(Self) -> Int64
+}
+pub impl ToInt64 for Int
+pub impl ToInt64 for Int64
+pub impl ToInt64 for Float
+pub impl ToInt64 for Double
 

--- a/wast/jit_support.mbt
+++ b/wast/jit_support.mbt
@@ -127,11 +127,10 @@ pub fn sync_jit_globals_to_store(
       // Note: For FuncRef, JIT stores module function index, we need to convert
       // it back to store address for the interpreter
       let new_value : @types.Value = match global_inst.get_type().value_type {
-        I32 => @types.Value::I32(raw_value.to_int())
-        I64 => @types.Value::I64(raw_value)
-        F32 =>
-          @types.Value::F32(Float::reinterpret_from_int(raw_value.to_int()))
-        F64 => @types.Value::F64(raw_value.reinterpret_as_double())
+        I32 => @types.Value::I32(@types.FromInt64::from_int64_bits(raw_value))
+        I64 => @types.Value::I64(@types.FromInt64::from_int64_bits(raw_value))
+        F32 => @types.Value::F32(@types.FromInt64::from_int64_bits(raw_value))
+        F64 => @types.Value::F64(@types.FromInt64::from_int64_bits(raw_value))
         FuncRef
         | RefFunc
         | RefFuncTyped(_)

--- a/wast/runner.mbt
+++ b/wast/runner.mbt
@@ -554,14 +554,14 @@ pub fn invoke_action(
               let i64_args : Array[Int64] = []
               for arg in args {
                 let v = match arg {
-                  I32(n) => n.to_int64()
-                  I64(n) => n
-                  F32(n) => n.reinterpret_as_int().to_int64()
-                  F64(n) => n.reinterpret_as_int64()
+                  I32(n) => @types.ToInt64::to_int64_bits(n)
+                  I64(n) => @types.ToInt64::to_int64_bits(n)
+                  F32(n) => @types.ToInt64::to_int64_bits(n)
+                  F64(n) => @types.ToInt64::to_int64_bits(n)
                   F32CanonicalNan | F32ArithmeticNan =>
-                    @float.not_a_number.reinterpret_as_int().to_int64()
+                    @types.ToInt64::to_int64_bits(@float.not_a_number)
                   F64CanonicalNan | F64ArithmeticNan =>
-                    @double.not_a_number.reinterpret_as_int64()
+                    @types.ToInt64::to_int64_bits(@double.not_a_number)
                   RefNull(_) => -1L // null sentinel
                   RefExtern(n) => n.to_int64()
                   RefFunc => 0L // func ref (placeholder)
@@ -642,10 +642,10 @@ pub fn invoke_action(
 /// Convert JIT result (Int64) to Value based on the given return type
 fn convert_jit_result(v : Int64, ty : @types.ValueType) -> @types.Value {
   match ty {
-    I32 => @types.Value::I32(@jit.FromInt64::from_int64_bits(v))
-    I64 => @types.Value::I64(@jit.FromInt64::from_int64_bits(v))
-    F32 => @types.Value::F32(@jit.FromInt64::from_int64_bits(v))
-    F64 => @types.Value::F64(@jit.FromInt64::from_int64_bits(v))
+    I32 => @types.Value::I32(@types.FromInt64::from_int64_bits(v))
+    I64 => @types.Value::I64(@types.FromInt64::from_int64_bits(v))
+    F32 => @types.Value::F32(@types.FromInt64::from_int64_bits(v))
+    F64 => @types.Value::F64(@types.FromInt64::from_int64_bits(v))
     // Reference types: -1L is null sentinel, otherwise index
     FuncRef | RefFunc | RefFuncTyped(_) | RefNullFuncTyped(_) | NullFuncRef =>
       if v == -1L {


### PR DESCRIPTION
## Summary
- Create `types/bit_conversion.mbt` with unified `ToInt64` / `FromInt64` traits
- Remove duplicate `JITArg` trait from `jit/ffi_jit.mbt` (-29 lines)
- Update `jit/polycall.mbt` to use `@types.ToInt64/FromInt64`
- Replace manual `reinterpret_as_*` patterns with trait methods

## Files Changed
| File | Change |
|------|--------|
| `types/bit_conversion.mbt` | New - unified traits |
| `jit/ffi_jit.mbt` | Remove duplicate `JITArg` trait |
| `jit/polycall.mbt` | Use `@types.ToInt64/FromInt64` |
| `main/run.mbt` | Use trait methods |
| `wast/runner.mbt` | Use trait methods |
| `wast/jit_support.mbt` | Use trait methods |
| `testsuite/compare.mbt` | Use trait methods |

## Test plan
- [x] All 914 tests pass
- [x] `moon check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)