### PR TITLE
feat: implement cross-module JIT function calls

### DIFF
--- a/ir/pkg.generated.mbti
+++ b/ir/pkg.generated.mbti
@@ -374,8 +374,10 @@ pub(all) struct Translator {
   global_types : Array[@types.GlobalType]
   num_wasm_params : Int
   canonical_type_indices : Array[Int]
+  func_base : Int
+  import_remap : Array[Int]
 }
-pub fn Translator::new(String, @types.FuncType, Array[@types.ValueType], Array[@types.FuncType], Array[Int], Int, Array[Int], memory_max? : Int?, tables? : Array[@types.Table], global_types? : Array[@types.GlobalType], type_rec_groups? : Array[Int]) -> Self
+pub fn Translator::new(String, @types.FuncType, Array[@types.ValueType], Array[@types.FuncType], Array[Int], Int, Array[Int], memory_max? : Int?, tables? : Array[@types.Table], global_types? : Array[@types.GlobalType], type_rec_groups? : Array[Int], func_base? : Int, import_remap? : Array[Int]) -> Self
 pub fn Translator::translate(Self, Array[@types.Instruction]) -> Function
 
 pub(all) enum Type {

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -43,6 +43,12 @@ pub(all) struct Translator {
   // Canonical type indices for structural type equivalence
   // Structurally equivalent types map to the same canonical index
   canonical_type_indices : Array[Int]
+  // Cross-module support: base index for this module's functions
+  // All function indices are offset by this value (default 0)
+  func_base : Int
+  // Cross-module support: maps local import indices to global indices
+  // If empty, uses local indices directly
+  import_remap : Array[Int]
 }
 
 ///|
@@ -80,6 +86,8 @@ pub fn Translator::new(
   tables? : Array[@types.Table] = [],
   global_types? : Array[@types.GlobalType] = [],
   type_rec_groups? : Array[Int] = [],
+  func_base? : Int = 0,
+  import_remap? : Array[Int] = [],
 ) -> Translator {
   let builder = IRBuilder::new(name)
   // Following Cranelift: add vmctx as explicit params
@@ -148,6 +156,8 @@ pub fn Translator::new(
     global_types,
     num_wasm_params: func_type.params.length(),
     canonical_type_indices,
+    func_base,
+    import_remap,
   }
 }
 
@@ -1757,6 +1767,24 @@ fn Translator::translate_br_table(
 }
 
 ///|
+/// Remap a local function index to global function index for cross-module calls
+/// - For imports: use import_remap if available
+/// - For local functions: add func_base
+fn Translator::remap_func_idx(self : Translator, func_idx : Int) -> Int {
+  if func_idx < self.num_imports {
+    // Import function - use remap if available
+    if self.import_remap.length() > 0 && func_idx < self.import_remap.length() {
+      self.import_remap[func_idx]
+    } else {
+      func_idx
+    }
+  } else {
+    // Local function - add base offset
+    self.func_base + func_idx
+  }
+}
+
+///|
 /// Translate a direct call
 fn Translator::translate_call(self : Translator, func_idx : Int) -> Unit {
   // Get function type
@@ -1785,8 +1813,10 @@ fn Translator::translate_call(self : Translator, func_idx : Int) -> Unit {
     args.rev_in_place()
     // Get result types
     let result_types : Array[Type] = func_type.results.map(Type::from_wasm)
+    // Remap function index for cross-module calls
+    let global_func_idx = self.remap_func_idx(func_idx)
     // Emit call with multi-value support
-    let results = self.builder.call_multi(func_idx, result_types, args)
+    let results = self.builder.call_multi(global_func_idx, result_types, args)
     // Push all results onto the stack
     for v in results {
       self.push(v)
@@ -1928,9 +1958,11 @@ fn Translator::translate_return_call(self : Translator, func_idx : Int) -> Unit 
       args.push(self.pop())
     }
     args.rev_in_place()
+    // Remap function index for cross-module calls
+    let global_func_idx = self.remap_func_idx(func_idx)
     // Emit return_call instruction (tail call - does not return to caller)
     // Following Cranelift: emit a single ReturnCall IR instruction, not call + return
-    self.builder.return_call_multi(func_idx, args)
+    self.builder.return_call_multi(global_func_idx, args)
     // Mark as unreachable since this is a terminator (does not return to this function)
     self.is_unreachable = true
   }

--- a/jit/jit_runtime.mbt
+++ b/jit/jit_runtime.mbt
@@ -41,6 +41,18 @@ pub fn JITModule::load(
   precompiled : @cwasm.PrecompiledModule,
   func_signatures : Array[(Array[@types.ValueType], Array[@types.ValueType])],
 ) -> JITModule? {
+  JITModule::load_with_imports(precompiled, func_signatures, {})
+}
+
+///|
+/// Load a precompiled module with external import resolution
+/// func_signatures: Array of (param_types, result_types) for each func_idx
+/// external_imports: Map from (module_name, func_name) to function pointer
+pub fn JITModule::load_with_imports(
+  precompiled : @cwasm.PrecompiledModule,
+  func_signatures : Array[(Array[@types.ValueType], Array[@types.ValueType])],
+  external_imports : Map[String, Map[String, Int64]],
+) -> JITModule? {
   let jit_module = JITModule::new()
   let num_imports = precompiled.imports.length()
 
@@ -54,7 +66,15 @@ pub fn JITModule::load(
     Some(ctx) => {
       // Step 1: Populate import trampolines into function table
       for i, imp in precompiled.imports {
-        let func_ptr = get_import_trampoline(imp.module_name, imp.func_name)
+        // First check external imports
+        let func_ptr = match external_imports.get(imp.module_name) {
+          Some(mod_exports) =>
+            match mod_exports.get(imp.func_name) {
+              Some(ptr) => ptr
+              None => get_import_trampoline(imp.module_name, imp.func_name)
+            }
+          None => get_import_trampoline(imp.module_name, imp.func_name)
+        }
         ctx.set_func(i, func_ptr)
       }
 
@@ -241,6 +261,33 @@ pub fn JITModule::get_func_ptr(self : JITModule, func_idx : Int) -> Int64 {
     Some(f) => f.exec_code.ptr()
     None => 0L
   }
+}
+
+///|
+/// Get function pointer by name
+/// Returns the executable code pointer for the function, or 0 if not found
+pub fn JITModule::get_func_ptr_by_name(
+  self : JITModule,
+  name : String,
+) -> Int64 {
+  match self.get_func_by_name(name) {
+    Some(f) => f.exec_code.ptr()
+    None => 0L
+  }
+}
+
+///|
+/// Export all function pointers as a map from name to function pointer
+/// Used for cross-module imports
+pub fn JITModule::export_functions(self : JITModule) -> Map[String, Int64] {
+  let exports : Map[String, Int64] = {}
+  for name, _idx in self.by_name {
+    let ptr = self.get_func_ptr_by_name(name)
+    if ptr != 0L {
+      exports.set(name, ptr)
+    }
+  }
+  exports
 }
 
 ///|

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -265,13 +265,16 @@ pub struct JITFunction {
 type JITModule
 pub fn JITModule::call_with_context(Self, JITFunction, Array[Int64]) -> Array[Int64] raise JITTrap
 pub fn[Arg : DynamicArgs, Ret : DynamicReturn] JITModule::call_with_context_poly(Self, JITFunction, Arg) -> Ret raise PolycallError
+pub fn JITModule::export_functions(Self) -> Map[String, Int64]
 pub fn JITModule::from_single_function(Array[Int], String, Array[@types.ValueType], Array[@types.ValueType], Int64) -> Self?
 pub fn JITModule::get_func(Self, Int) -> JITFunction?
 pub fn JITModule::get_func_by_name(Self, String) -> JITFunction?
 pub fn JITModule::get_func_ptr(Self, Int) -> Int64
+pub fn JITModule::get_func_ptr_by_name(Self, String) -> Int64
 pub fn JITModule::init_indirect_table(Self, Int, Array[(Int, Int, Int)]) -> Unit
 pub fn JITModule::init_shared_tables(Self, Array[JITTable?], Array[(Int, Int, Int, Int)]) -> Unit
 pub fn JITModule::load(@cwasm.PrecompiledModule, Array[(Array[@types.ValueType], Array[@types.ValueType])]) -> Self?
+pub fn JITModule::load_with_imports(@cwasm.PrecompiledModule, Array[(Array[@types.ValueType], Array[@types.ValueType])], Map[String, Map[String, Int64]]) -> Self?
 pub fn JITModule::new() -> Self
 pub fn JITModule::set_globals(Self, Int64) -> Unit
 pub fn JITModule::set_memory(Self, Int64, Int64) -> Unit

--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -21,7 +21,7 @@ pub impl Show for CompareResult with output(self, logger) {
 
 ///|
 /// Convert JIT Int64 results to @types.Value using result_types
-fn jit_results_to_values(
+pub fn jit_results_to_values(
   results : Array[Int64],
   result_types : Array[@types.ValueType],
 ) -> Array[@types.Value] {
@@ -57,7 +57,7 @@ fn jit_results_to_values(
 
 ///|
 /// Convert @types.Value to Int64 for JIT call
-fn value_to_jit_arg(value : @types.Value) -> Int64 {
+pub fn value_to_jit_arg(value : @types.Value) -> Int64 {
   match value {
     I32(n) => @types.ToInt64::to_int64_bits(n)
     I64(n) => @types.ToInt64::to_int64_bits(n)
@@ -72,7 +72,10 @@ fn value_to_jit_arg(value : @types.Value) -> Int64 {
 
 ///|
 /// Compare two Value arrays for equality
-fn values_array_equal(a : Array[@types.Value], b : Array[@types.Value]) -> Bool {
+pub fn values_array_equal(
+  a : Array[@types.Value],
+  b : Array[@types.Value],
+) -> Bool {
   if a.length() != b.length() {
     return false
   }
@@ -158,7 +161,7 @@ fn run_interp(
 }
 
 ///|
-fn run_jit(
+pub fn run_jit(
   mod_ : @types.Module,
   func_name : String,
   func_idx : Int,

--- a/testsuite/cross_module_test.mbt
+++ b/testsuite/cross_module_test.mbt
@@ -1,0 +1,329 @@
+///|
+/// Cross-module JIT tests
+/// Tests for importing functions from one module to another in JIT mode
+
+///|
+/// Error type for cross-module JIT operations
+pub suberror CrossModuleError String
+
+///|
+/// Test: simple cross-module function call
+/// Module A exports `add(i32, i32) -> i32`
+/// Module B imports it and calls it
+test "cross-module: simple function import" {
+  let mod_a_src = "(module (func (export \"add\") (param i32 i32) (result i32) local.get 0 local.get 1 i32.add))"
+  let mod_b_src = "(module (import \"mod_a\" \"add\" (func $add (param i32 i32) (result i32))) (func (export \"call_add\") (param i32 i32) (result i32) local.get 0 local.get 1 call $add))"
+  let result = compare_cross_module_jit_interp(
+    [("mod_a", mod_a_src)],
+    mod_b_src,
+    "call_add",
+    [@types.Value::I32(3), @types.Value::I32(5)],
+  )
+  inspect(result, content="matched")
+}
+
+///|
+/// Test: cross-module with multiple imports
+test "cross-module: multiple function imports" {
+  let mod_a_src = "(module (func (export \"add\") (param i32 i32) (result i32) local.get 0 local.get 1 i32.add) (func (export \"sub\") (param i32 i32) (result i32) local.get 0 local.get 1 i32.sub))"
+  let mod_b_src = "(module (import \"mod_a\" \"add\" (func $add (param i32 i32) (result i32))) (import \"mod_a\" \"sub\" (func $sub (param i32 i32) (result i32))) (func (export \"add_then_sub\") (param i32 i32 i32) (result i32) local.get 0 local.get 1 call $add local.get 2 call $sub))"
+  let result = compare_cross_module_jit_interp(
+    [("mod_a", mod_a_src)],
+    mod_b_src,
+    "add_then_sub",
+    [@types.Value::I32(10), @types.Value::I32(5), @types.Value::I32(3)],
+  )
+  inspect(result, content="matched")
+}
+
+///|
+/// Test: cross-module with float functions
+test "cross-module: float function import" {
+  let mod_a_src = "(module (func (export \"addf\") (param f32 f32) (result f32) local.get 0 local.get 1 f32.add))"
+  let mod_b_src = "(module (import \"mod_a\" \"addf\" (func $addf (param f32 f32) (result f32))) (func (export \"call_addf\") (param f32 f32) (result f32) local.get 0 local.get 1 call $addf))"
+  let result = compare_cross_module_jit_interp(
+    [("mod_a", mod_a_src)],
+    mod_b_src,
+    "call_addf",
+    [@types.Value::F32(1.5), @types.Value::F32(2.5)],
+  )
+  inspect(result, content="matched")
+}
+
+///|
+/// Test: chain of module imports (A -> B -> C)
+test "cross-module: chain imports" {
+  let mod_a_src = "(module (func (export \"double\") (param i32) (result i32) local.get 0 local.get 0 i32.add))"
+  let mod_b_src = "(module (import \"mod_a\" \"double\" (func $double (param i32) (result i32))) (func (export \"quadruple\") (param i32) (result i32) local.get 0 call $double call $double))"
+  let mod_c_src = "(module (import \"mod_b\" \"quadruple\" (func $quad (param i32) (result i32))) (func (export \"octuple\") (param i32) (result i32) local.get 0 call $quad call $quad))"
+  let result = compare_cross_module_jit_interp(
+    [("mod_a", mod_a_src), ("mod_b", mod_b_src)],
+    mod_c_src,
+    "octuple",
+    [@types.Value::I32(1)],
+  )
+  // 1 * 8 = 8
+  inspect(result, content="matched")
+}
+
+///|
+/// Cross-module comparison result
+struct CrossModuleResult {
+  jit_result : Result[Array[@types.Value], String]
+  interp_result : Result[Array[@types.Value], String]
+  matched : Bool
+}
+
+///|
+pub impl Show for CrossModuleResult with output(self, logger) {
+  if self.matched {
+    logger.write_string("matched")
+  } else {
+    logger.write_string("JIT: ")
+    logger.write_object(self.jit_result)
+    logger.write_string(", Interp: ")
+    logger.write_object(self.interp_result)
+  }
+}
+
+///|
+/// Compare cross-module execution between JIT and interpreter
+fn compare_cross_module_jit_interp(
+  dependencies : Array[(String, String)],
+  main_module : String,
+  func_name : String,
+  args : Array[@types.Value],
+) -> CrossModuleResult {
+  // Run with interpreter
+  let interp_result : Result[Array[@types.Value], String] = Ok(
+    run_cross_module_interp(dependencies, main_module, func_name, args),
+  ) catch {
+    CrossModuleError(e) => Err("Interpreter: \{e}")
+  }
+  // Run with JIT
+  let jit_result : Result[Array[@types.Value], String] = Ok(
+    run_cross_module_jit(dependencies, main_module, func_name, args),
+  ) catch {
+    CrossModuleError(e) => Err("JIT: \{e}")
+  }
+  // Compare results
+  let matched = match (jit_result, interp_result) {
+    (Ok(jit_vals), Ok(interp_vals)) =>
+      @testsuite.values_array_equal(jit_vals, interp_vals)
+    (Err(_), Err(_)) => true
+    _ => false
+  }
+  { jit_result, interp_result, matched }
+}
+
+///|
+/// Run cross-module test with interpreter
+fn run_cross_module_interp(
+  dependencies : Array[(String, String)],
+  main_module : String,
+  func_name : String,
+  args : Array[@types.Value],
+) -> Array[@types.Value] raise CrossModuleError {
+  let linker = @runtime.Linker::new()
+  // Instantiate and register each dependency module
+  for dep in dependencies {
+    let (name, source) = dep
+    let mod_ = @wat.parse(source) catch {
+      e => raise CrossModuleError("parse error: \{e}")
+    }
+    let instance = @executor.instantiate_with_linker(linker, name, mod_) catch {
+      e => raise CrossModuleError("instantiate error: \{e}")
+    }
+    linker.register(name, instance)
+  }
+  // Instantiate and run main module
+  let main_mod = @wat.parse(main_module) catch {
+    e => raise CrossModuleError("parse main error: \{e}")
+  }
+  let store = linker.get_store()
+  let main_instance = @executor.instantiate_with_linker(
+    linker, "main", main_mod,
+  ) catch {
+    e => raise CrossModuleError("instantiate main error: \{e}")
+  }
+  @executor.call_exported_func(store, main_instance, func_name, args) catch {
+    e => raise CrossModuleError("call error: \{e}")
+  }
+}
+
+///|
+/// Run cross-module test with JIT using merged compilation
+/// All modules are compiled together with globally unique function indices
+fn run_cross_module_jit(
+  dependencies : Array[(String, String)],
+  main_module : String,
+  func_name : String,
+  args : Array[@types.Value],
+) -> Array[@types.Value] raise CrossModuleError {
+  // Parse all modules first
+  let parsed_modules : Array[(String, @types.Module)] = []
+  for dep in dependencies {
+    let (name, source) = dep
+    let mod_ = @wat.parse(source) catch {
+      e => raise CrossModuleError("parse error: \{e}")
+    }
+    parsed_modules.push((name, mod_))
+  }
+  let main_mod = @wat.parse(main_module) catch {
+    e => raise CrossModuleError("parse main error: \{e}")
+  }
+  parsed_modules.push(("main", main_mod))
+
+  // Calculate global function indices for each module
+  // module_func_base[i] = starting global index for module i's functions
+  let module_func_base : Array[Int] = []
+  let mut global_func_idx = 0
+  for entry in parsed_modules {
+    let (_, mod_) = entry
+    module_func_base.push(global_func_idx)
+    let num_imports = @wast.count_func_imports(mod_.imports)
+    let num_funcs = mod_.codes.length()
+    global_func_idx = global_func_idx + num_imports + num_funcs
+  }
+
+  // Build export map: module_name -> func_name -> global_func_idx
+  let export_map : Map[String, Map[String, Int]] = {}
+  for i, entry in parsed_modules {
+    let (name, mod_) = entry
+    let base = module_func_base[i]
+    let mod_exports : Map[String, Int] = {}
+    for exp in mod_.exports {
+      guard exp.desc is @types.ExportDesc::Func(local_idx) else { continue }
+      mod_exports.set(exp.name, base + local_idx)
+    }
+    export_map.set(name, mod_exports)
+  }
+
+  // Build merged PrecompiledModule with all functions
+  let precompiled = @cwasm.PrecompiledModule::new(@cwasm.AArch64)
+  let all_signatures : Array[(Array[@types.ValueType], Array[@types.ValueType])] = Array::make(
+    global_func_idx,
+    ([], []),
+  )
+  let func_name_to_idx : Map[String, Int] = {}
+  for mod_idx, entry in parsed_modules {
+    let (mod_name, mod_) = entry
+    let base = module_func_base[mod_idx]
+    let num_imports = @wast.count_func_imports(mod_.imports)
+
+    // Build import function type indices for this module
+    let import_func_type_indices : Array[Int] = []
+    for imp in mod_.imports {
+      guard imp.desc is Func(type_idx) else { continue }
+      import_func_type_indices.push(type_idx)
+    }
+
+    // Get memory max from module
+    let memory_max : Int? = if mod_.memories.length() > 0 {
+      mod_.memories[0].limits.max
+    } else {
+      None
+    }
+
+    // Compile each function in this module
+    for i, code in mod_.codes {
+      let local_func_idx = num_imports + i
+      let global_idx = base + local_func_idx
+      let type_idx = mod_.funcs[i]
+      let func_type = mod_.types[type_idx]
+      let f_name = get_exported_func_name(mod_, local_func_idx)
+
+      // For cross-module calls, remap import indices to global indices
+      // Create a remapped imports array
+      let import_remap : Array[Int] = []
+      for imp in mod_.imports {
+        guard imp.desc is Func(_) else { continue }
+        // Look up the global index for this import
+        guard export_map.get(imp.mod_name) is Some(mod_exports) else {
+          raise CrossModuleError(
+            "Module '\{imp.mod_name}' not found for import '\{imp.name}'",
+          )
+        }
+        guard mod_exports.get(imp.name) is Some(target_global_idx) else {
+          raise CrossModuleError(
+            "Function '\{imp.name}' not found in module '\{imp.mod_name}'",
+          )
+        }
+        import_remap.push(target_global_idx)
+      }
+
+      // Translate to IR with import remapping
+      let translator = @ir.Translator::new(
+        f_name,
+        func_type,
+        code.locals,
+        mod_.types,
+        mod_.funcs,
+        num_imports,
+        import_func_type_indices,
+        memory_max~,
+        tables=mod_.tables,
+        type_rec_groups=mod_.type_rec_groups,
+        func_base=base,
+        import_remap~,
+      )
+      let ir_func = translator.translate(code.body)
+      let vcode = @lower.lower_function(ir_func)
+      let allocated_func = @lower.allocate_registers_aarch64(vcode)
+      let mc = @emit.emit_function(allocated_func)
+      let compiled = @vcode.CompiledFunction::new(f_name, mc, 0)
+      precompiled.add_function(
+        global_idx,
+        f_name,
+        compiled,
+        func_type.params.length(),
+        func_type.results.length(),
+      )
+      all_signatures[global_idx] = (func_type.params, func_type.results)
+
+      // Track main module's exported function
+      if mod_name == "main" {
+        func_name_to_idx.set(f_name, global_idx)
+      }
+    }
+  }
+
+  // Load merged JIT module
+  guard @jit.JITModule::load(precompiled, all_signatures) is Some(jm) else {
+    raise CrossModuleError("Failed to create merged JIT module")
+  }
+
+  // Allocate memory
+  let mem_size = 65536L
+  let mem_ptr = @jit.alloc_memory(mem_size)
+  if mem_ptr == 0L {
+    raise CrossModuleError("Failed to allocate memory")
+  }
+  jm.set_memory(mem_ptr, mem_size)
+
+  // Get target function's result types
+  guard func_name_to_idx.get(func_name) is Some(target_idx) else {
+    raise CrossModuleError("Function '\{func_name}' not found in main module")
+  }
+  let (_, result_types) = all_signatures[target_idx]
+
+  // Call the target function
+  guard jm.get_func_by_name(func_name) is Some(f) else {
+    raise CrossModuleError("Failed to get JIT function '\{func_name}'")
+  }
+  let jit_args = args.map(@testsuite.value_to_jit_arg)
+  let raw_results = jm.call_with_context(f, jit_args) catch {
+    e => raise CrossModuleError("JIT call error: \{e}")
+  }
+  @testsuite.jit_results_to_values(raw_results, result_types)
+}
+
+///|
+fn get_exported_func_name(mod_ : @types.Module, func_idx : Int) -> String {
+  for exp in mod_.exports {
+    if exp.desc is @types.ExportDesc::Func(idx) && idx == func_idx {
+      return exp.name
+    }
+  }
+  "func_\{func_idx}"
+}

--- a/testsuite/pkg.generated.mbti
+++ b/testsuite/pkg.generated.mbti
@@ -10,6 +10,8 @@ import(
 // Values
 pub fn compare_jit_interp(String, String, Array[@types.Value]) -> CompareResult
 
+pub fn jit_results_to_values(Array[Int64], Array[@types.ValueType]) -> Array[@types.Value]
+
 pub fn parse_json_test_file(String) -> ParsedTestFile raise TestRunnerError
 
 pub fn parse_test_value(TestValue) -> @types.Value
@@ -18,11 +20,17 @@ pub fn run_assert_return(TestContext, String?, String, Array[TestValue], Array[T
 
 pub fn run_assert_trap(TestContext, String?, String, Array[TestValue], String) -> Bool
 
+pub fn run_jit(@types.Module, String, Int, Array[@types.Value], Array[@types.ValueType]) -> Result[Array[@types.Value], String]
+
 pub fn run_json_tests(String, String, (String) -> Bytes raise) -> TestResult raise TestRunnerError
 
 pub fn run_test_command(TestContext, TestCommand, TestResult, String, (String) -> Bytes raise) -> Unit raise TestRunnerError
 
 pub fn run_test_command_with_line(TestContext, TestCommandWithLine, TestResult, String, (String) -> Bytes raise) -> Unit raise TestRunnerError
+
+pub fn value_to_jit_arg(@types.Value) -> Int64
+
+pub fn values_array_equal(Array[@types.Value], Array[@types.Value]) -> Bool
 
 pub fn values_equal(@types.Value, @types.Value) -> Bool
 


### PR DESCRIPTION
## Summary

- Add support for JIT compilation across multiple WebAssembly modules
- Implement merged compilation approach where all modules share a unified function table with globally unique indices
- Enable chain imports (e.g., mod_a → mod_b → mod_c) where each module can call functions from previously compiled modules

### Key changes:

- **ir/translator.mbt**: Add `func_base` and `import_remap` parameters to remap local function indices to global indices during IR translation
- **jit/jit_runtime.mbt**: Add `load_with_imports` and `export_functions` methods for cross-module linking
- **testsuite/cross_module_test.mbt**: Add 4 test cases covering simple imports, multiple imports, float functions, and chain imports

## Test plan

- [x] All 4 cross-module tests pass
- [x] Full test suite passes (918 tests)
- [x] `moon check` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)