### PR TITLE
fix(wat): correctly parse memory.init with single dataidx

### DIFF
--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -2020,6 +2020,40 @@ fn Parser::parse_table_idx(self : Parser) -> Int raise WatError {
 }
 
 ///|
+/// Parse an index for memory.init instruction.
+/// This handles the ambiguity where the first index could be either memidx or dataidx.
+/// We parse it as a raw number/id and resolve based on context.
+fn Parser::parse_index_for_memory_init(self : Parser) -> Int raise WatError {
+  match self.current.token {
+    Number(s) => {
+      self.advance()
+      parse_int(s)
+    }
+    Id(name) => {
+      self.advance()
+      // Try memory names first, then data names
+      match self.memory_names.get(name) {
+        Some(idx) => idx
+        None =>
+          match self.data_names.get(name) {
+            Some(idx) => idx
+            None =>
+              raise WatError::UndefinedIdentifier(
+                "memory or data $\{name}",
+                self.loc(),
+              )
+          }
+      }
+    }
+    _ =>
+      raise WatError::UnexpectedToken(
+        "expected memory or data index",
+        self.loc(),
+      )
+  }
+}
+
+///|
 fn Parser::parse_data_idx(self : Parser) -> Int raise WatError {
   match self.current.token {
     Number(s) => {

--- a/wat/parser_instr.mbt
+++ b/wat/parser_instr.mbt
@@ -760,11 +760,23 @@ fn Parser::parse_plain_instruction(
     "memory.grow" =>
       @types.Instruction::MemoryGrow(self.parse_optional_memidx())
     "memory.init" => {
-      // Multi-memory format: memory.init memidx dataidx
-      // memidx is optional (defaults to 0), dataidx is required
-      let memidx = self.parse_optional_memidx()
-      let dataidx = self.parse_data_idx()
-      @types.Instruction::MemoryInit(memidx, dataidx)
+      // memory.init can have one or two indices:
+      // - memory.init dataidx (memidx defaults to 0)
+      // - memory.init memidx dataidx
+      // We need to look ahead to determine which format
+      let first_idx = self.parse_index_for_memory_init()
+      // Check if there's another index
+      match self.current.token {
+        Number(_) | Id(_) => {
+          // Two indices: first is memidx, second is dataidx
+          let memidx = first_idx
+          let dataidx = self.parse_data_idx()
+          @types.Instruction::MemoryInit(memidx, dataidx)
+        }
+        _ =>
+          // One index: it's dataidx, memidx defaults to 0
+          @types.Instruction::MemoryInit(0, first_idx)
+      }
     }
     "memory.copy" => {
       let dst = self.parse_optional_memidx()


### PR DESCRIPTION
## Summary

- Fix parsing of `memory.init` instruction to correctly handle single-index format
- Previously `memory.init 0` (where 0 is dataidx) failed with "expected data segment index" error
- Now correctly distinguishes between `memory.init dataidx` and `memory.init memidx dataidx`

## Problem

The `memory.init` instruction has two valid formats:
- Single-index: `memory.init dataidx` (memidx defaults to 0)
- Two-index: `memory.init memidx dataidx`

The previous code used `parse_optional_memidx()` which consumed the first number as a memory index, causing `parse_data_idx()` to fail when only a data index was provided.

## Solution

Parse the first index, then check if there's a second index to determine which format is being used.

## Test plan
- [x] `moon check` passes
- [x] All 8 bulk-memory tests pass (7183 tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)