### PR TITLE
refactor: move reference encoding constants to types package

### DIFF
--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -1333,15 +1333,15 @@ fn Translator::translate_instruction(
 
     // Reference types
     RefNull(_ref_type) => {
-      // Null reference is represented as 0
+      // Null reference is represented as NULL_REF
       // (GC refs are encoded as (gc_ref << 1) where gc_ref is 1-based, so 0 is safe for null)
-      let result = self.builder.iconst(Type::I64, 0L)
+      let result = self.builder.iconst(Type::I64, @types.NULL_REF)
       self.push(result)
     }
     RefIsNull => {
-      // Check if reference is null (compare with 0)
+      // Check if reference is null (compare with NULL_REF)
       let ref_val = self.pop()
-      let null_sentinel = self.builder.iconst(Type::I64, 0L)
+      let null_sentinel = self.builder.iconst(Type::I64, @types.NULL_REF)
       let result = self.builder.icmp_eq(ref_val, null_sentinel)
       self.push(result)
     }
@@ -1355,7 +1355,7 @@ fn Translator::translate_instruction(
       // ref.as_non_null: convert nullable ref to non-null ref
       // Pop the reference, check if null, trap if so, otherwise push back
       let ref_val = self.pop()
-      let null_sentinel = self.builder.iconst(Type::I64, 0L)
+      let null_sentinel = self.builder.iconst(Type::I64, @types.NULL_REF)
       let is_null = self.builder.icmp_eq(ref_val, null_sentinel)
 
       // Create trap block and continuation block
@@ -3516,8 +3516,8 @@ fn Translator::translate_br_on_null(self : Translator, depth : Int) -> Unit {
   let ref_val = self.pop()
   let idx = self.block_stack.length() - 1 - depth
 
-  // Check if reference is null (GC refs use 0 for null)
-  let null_sentinel = self.builder.iconst(Type::I64, 0L)
+  // Check if reference is null (GC refs use NULL_REF for null)
+  let null_sentinel = self.builder.iconst(Type::I64, @types.NULL_REF)
   let is_null = self.builder.icmp_eq(ref_val, null_sentinel)
 
   // For br_on_null, we need a fallthrough block and a taken block (critical edge split)
@@ -3580,8 +3580,8 @@ fn Translator::translate_br_on_non_null(self : Translator, depth : Int) -> Unit 
   let ref_val = self.pop()
   let idx = self.block_stack.length() - 1 - depth
 
-  // Check if reference is null (GC refs use 0 for null)
-  let null_sentinel = self.builder.iconst(Type::I64, 0L)
+  // Check if reference is null (GC refs use NULL_REF for null)
+  let null_sentinel = self.builder.iconst(Type::I64, @types.NULL_REF)
   let is_null = self.builder.icmp_eq(ref_val, null_sentinel)
 
   // For br_on_non_null, we need a fallthrough block and a taken block
@@ -3996,8 +3996,11 @@ fn Translator::translate_call_ref(self : Translator, type_idx : Int) -> Unit {
     // Pop the function reference (which is a function index stored as I64)
     let func_ref = self.pop()
 
-    // Null check: if func_ref == -1, trap
-    let null_sentinel = self.builder.iconst(Type::I64, -1L)
+    // Null check: if func_ref == FUNCREF_NULL_SENTINEL, trap
+    let null_sentinel = self.builder.iconst(
+      Type::I64,
+      @types.FUNCREF_NULL_SENTINEL,
+    )
     let is_null = self.builder.icmp_eq(func_ref, null_sentinel)
 
     // Create trap block and continuation block
@@ -4113,8 +4116,11 @@ fn Translator::translate_return_call_ref(
     // Pop the function reference (which is a function index stored as I64)
     let func_ref = self.pop()
 
-    // Null check: if func_ref == -1, trap
-    let null_sentinel = self.builder.iconst(Type::I64, -1L)
+    // Null check: if func_ref == FUNCREF_NULL_SENTINEL, trap
+    let null_sentinel = self.builder.iconst(
+      Type::I64,
+      @types.FUNCREF_NULL_SENTINEL,
+    )
     let is_null = self.builder.icmp_eq(func_ref, null_sentinel)
 
     // Create trap block and continuation block

--- a/jit/c_heap.mbt
+++ b/jit/c_heap.mbt
@@ -89,7 +89,7 @@ pub fn value_to_i64(value : @types.Value) -> Int64 {
     ExternRef(idx) => (idx + 1).to_int64()
     ExnRef(idx) => (idx + 1).to_int64()
     I31(n) => (n.to_int64() << 1) | 1L
-    Null => 0L
+    Null => @types.NULL_REF
   }
 }
 
@@ -102,46 +102,46 @@ pub fn i64_to_value(raw : Int64, ty : @types.ValueType) -> @types.Value {
     F32 => @types.Value::F32(Float::reinterpret_from_int(raw.to_int()))
     F64 => @types.Value::F64(raw.reinterpret_as_double())
     RefStruct(_) | RefNullStruct(_) =>
-      if raw == 0L {
+      if raw == @types.NULL_REF {
         @types.Value::Null
       } else {
         // Decode: gc_ref = raw >> 1, idx = gc_ref - 1
         @types.Value::StructRef(((raw >> 1) - 1L).to_int())
       }
     RefArray(_) | RefNullArray(_) =>
-      if raw == 0L {
+      if raw == @types.NULL_REF {
         @types.Value::Null
       } else {
         // Decode: gc_ref = raw >> 1, idx = gc_ref - 1
         @types.Value::ArrayRef(((raw >> 1) - 1L).to_int())
       }
     FuncRef | RefFunc | RefFuncTyped(_) | RefNullFuncTyped(_) =>
-      if raw == 0L {
+      if raw == @types.NULL_REF {
         @types.Value::Null
       } else {
         @types.Value::FuncRef((raw - 1L).to_int())
       }
     ExternRef | RefExtern =>
-      if raw == 0L {
+      if raw == @types.NULL_REF {
         @types.Value::Null
       } else {
         @types.Value::ExternRef((raw - 1L).to_int())
       }
     ExnRef =>
-      if raw == 0L {
+      if raw == @types.NULL_REF {
         @types.Value::Null
       } else {
         @types.Value::ExnRef((raw - 1L).to_int())
       }
     RefI31 | RefNullI31 =>
-      if raw == 0L {
+      if raw == @types.NULL_REF {
         @types.Value::Null
       } else {
         @types.Value::I31((raw >> 1).to_int())
       }
     RefEq | RefNullEq | AnyRef | RefAny =>
       // For abstract types, we need to decode based on the actual value
-      if raw == 0L {
+      if raw == @types.NULL_REF {
         @types.Value::Null
       } else if (raw & 1L) != 0L {
         // Tagged i31 (odd)

--- a/jit/gc_helpers.mbt
+++ b/jit/gc_helpers.mbt
@@ -46,7 +46,7 @@ pub fn is_i31(value : Int64) -> Bool {
 ///|
 /// Check if a JIT value is null
 pub fn is_null(value : Int64) -> Bool {
-  value == 0L
+  value == @types.NULL_REF
 }
 
 ///|

--- a/jit/jit_runtime.mbt
+++ b/jit/jit_runtime.mbt
@@ -437,8 +437,8 @@ pub fn JITModule::init_shared_tables(
     // Get function pointer and encode as funcref
     // func_idx = -1 represents ref.null (null reference sentinel)
     let funcref_value = if func_idx == -1 {
-      0L // Use 0 for null reference (matches new encoding)
-    } else {
+      @types.NULL_REF
+    } else { // Use NULL_REF for null reference
       // Tag function pointer with FUNCREF_TAG (bit 61) for ref.test detection
       // FUNCREF_TAG = 0x2000000000000000
       self.get_func_ptr(func_idx) | 0x2000000000000000L

--- a/main/run.mbt
+++ b/main/run.mbt
@@ -525,8 +525,8 @@ fn init_jit_globals(
         // Get function pointer from JIT module and tag it
         let func_ptr = jit_module.get_func_ptr(func_idx)
         if func_ptr == 0L {
-          0L // null funcref
-        } else {
+          @types.NULL_REF
+        } else { // null funcref
           func_ptr | funcref_tag // Tagged function pointer
         }
       }
@@ -535,7 +535,7 @@ fn init_jit_globals(
       ArrayRef(gc_ref) => @jit.encode_heap_ref(gc_ref)
       StructRef(gc_ref) => @jit.encode_heap_ref(gc_ref)
       I31(n) => @jit.encode_i31(n)
-      Null => 0L // null is encoded as 0 in JIT
+      Null => @types.NULL_REF // null is encoded as 0 in JIT
       V128(bytes) => {
         // V128 needs special handling - write both 64-bit halves
         let offset = globals_ptr + (i * 16).to_int64()
@@ -627,7 +627,7 @@ fn run_with_jit(
                   ArrayRef(idx) => idx.to_int64()
                   StructRef(idx) => idx.to_int64()
                   I31(n) => n.to_int64()
-                  Null => -1L // Sentinel value for null reference
+                  Null => @types.FUNCREF_NULL_SENTINEL // Sentinel value for null reference
                   V128(_) => abort("V128 args not yet supported in JIT")
                 }
                 i64_args.push(v)
@@ -679,13 +679,13 @@ fn run_with_jit(
                     | RefFuncTyped(_)
                     | RefNullFuncTyped(_)
                     | NullFuncRef =>
-                      if r == -1L {
+                      if r == @types.FUNCREF_NULL_SENTINEL {
                         @types.Value::Null
                       } else {
                         @types.Value::FuncRef(r.to_int())
                       }
                     ExternRef | RefExtern | NullExternRef =>
-                      if r == -1L {
+                      if r == @types.FUNCREF_NULL_SENTINEL {
                         @types.Value::Null
                       } else {
                         @types.Value::ExternRef(r.to_int())

--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -50,11 +50,11 @@ pub fn jit_results_to_values(
         slot_idx += 1
         F64(@types.FromInt64::from_int64_bits(raw))
       }
-      // Reference types: -1L is null sentinel
+      // Reference types: FUNCREF_NULL_SENTINEL is null sentinel
       FuncRef | RefFunc | RefFuncTyped(_) | RefNullFuncTyped(_) | NullFuncRef => {
         let raw = results[slot_idx]
         slot_idx += 1
-        if raw == -1L {
+        if raw == @types.FUNCREF_NULL_SENTINEL {
           Null
         } else {
           FuncRef(raw.to_int())
@@ -63,7 +63,7 @@ pub fn jit_results_to_values(
       ExternRef | RefExtern | NullExternRef => {
         let raw = results[slot_idx]
         slot_idx += 1
-        if raw == -1L {
+        if raw == @types.FUNCREF_NULL_SENTINEL {
           Null
         } else {
           ExternRef(raw.to_int())
@@ -132,7 +132,7 @@ pub fn value_to_jit_arg(value : @types.Value) -> Int64 {
     ArrayRef(idx) => idx.to_int64()
     StructRef(idx) => idx.to_int64()
     I31(n) => n.to_int64()
-    Null => -1L // null sentinel
+    Null => @types.FUNCREF_NULL_SENTINEL // null sentinel
     V128(_) => abort("V128 not yet supported in testsuite")
   }
 }

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -2,6 +2,14 @@
 package "Milky2018/wasmoon/types"
 
 // Values
+pub const EXTERNREF_TAG : Int64 = 0x4000000000000000
+
+pub const FUNCREF_NULL_SENTINEL : Int64 = -1
+
+pub const FUNCREF_TAG : Int64 = 0x2000000000000000
+
+pub const NULL_REF : Int64 = 0
+
 pub fn compute_canonical_type_indices(Array[SubType], type_rec_groups? : Array[Int]) -> Array[Int]
 
 pub fn extract_func_types(Array[SubType]) -> Array[FuncType]

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -2,6 +2,28 @@
 // Core data structures and type definitions
 
 // ============================================================
+// Reference Encoding Constants
+// ============================================================
+// These constants define how references are encoded in JIT mode.
+// They must match the encoding in jit/jit_ffi/jit.c
+
+///|
+/// Null reference value for GC types and externref (used in JIT)
+pub const NULL_REF : Int64 = 0L
+
+///|
+/// Null reference sentinel for funcref in interpreter mode
+pub const FUNCREF_NULL_SENTINEL : Int64 = -1L
+
+///|
+/// Tag for externref values: bit 62 set
+pub const EXTERNREF_TAG : Int64 = 0x4000000000000000L
+
+///|
+/// Tag for funcref pointer values: bit 61 set
+pub const FUNCREF_TAG : Int64 = 0x2000000000000000L
+
+// ============================================================
 // Value Types
 // ============================================================
 

--- a/wast/jit_support.mbt
+++ b/wast/jit_support.mbt
@@ -142,7 +142,7 @@ pub fn sync_jit_globals_to_store(
         | RefFuncTyped(_)
         | RefNullFuncTyped(_)
         | NullFuncRef =>
-          if raw_value == -1L {
+          if raw_value == FUNCREF_NULL_SENTINEL {
             @types.Value::Null
           } else {
             // Convert module function index back to store address
@@ -155,7 +155,7 @@ pub fn sync_jit_globals_to_store(
             }
           }
         ExternRef | RefExtern | NullExternRef =>
-          if raw_value == -1L {
+          if raw_value == FUNCREF_NULL_SENTINEL {
             @types.Value::Null
           } else {
             @types.Value::ExternRef(raw_value.to_int())

--- a/wast/runner.mbt
+++ b/wast/runner.mbt
@@ -1,23 +1,18 @@
 // WAST Runner - Execute WAST test scripts
 
-// Reference encoding constants for JIT
-// These must match the encoding in jit/jit_ffi/jit.c
+// Reference encoding constants - re-exported from @types for convenience
 
 ///|
-/// Null reference value for GC types and externref (used in JIT)
-pub const NULL_REF : Int64 = 0L
+pub const NULL_REF : Int64 = @types.NULL_REF
 
 ///|
-/// Null reference sentinel for funcref in interpreter mode
-pub const FUNCREF_NULL_SENTINEL : Int64 = -1L
+pub const FUNCREF_NULL_SENTINEL : Int64 = @types.FUNCREF_NULL_SENTINEL
 
 ///|
-/// Tag for externref values: bit 62 set
-pub const EXTERNREF_TAG : Int64 = 0x4000000000000000L
+pub const EXTERNREF_TAG : Int64 = @types.EXTERNREF_TAG
 
 ///|
-/// Tag for funcref pointer values: bit 61 set
-pub const FUNCREF_TAG : Int64 = 0x2000000000000000L
+pub const FUNCREF_TAG : Int64 = @types.FUNCREF_TAG
 
 ///|
 /// Convert 8 bytes from Bytes at given offset to Int64 (little-endian)


### PR DESCRIPTION
## Summary
- Move `NULL_REF`, `FUNCREF_NULL_SENTINEL`, `EXTERNREF_TAG`, and `FUNCREF_TAG` constants from `wast/runner.mbt` to `types/types.mbt`
- Replace hardcoded `0L` with `@types.NULL_REF` for null reference encoding
- Replace hardcoded `-1L` with `@types.FUNCREF_NULL_SENTINEL` for funcref null sentinel
- Re-export constants from `wast/runner.mbt` for backward compatibility

## Motivation
The reference encoding constants were defined in `wast/runner.mbt`, but they are used across many packages (`ir`, `jit`, `main`, `testsuite`). Moving them to the foundational `types` package:
- Avoids awkward dependencies on the high-level `wast` package
- Makes the constants more discoverable
- Improves code clarity by using named constants instead of magic numbers

## Test plan
- [x] All existing tests pass
- [x] ref_null.wast: 32/32 pass
- [x] ref_func.wast: 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)