### PR TITLE
fix: correct f32 result conversion in JIT mode

### DIFF
--- a/main/run.mbt
+++ b/main/run.mbt
@@ -594,13 +594,8 @@ fn run_with_jit(
                       @types.Value::I32(@types.FromInt64::from_int64_bits(r))
                     I64 =>
                       @types.Value::I64(@types.FromInt64::from_int64_bits(r))
-                    F32 => {
-                      // r contains bits of f64, convert to f32
-                      let f64_val : Double = @types.FromInt64::from_int64_bits(
-                        r,
-                      )
-                      @types.Value::F32(Float::from_double(f64_val))
-                    }
+                    F32 =>
+                      @types.Value::F32(@types.FromInt64::from_int64_bits(r))
                     F64 =>
                       @types.Value::F64(@types.FromInt64::from_int64_bits(r))
                     FuncRef


### PR DESCRIPTION
## Summary

Fix JIT mode returning wrong values for f32 results (e.g., `addf(1, 2)` returning `0` instead of `3`).

## Root Cause

The JIT trampoline stores f32 results as 32-bit values in the lower 32 bits of an Int64 slot. The previous code incorrectly interpreted these bits as f64 bits:

```moonbit
// Wrong: interprets 0x40400000 (3.0f bits) as f64 bits ≈ 0.0
let f64_val : Double = @types.FromInt64::from_int64_bits(r)
@types.Value::F32(Float::from_double(f64_val))
```

## Fix

Use `FromInt64::from_int64_bits` for Float which correctly extracts the lower 32 bits:

```moonbit
@types.Value::F32(@types.FromInt64::from_int64_bits(r))
```

## Test

```bash
./wasmoon run examples/add.wat --invoke addf --arg 1 --arg 2
# Before: 0
# After: 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)