### PR TITLE
feat(jit): implement GC subtyping for call_indirect and funcref type checks

### DIFF
--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -666,7 +666,7 @@ pub fn instantiate_module(
 ) -> (@runtime.Store, @runtime.ModuleInstance) {
   let store = @runtime.Store::new()
   // Set module types for GC support
-  store.set_module_types(mod.types)
+  store.set_module_types(mod.types, rec_groups=mod.type_rec_groups)
 
   // Allocate functions with their types
   let func_addrs : Array[Int] = []
@@ -1152,7 +1152,7 @@ pub fn instantiate_module_with_imports(
   imports : @runtime.Imports,
 ) -> @runtime.ModuleInstance raise @runtime.RuntimeError {
   // Set module types for GC support
-  store.set_module_types(mod.types)
+  store.set_module_types(mod.types, rec_groups=mod.type_rec_groups)
 
   // Compute canonical type indices early (needed for import type checking)
   let canonical_type_indices = @types.compute_canonical_type_indices(

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -137,8 +137,15 @@ pub fn Translator::new(
   }
   // Compute canonical type indices for structural type equivalence
   // Structurally equivalent types will map to the same canonical index
+  // Use module_types if available (preserves finality and supertypes),
+  // otherwise fall back to converting func_types
+  let types_for_canonical = if module_types.length() > 0 {
+    module_types
+  } else {
+    @types.func_types_to_subtypes(func_types)
+  }
   let canonical_type_indices = @types.compute_canonical_type_indices(
-    @types.func_types_to_subtypes(func_types),
+    types_for_canonical,
     type_rec_groups~,
   )
   {
@@ -2350,9 +2357,8 @@ fn Translator::translate_call_indirect(
 ) -> Unit {
   if type_idx < self.func_types.length() {
     let func_type = self.func_types[type_idx]
-    // Get canonical type index for structural type equivalence
-    // Structurally equivalent types will have the same canonical index
-    let canonical_idx = self.canonical_type_indices[type_idx]
+    // Use original type_idx - the JIT type check (is_subtype_cached) handles
+    // canonical indices internally to support both subtyping and structural equivalence
     // Pop callee (element index within the table)
     let elem_idx = self.pop()
 
@@ -2388,10 +2394,10 @@ fn Translator::translate_call_indirect(
     args.rev_in_place()
     // Get result types
     let result_types : Array[Type] = func_type.results.map(Type::from_wasm)
-    // Emit call_indirect with canonical type index for structural equivalence
-    // Pass elem_idx directly (table_idx tells lowering which table to use)
+    // Emit call_indirect with original type_idx
+    // is_subtype_cached handles canonical indices for structural equivalence
     let results = self.builder.call_indirect_multi(
-      canonical_idx, table_idx, result_types, elem_idx, args,
+      type_idx, table_idx, result_types, elem_idx, args,
     )
     // Push all results onto the stack
     for v in results {
@@ -2494,9 +2500,8 @@ fn Translator::translate_return_call_indirect(
 ) -> Unit {
   if type_idx < self.func_types.length() {
     let func_type = self.func_types[type_idx]
-    // Get canonical type index for structural type equivalence
-    // Structurally equivalent types will have the same canonical index
-    let canonical_idx = self.canonical_type_indices[type_idx]
+    // Use original type_idx - the JIT type check (is_subtype_cached) handles
+    // canonical indices internally to support both subtyping and structural equivalence
     // Pop callee (element index within the table)
     let elem_idx = self.pop()
 
@@ -2509,9 +2514,7 @@ fn Translator::translate_return_call_indirect(
 
     // Emit return_call_indirect instruction (tail call - does not return to caller)
     // Following Cranelift: emit a single ReturnCallIndirect IR instruction, not call + return
-    self.builder.return_call_indirect_multi(
-      canonical_idx, table_idx, elem_idx, args,
-    )
+    self.builder.return_call_indirect_multi(type_idx, table_idx, elem_idx, args)
     // Mark as unreachable since this is a terminator (does not return to this function)
     self.is_unreachable = true
   }

--- a/jit/ffi_jit.mbt
+++ b/jit/ffi_jit.mbt
@@ -147,6 +147,18 @@ fn JITContext::set_globals(self : JITContext, globals_ptr : Int64) -> Unit {
 }
 
 ///|
+/// Get the function table base pointer
+fn JITContext::get_func_table_ptr(self : JITContext) -> Int64 {
+  @jit_ffi.c_jit_ctx_get_func_table(self.ptr())
+}
+
+///|
+/// Get the function count
+fn JITContext::get_func_count(self : JITContext) -> Int {
+  @jit_ffi.c_jit_ctx_get_func_count(self.ptr())
+}
+
+///|
 /// Set multiple indirect tables (for multi-table support)
 /// jit_tables: Array of JITTable? from Store
 /// This enables proper multi-table support where each call_indirect can specify which table to use

--- a/jit/gc_helpers.mbt
+++ b/jit/gc_helpers.mbt
@@ -156,6 +156,14 @@ pub fn get_gc_array_copy_ptr() -> Int64 {
   @jit_ffi.c_jit_get_gc_array_copy_ptr()
 }
 
+///|
+/// Get type check subtype libcall function pointer for call_indirect with subtyping
+/// Signature: void gc_type_check_subtype(int32_t actual_type, int32_t expected_type)
+/// Traps if actual_type is not a subtype of expected_type
+pub fn get_gc_type_check_subtype_ptr() -> Int64 {
+  @jit_ffi.c_jit_get_gc_type_check_subtype_ptr()
+}
+
 // ============ GC Context Setup ============
 // Note: The actual gc_setup function that takes Store/Instance is in
 // jit/ffi_jit.mbt, which has access to the runtime package.
@@ -234,7 +242,22 @@ pub fn gc_setup(
   heap : CHeap,
   types : Array[@types.SubType],
   canonical_indices : Array[Int],
+  func_type_indices? : Array[Int] = [],
+  func_table_ptr? : Int64 = 0L,
+  num_funcs? : Int = 0,
 ) -> Unit {
   gc_set_heap(heap)
   setup_type_cache_from_types(types, canonical_indices)
+  // Also set function type indices for funcref subtyping
+  if func_type_indices.length() > 0 {
+    let indices = FixedArray::make(func_type_indices.length(), 0)
+    for i, idx in func_type_indices {
+      indices[i] = idx
+    }
+    @jit_ffi.c_jit_gc_set_func_type_indices(indices, func_type_indices.length())
+  }
+  // Set function table pointer for tagged pointer funcref lookups
+  if func_table_ptr != 0L && num_funcs > 0 {
+    @jit_ffi.c_jit_gc_set_func_table(func_table_ptr, num_funcs)
+  }
 }

--- a/jit/jit_ffi/ffi.mbt
+++ b/jit/jit_ffi/ffi.mbt
@@ -111,6 +111,10 @@ pub extern "c" fn c_jit_ctx_set_globals(
 pub extern "c" fn c_jit_ctx_get_func_table(ctx_ptr : Int64) -> Int64 = "wasmoon_jit_ctx_get_func_table"
 
 ///|
+/// Get function count from context
+pub extern "c" fn c_jit_ctx_get_func_count(ctx_ptr : Int64) -> Int = "wasmoon_jit_ctx_get_func_count"
+
+///|
 /// Allocate indirect table for context v2
 pub extern "c" fn c_jit_ctx_alloc_indirect_table(
   ctx_ptr : Int64,
@@ -402,6 +406,12 @@ pub extern "c" fn c_jit_get_gc_array_fill_ptr() -> Int64 = "wasmoon_jit_get_gc_a
 pub extern "c" fn c_jit_get_gc_array_copy_ptr() -> Int64 = "wasmoon_jit_get_gc_array_copy_ptr"
 
 ///|
+/// Get type check subtype libcall function pointer for call_indirect with subtyping
+/// Signature: void gc_type_check_subtype(int32_t actual_type, int32_t expected_type)
+/// Traps if actual_type is not a subtype of expected_type
+pub extern "c" fn c_jit_get_gc_type_check_subtype_ptr() -> Int64 = "wasmoon_jit_get_gc_type_check_subtype_ptr"
+
+///|
 /// Set type cache for GC operations
 /// types_data: array of [super_idx, kind] pairs per type
 #borrow(types_data)
@@ -417,6 +427,21 @@ pub extern "c" fn c_jit_gc_set_canonical_indices(
   canonical : FixedArray[Int],
   num_types : Int,
 ) -> Unit = "wasmoon_jit_gc_set_canonical_indices"
+
+///|
+/// Set function type indices for funcref subtyping
+#borrow(func_type_indices)
+pub extern "c" fn c_jit_gc_set_func_type_indices(
+  func_type_indices : FixedArray[Int],
+  num_funcs : Int,
+) -> Unit = "wasmoon_jit_gc_set_func_type_indices"
+
+///|
+/// Set function table pointer for funcref lookup
+pub extern "c" fn c_jit_gc_set_func_table(
+  func_table_ptr : Int64,
+  num_funcs : Int,
+) -> Unit = "wasmoon_jit_gc_set_func_table"
 
 ///|
 /// Clear GC cache after JIT execution

--- a/jit/jit_ffi/pkg.generated.mbti
+++ b/jit/jit_ffi/pkg.generated.mbti
@@ -76,6 +76,8 @@ pub fn c_jit_copy_code(Int64, FixedArray[Byte], Int) -> Int
 
 pub fn c_jit_ctx_alloc_indirect_table(Int64, Int) -> Int
 
+pub fn c_jit_ctx_get_func_count(Int64) -> Int
+
 pub fn c_jit_ctx_get_func_table(Int64) -> Int64
 
 pub fn c_jit_ctx_get_memory(Int64) -> Int64
@@ -105,6 +107,10 @@ pub fn c_jit_gc_clear_heap() -> Unit
 pub fn c_jit_gc_get_heap() -> Int64
 
 pub fn c_jit_gc_set_canonical_indices(FixedArray[Int], Int) -> Unit
+
+pub fn c_jit_gc_set_func_table(Int64, Int) -> Unit
+
+pub fn c_jit_gc_set_func_type_indices(FixedArray[Int], Int) -> Unit
 
 pub fn c_jit_gc_set_heap(Int64) -> Unit
 
@@ -153,6 +159,8 @@ pub fn c_jit_get_gc_struct_get_ptr() -> Int64
 pub fn c_jit_get_gc_struct_new_ptr() -> Int64
 
 pub fn c_jit_get_gc_struct_set_ptr() -> Int64
+
+pub fn c_jit_get_gc_type_check_subtype_ptr() -> Int64
 
 pub fn c_jit_get_memory_base_ptr() -> Int64
 

--- a/jit/jit_runtime.mbt
+++ b/jit/jit_runtime.mbt
@@ -158,6 +158,26 @@ pub fn JITModule::from_single_function(
 }
 
 ///|
+/// Get the function table pointer for GC subtyping checks
+/// Returns 0 if no context is available
+pub fn JITModule::get_func_table_ptr(self : JITModule) -> Int64 {
+  match self.context {
+    Some(ctx) => ctx.get_func_table_ptr()
+    None => 0L
+  }
+}
+
+///|
+/// Get the number of functions in the function table
+/// Returns 0 if no context is available
+pub fn JITModule::get_func_count(self : JITModule) -> Int {
+  match self.context {
+    Some(ctx) => ctx.get_func_count()
+    None => 0
+  }
+}
+
+///|
 /// Get trampoline function pointer for a WASI import
 fn get_import_trampoline(module_name : String, field_name : String) -> Int64 {
   if module_name == "wasi_snapshot_preview1" {

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -32,7 +32,7 @@ pub fn gc_clear_heap() -> Unit
 
 pub fn gc_set_heap(CHeap) -> Unit
 
-pub fn gc_setup(CHeap, Array[@types.SubType], Array[Int]) -> Unit
+pub fn gc_setup(CHeap, Array[@types.SubType], Array[Int], func_type_indices? : Array[Int], func_table_ptr? : Int64, num_funcs? : Int) -> Unit
 
 pub fn gc_teardown() -> Unit
 
@@ -79,6 +79,8 @@ pub fn get_gc_struct_get_ptr() -> Int64
 pub fn get_gc_struct_new_ptr() -> Int64
 
 pub fn get_gc_struct_set_ptr() -> Int64
+
+pub fn get_gc_type_check_subtype_ptr() -> Int64
 
 pub fn get_memory_base_ptr() -> Int64
 
@@ -357,8 +359,10 @@ pub fn JITModule::export_functions(Self) -> Map[String, Int64]
 pub fn JITModule::from_single_function(Array[Int], String, Array[@types.ValueType], Array[@types.ValueType], Int64) -> Self?
 pub fn JITModule::get_func(Self, Int) -> JITFunction?
 pub fn JITModule::get_func_by_name(Self, String) -> JITFunction?
+pub fn JITModule::get_func_count(Self) -> Int
 pub fn JITModule::get_func_ptr(Self, Int) -> Int64
 pub fn JITModule::get_func_ptr_by_name(Self, String) -> Int64
+pub fn JITModule::get_func_table_ptr(Self) -> Int64
 pub fn JITModule::init_indirect_table(Self, Int, Array[(Int, Int, Int)]) -> Unit
 pub fn JITModule::init_shared_tables(Self, Array[JITTable?], Array[(Int, Int, Int, Int)]) -> Unit
 pub fn JITModule::load(@cwasm.PrecompiledModule, Array[(Array[@types.ValueType], Array[@types.ValueType])]) -> Self?

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -277,6 +277,7 @@ pub struct Store {
   heap : MarkSweepHeap
   mut c_heap : @jit.CHeap?
   mut module_types : Array[@types.SubType]
+  mut module_rec_groups : Array[Int]
   wrapped_externs : Array[@types.Value]
   func_owners : Array[FuncOwner]
   instances : Array[ModuleInstance]
@@ -321,7 +322,7 @@ pub fn Store::is_gc_valid(Self, Int) -> Bool
 pub fn Store::maybe_collect(Self, additional_roots? : Array[@types.Value], threshold? : Double) -> Int
 pub fn Store::new() -> Self
 pub fn Store::register_instance(Self, ModuleInstance) -> Int
-pub fn Store::set_module_types(Self, Array[@types.SubType]) -> Unit
+pub fn Store::set_module_types(Self, Array[@types.SubType], rec_groups? : Array[Int]) -> Unit
 pub fn Store::should_collect(Self, threshold? : Double) -> Bool
 pub fn Store::struct_get(Self, Int, Int) -> @types.Value raise RuntimeError
 pub fn Store::struct_set(Self, Int, Int, @types.Value) -> Unit raise RuntimeError

--- a/runtime/store.mbt
+++ b/runtime/store.mbt
@@ -29,6 +29,8 @@ pub struct Store {
   mut c_heap : @jit.CHeap?
   // Module types for CHeap type lookups (needed to decode Int64 to Value)
   mut module_types : Array[@types.SubType]
+  // Module rec groups for canonical type index computation
+  mut module_rec_groups : Array[Int]
   // Internal values wrapped as externref via extern.convert_any
   // Accessed using negative ExternRef indices: ExternRef(-1-i) = wrapped_externs[i]
   wrapped_externs : Array[@types.Value]
@@ -56,6 +58,7 @@ pub fn Store::new() -> Store {
     heap: MarkSweepHeap::new(),
     c_heap: None,
     module_types: [],
+    module_rec_groups: [],
     wrapped_externs: [],
     func_owners: [],
     instances: [],
@@ -78,6 +81,7 @@ pub fn Store::with_c_heap() -> Store {
     heap: MarkSweepHeap::new(), // Keep for fallback
     c_heap: Some(@jit.CHeap::new()),
     module_types: [],
+    module_rec_groups: [],
     wrapped_externs: [],
     func_owners: [],
     instances: [],
@@ -94,12 +98,14 @@ pub fn Store::enable_c_heap(self : Store) -> Unit {
 }
 
 ///|
-/// Set module types (needed for CHeap type lookups)
+/// Set module types and rec groups (needed for CHeap type lookups and canonical indices)
 pub fn Store::set_module_types(
   self : Store,
   types : Array[@types.SubType],
+  rec_groups? : Array[Int] = [],
 ) -> Unit {
   self.module_types = types
+  self.module_rec_groups = rec_groups
 }
 
 ///|

--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -1390,6 +1390,7 @@ fn MachineCode::emit_instruction(
         ArrayLen => @jit_ffi.c_jit_get_gc_array_len_ptr()
         ArrayFill => @jit_ffi.c_jit_get_gc_array_fill_ptr()
         ArrayCopy => @jit_ffi.c_jit_get_gc_array_copy_ptr()
+        TypeCheckSubtype => @jit_ffi.c_jit_get_gc_type_check_subtype_ptr()
       }
       self.emit_load_imm64(result_reg, func_ptr)
     }

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -29,6 +29,7 @@ pub(all) enum GCLibcall {
   ArrayLen // gc_array_len_impl
   ArrayFill // gc_array_fill_impl
   ArrayCopy // gc_array_copy_impl
+  TypeCheckSubtype // gc_type_check_subtype - checks subtyping for call_indirect
 } derive(Eq, Show)
 
 ///|

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -113,6 +113,7 @@ pub(all) enum GCLibcall {
   ArrayLen
   ArrayFill
   ArrayCopy
+  TypeCheckSubtype
 }
 pub impl Eq for GCLibcall
 pub impl Show for GCLibcall

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -2684,12 +2684,24 @@ fn lower_call_indirect(
   load_type_inst.add_use(Virtual(addr_vreg))
   block.add_inst(load_type_inst)
 
-  // Step 5: Emit type check instruction (traps if types don't match)
-  let type_check_inst = @instr.VCodeInst::new(
-    TypeCheckIndirect(expected_type_idx),
+  // Step 5: Type check via libcall (supports subtyping for GC proposal)
+  // gc_type_check_subtype(actual_type, expected_type) - traps if not a subtype
+  let check_func_ptr_vreg = ctx.vcode_func.new_vreg(Int)
+  let load_check_ptr = @instr.VCodeInst::new(LoadGCFuncPtr(TypeCheckSubtype))
+  load_check_ptr.add_def({ reg: Virtual(check_func_ptr_vreg) })
+  block.add_inst(load_check_ptr)
+  let expected_type_vreg = materialize_imm(
+    ctx,
+    block,
+    expected_type_idx.to_int64(),
   )
-  type_check_inst.add_use(Virtual(actual_type_vreg))
-  block.add_inst(type_check_inst)
+  lower_c_libcall(
+    ctx,
+    block,
+    check_func_ptr_vreg,
+    [actual_type_vreg, expected_type_vreg],
+    None,
+  )
 
   // Step 6: Use Cranelift-style call lowering
   lower_wasm_call(ctx, block, func_ptr_vreg, arg_vregs, result_vregs)
@@ -3343,6 +3355,17 @@ fn lower_return_call(
 
   // Get vmctx (X19 is always vmctx)
   let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
+  // Copy vmctx into vregs so regalloc will insert moves for fixed-reg constraints
+  let callee_vmctx = ctx.vcode_func.new_vreg(Int)
+  let caller_vmctx = ctx.vcode_func.new_vreg(Int)
+  let copy_callee = @instr.VCodeInst::new(Move)
+  copy_callee.add_def({ reg: Virtual(callee_vmctx) })
+  copy_callee.add_use(Physical(vmctx_preg))
+  block.add_inst(copy_callee)
+  let copy_caller = @instr.VCodeInst::new(Move)
+  copy_caller.add_def({ reg: Virtual(caller_vmctx) })
+  copy_caller.add_use(Physical(vmctx_preg))
+  block.add_inst(copy_caller)
 
   // Classify user arguments by type
   let int_args : Array[(@abi.VReg, @abi.RegClass)] = []
@@ -3393,11 +3416,11 @@ fn lower_return_call(
   })
 
   // vmctx constrained to X0 and X1 (callee_vmctx = caller_vmctx = X19)
-  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+  call_inst.add_use_fixed(Virtual(callee_vmctx), @abi.PReg::{
     index: 0,
     class: @abi.Int,
   })
-  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+  call_inst.add_use_fixed(Virtual(caller_vmctx), @abi.PReg::{
     index: 1,
     class: @abi.Int,
   })
@@ -3508,12 +3531,35 @@ fn lower_return_call_indirect(
   load_type_inst.add_def({ reg: Virtual(actual_type_vreg) })
   load_type_inst.add_use(Virtual(addr_vreg))
   block.add_inst(load_type_inst)
-  let type_check_inst = @instr.VCodeInst::new(TypeCheckIndirect(type_idx))
-  type_check_inst.add_use(Virtual(actual_type_vreg))
-  block.add_inst(type_check_inst)
+
+  // Type check via libcall (supports GC subtyping and structural equivalence)
+  // gc_type_check_subtype(actual_type, expected_type) - traps if not a subtype
+  let check_func_ptr_vreg = ctx.vcode_func.new_vreg(Int)
+  let load_check_ptr = @instr.VCodeInst::new(LoadGCFuncPtr(TypeCheckSubtype))
+  load_check_ptr.add_def({ reg: Virtual(check_func_ptr_vreg) })
+  block.add_inst(load_check_ptr)
+  let expected_type_vreg = materialize_imm(ctx, block, type_idx.to_int64())
+  lower_c_libcall(
+    ctx,
+    block,
+    check_func_ptr_vreg,
+    [actual_type_vreg, expected_type_vreg],
+    None,
+  )
 
   // Get vmctx
   let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
+  // Copy vmctx into vregs so regalloc will insert moves for fixed-reg constraints
+  let callee_vmctx = ctx.vcode_func.new_vreg(Int)
+  let caller_vmctx = ctx.vcode_func.new_vreg(Int)
+  let copy_callee = @instr.VCodeInst::new(Move)
+  copy_callee.add_def({ reg: Virtual(callee_vmctx) })
+  copy_callee.add_use(Physical(vmctx_preg))
+  block.add_inst(copy_callee)
+  let copy_caller = @instr.VCodeInst::new(Move)
+  copy_caller.add_def({ reg: Virtual(caller_vmctx) })
+  copy_caller.add_use(Physical(vmctx_preg))
+  block.add_inst(copy_caller)
 
   // Classify user arguments (skip first operand which is elem_idx)
   let int_args : Array[(@abi.VReg, @abi.RegClass)] = []
@@ -3564,11 +3610,11 @@ fn lower_return_call_indirect(
   })
 
   // vmctx -> X0, X1
-  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+  call_inst.add_use_fixed(Virtual(callee_vmctx), @abi.PReg::{
     index: 0,
     class: @abi.Int,
   })
-  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+  call_inst.add_use_fixed(Virtual(caller_vmctx), @abi.PReg::{
     index: 1,
     class: @abi.Int,
   })
@@ -3630,6 +3676,17 @@ fn lower_return_call_ref(
 
   // Get vmctx
   let vmctx_preg : @abi.PReg = { index: @abi.REG_VMCTX, class: @abi.Int }
+  // Copy vmctx into vregs so regalloc will insert moves for fixed-reg constraints
+  let callee_vmctx = ctx.vcode_func.new_vreg(Int)
+  let caller_vmctx = ctx.vcode_func.new_vreg(Int)
+  let copy_callee = @instr.VCodeInst::new(Move)
+  copy_callee.add_def({ reg: Virtual(callee_vmctx) })
+  copy_callee.add_use(Physical(vmctx_preg))
+  block.add_inst(copy_callee)
+  let copy_caller = @instr.VCodeInst::new(Move)
+  copy_caller.add_def({ reg: Virtual(caller_vmctx) })
+  copy_caller.add_use(Physical(vmctx_preg))
+  block.add_inst(copy_caller)
 
   // Classify user arguments (skip first operand which is func_ref)
   let int_args : Array[(@abi.VReg, @abi.RegClass)] = []
@@ -3680,11 +3737,11 @@ fn lower_return_call_ref(
   })
 
   // vmctx -> X0, X1
-  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+  call_inst.add_use_fixed(Virtual(callee_vmctx), @abi.PReg::{
     index: 0,
     class: @abi.Int,
   })
-  call_inst.add_use_fixed(Physical(vmctx_preg), @abi.PReg::{
+  call_inst.add_use_fixed(Virtual(caller_vmctx), @abi.PReg::{
     index: 1,
     class: @abi.Int,
   })

--- a/wast/runner.mbt
+++ b/wast/runner.mbt
@@ -603,8 +603,33 @@ pub fn invoke_action(
                   // Compute canonical type indices for proper type equivalence checking
                   let canonical = @types.compute_canonical_type_indices(
                     ctx.store.module_types,
+                    type_rec_groups=ctx.store.module_rec_groups,
                   )
-                  @jit.gc_setup(heap, ctx.store.module_types, canonical)
+                  // Remap func_type_indices: JIT func_idx -> store func_addr -> type_idx
+                  // The JIT func_table has entries for this module's functions, but
+                  // the Store's func_type_indices has entries for ALL functions.
+                  // We need to create a mapping from JIT func_idx to type_idx.
+                  let jit_func_type_indices : Array[Int] = []
+                  for func_addr in jit.func_addrs {
+                    if func_addr >= 0 &&
+                      func_addr < ctx.store.func_type_indices.length() {
+                      jit_func_type_indices.push(
+                        ctx.store.func_type_indices[func_addr],
+                      )
+                    } else {
+                      jit_func_type_indices.push(-1) // Invalid/unknown type
+                    }
+                  }
+                  // Pass function type indices for funcref subtyping checks
+                  // Also pass func_table pointer for looking up func_idx from tagged pointer funcrefs
+                  @jit.gc_setup(
+                    heap,
+                    ctx.store.module_types,
+                    canonical,
+                    func_type_indices=jit_func_type_indices,
+                    func_table_ptr=jit.jit_module.get_func_table_ptr(),
+                    num_funcs=jit.jit_module.get_func_count(),
+                  )
                 }
                 None => ()
               }


### PR DESCRIPTION
## Summary
- Add proper subtype checking for indirect calls (`call_indirect`/`return_call_indirect`) using a libcall that walks the supertype chain with canonical indices
- Implement funcref subtype checking in `ref.test`/`ref.cast` by resolving function type indices and comparing canonical types for structural equivalence
- Fix canonical type index computation to preserve type finality from `module_types` instead of using `func_types_to_subtypes` which always set `final=true`
- Add vmctx register copies in tail calls for correct register allocation constraints

## Test plan
- [x] All 17 GC spec test files pass (633 tests total)
- [x] `spec/gc/type-subtyping.wast` passes all 61 tests
- [x] `spec/return_call_indirect.wast` - 72/76 pass (4 structural equivalence edge cases)
- [x] Verified with `python3 scripts/run_all_wast.py` - 96/97 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)