### PR TITLE
fix(bulk-memory): improve validation and bounds checking

### DIFF
--- a/executor/instr_memory.mbt
+++ b/executor/instr_memory.mbt
@@ -347,22 +347,34 @@ fn ExecContext::exec_memory_misc(
       let n = self.stack.pop_i32() // length
       let s = self.stack.pop_i32() // source offset in data segment
       let d = self.stack.pop_i32() // destination in memory
-      // Check if segment has been dropped
-      if self.instance.dropped_datas[data_idx] {
-        // Dropped segments behave as if they have zero length
-        if n != 0 {
-          raise @runtime.RuntimeError::OutOfBoundsMemoryAccess
-        }
-        return
-      }
       let mem_addr = self.instance.mem_addrs[memidx]
       let mem = self.store.get_mem(mem_addr)
-      let data_segment = self.instance.data_segments[data_idx]
-      // Extract the slice from data segment
-      if s < 0 || n < 0 || s + n > data_segment.init.length() {
+      // Use 64-bit arithmetic to avoid overflow
+      let n64 = n.to_int64() & 0xFFFF_FFFFL
+      let s64 = s.to_int64() & 0xFFFF_FFFFL
+      let d64 = d.to_int64() & 0xFFFF_FFFFL
+      // Determine data segment length (0 if dropped)
+      let data_len = if self.instance.dropped_datas[data_idx] {
+        0
+      } else {
+        self.instance.data_segments[data_idx].init.length()
+      }
+      // Check bounds (must happen even when n=0)
+      // 1. Check data segment bounds
+      if s64 + n64 > data_len.to_int64() {
         raise @runtime.RuntimeError::OutOfBoundsMemoryAccess
       }
+      // 2. Check memory bounds
+      let mem_size_bytes = mem.size_pages() * 65536
+      if d64 + n64 > mem_size_bytes.to_int64() {
+        raise @runtime.RuntimeError::OutOfBoundsMemoryAccess
+      }
+      // 3. If n=0, no-op
+      if n == 0 {
+        return
+      }
       // Copy bytes directly to memory
+      let data_segment = self.instance.data_segments[data_idx]
       for i in 0..<n {
         mem.store_byte(d + i, data_segment.init[s + i])
       }

--- a/runtime/memory.mbt
+++ b/runtime/memory.mbt
@@ -379,10 +379,12 @@ pub fn Memory::copy(
   src : Int,
   len : Int,
 ) -> Unit raise RuntimeError {
-  if dest < 0 ||
-    src < 0 ||
-    dest + len > self.data.length() ||
-    src + len > self.data.length() {
+  // Use 64-bit unsigned arithmetic to avoid wraparound
+  let dest64 = dest.to_int64() & 0xFFFF_FFFFL
+  let src64 = src.to_int64() & 0xFFFF_FFFFL
+  let len64 = len.to_int64() & 0xFFFF_FFFFL
+  let mem_size = self.data.length().to_int64()
+  if dest64 + len64 > mem_size || src64 + len64 > mem_size {
     raise OutOfBoundsMemoryAccess
   }
   if len == 0 {
@@ -410,8 +412,15 @@ pub fn Memory::fill(
   value : Byte,
   len : Int,
 ) -> Unit raise RuntimeError {
-  if dest < 0 || dest + len > self.data.length() {
+  // Use 64-bit unsigned arithmetic to avoid wraparound
+  let dest64 = dest.to_int64() & 0xFFFF_FFFFL
+  let len64 = len.to_int64() & 0xFFFF_FFFFL
+  let mem_size = self.data.length().to_int64()
+  if dest64 + len64 > mem_size {
     raise OutOfBoundsMemoryAccess
+  }
+  if len == 0 {
+    return
   }
   for i in 0..<len {
     self.data[dest + i] = value

--- a/validator/pkg.generated.mbti
+++ b/validator/pkg.generated.mbti
@@ -25,6 +25,7 @@ pub(all) suberror ValidationError {
   InvalidMemoryIndex(Int)
   InvalidLabelIndex(Int)
   InvalidElemIndex(Int)
+  InvalidDataIndex(Int)
   UnknownTag(Int)
   UnknownType(Int)
   UnreachableCode

--- a/validator/validator.mbt
+++ b/validator/validator.mbt
@@ -14,6 +14,7 @@ pub(all) suberror ValidationError {
   InvalidMemoryIndex(Int)
   InvalidLabelIndex(Int)
   InvalidElemIndex(Int)
+  InvalidDataIndex(Int) // Unknown data segment index
   UnknownTag(Int) // Unknown tag index
   UnknownType(Int) // Forward type reference outside rec group
   UnreachableCode
@@ -61,7 +62,8 @@ pub fn ValidationErrorContext::from_error(
     InvalidTableIndex(idx) => "invalid table index: \{idx}"
     InvalidMemoryIndex(idx) => "invalid memory index: \{idx}"
     InvalidLabelIndex(idx) => "invalid label index: \{idx}"
-    InvalidElemIndex(idx) => "invalid element index: \{idx}"
+    InvalidElemIndex(idx) => "unknown elem segment \{idx}"
+    InvalidDataIndex(idx) => "unknown data segment \{idx}"
     UnknownTag(idx) => "unknown tag \{idx}"
     UnknownType(_) => "unknown type"
     UnreachableCode => "unreachable code"
@@ -1914,15 +1916,21 @@ fn validate_instr(
       }
       stack.push(@types.ValueType::I32)
     }
-    MemoryInit(memidx, _) => {
+    MemoryInit(memidx, data_idx) => {
       if memidx >= ctx.mems.length() {
         raise InvalidMemoryIndex(memidx)
+      }
+      if data_idx >= ctx.data_count {
+        raise InvalidDataIndex(data_idx)
       }
       stack.pop(@types.ValueType::I32) // n
       stack.pop(@types.ValueType::I32) // s
       stack.pop(@types.ValueType::I32) // d
     }
-    DataDrop(_) => ()
+    DataDrop(data_idx) =>
+      if data_idx >= ctx.data_count {
+        raise InvalidDataIndex(data_idx)
+      }
     MemoryCopy(dst, src) => {
       if dst >= ctx.mems.length() {
         raise InvalidMemoryIndex(dst)
@@ -1975,7 +1983,21 @@ fn validate_instr(
       stack.pop(ctx.tables[idx].elem_type) // value
       stack.pop(@types.ValueType::I32) // i
     }
-    TableCopy(_, _) => {
+    TableCopy(dst_idx, src_idx) => {
+      if dst_idx >= ctx.tables.length() {
+        raise InvalidTableIndex(dst_idx)
+      }
+      if src_idx >= ctx.tables.length() {
+        raise InvalidTableIndex(src_idx)
+      }
+      // Check that source element type is subtype of destination element type
+      let dst_elem_type = ctx.tables[dst_idx].elem_type
+      let src_elem_type = ctx.tables[src_idx].elem_type
+      if not(is_type_subtype(src_elem_type, dst_elem_type)) {
+        raise TypeMismatch(
+          "table.copy: source element type \{src_elem_type} is not subtype of destination element type \{dst_elem_type}",
+        )
+      }
       stack.pop(@types.ValueType::I32) // n
       stack.pop(@types.ValueType::I32) // s
       stack.pop(@types.ValueType::I32) // d
@@ -2000,7 +2022,10 @@ fn validate_instr(
       stack.pop(@types.ValueType::I32) // s
       stack.pop(@types.ValueType::I32) // d
     }
-    ElemDrop(_) => ()
+    ElemDrop(elem_idx) =>
+      if elem_idx >= ctx.elems.length() {
+        raise InvalidElemIndex(elem_idx)
+      }
 
     // Reference instructions
     RefNull(ref_type) => stack.push(ref_type)

--- a/wat/parser_instr.mbt
+++ b/wat/parser_instr.mbt
@@ -760,8 +760,10 @@ fn Parser::parse_plain_instruction(
     "memory.grow" =>
       @types.Instruction::MemoryGrow(self.parse_optional_memidx())
     "memory.init" => {
-      let memidx = self.parse_optional_memidx()
+      // WAT format: memory.init dataidx [memidx]
+      // dataidx is required, memidx is optional (defaults to 0)
       let dataidx = self.parse_data_idx()
+      let memidx = self.parse_optional_memidx()
       @types.Instruction::MemoryInit(memidx, dataidx)
     }
     "memory.copy" => {


### PR DESCRIPTION
## Summary

- Fix `memory.init` parser to parse dataidx before optional memidx (WAT spec compliance)
- Add `InvalidDataIndex` validation error for `data.drop` and `memory.init`
- Add `ElemDrop` validation to check elem segment exists
- Fix `table.copy` validation to check element type compatibility between tables
- Use 64-bit unsigned arithmetic in `memory.copy`/`fill`/`init` bounds checks to prevent wraparound with large length values

## Test plan

- [x] All 8 bulk-memory spec tests pass (7183 total assertions):
  - bulk.wast: 66 passed
  - memory_copy.wast: 4402 passed
  - memory_fill.wast: 84 passed
  - memory_init.wast: 207 passed
  - table_copy.wast: 1649 passed
  - table_fill.wast: 44 passed
  - table_init.wast: 729 passed
  - table-sub.wast: 2 passed
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)