### PR TITLE
fix(testsuite): update run_jit to use multi-memory API

### DIFF
--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -258,13 +258,18 @@ pub fn run_jit(
       return Err("Failed to create JIT module")
     }
 
-    // Allocate memory
-    let mem_size = 65536L // 64KB
+    // Allocate memory - support multi-memory by using the array-based API
+    let mem_size = 65536L // 64KB (1 page)
     let mem_ptr = @jit.alloc_memory(mem_size)
     if mem_ptr == 0L {
       return Err("Failed to allocate memory")
     }
-    // Memory ownership transfers to context - GC finalizer will free it
+    // Set up multi-memory array (single memory at index 0)
+    let memory_ptrs = [mem_ptr]
+    let memory_sizes = [mem_size]
+    let memory_max_pages : Array[Int?] = [None] // No max limit
+    jm.set_memory_pointers(memory_ptrs, memory_sizes, memory_max_pages)
+    // Also set fast path for memory 0 (backward compatibility)
     jm.set_memory(mem_ptr, mem_size)
 
     // Initialize indirect table for call_indirect support


### PR DESCRIPTION
## Summary

- Update `testsuite/compare.mbt` to call `set_memory_pointers` in addition to `set_memory`
- This matches the pattern used in `main/run.mbt` for proper multi-memory support

## Problem

After the multi-memory support was added in PR #241, `testsuite/compare.mbt`'s `run_jit` function was not updated to use the new multi-memory API. This could cause issues with v4 memory operations accessing uninitialized memory arrays.

## Solution

Add `set_memory_pointers` call before `set_memory` to properly initialize the multi-memory arrays in the JIT context.

## Test plan
- [x] `moon check` passes
- [x] All 256 testsuite tests pass
- [x] `moon test -p testsuite -f exceptions_test.mbt` passes (17 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)