### PR TITLE
refactor: remove Cranelift references from codebase

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,9 +93,9 @@ The IR uses Static Single Assignment form for easier optimization:
 - Phi nodes handle control flow merges
 - Enables standard optimizations (DCE, CSE, constant propagation)
 
-### Cranelift-style VCode
+### VCode (Virtual Code)
 
-VCode is a low-level IR similar to Cranelift's VCode:
+VCode is a low-level IR designed for efficient code generation:
 - Virtual registers (infinite)
 - Platform-specific instructions
 - Linear scan register allocation

--- a/docs/jit-abi.md
+++ b/docs/jit-abi.md
@@ -4,7 +4,7 @@ This document describes the calling convention and ABI used by wasmoon's JIT com
 
 ## Calling Convention
 
-Wasmoon uses a Cranelift-style calling convention optimized for WebAssembly execution.
+Wasmoon uses a custom calling convention optimized for WebAssembly execution.
 
 ### Register Usage
 

--- a/ir/builder.mbt
+++ b/ir/builder.mbt
@@ -1,5 +1,5 @@
 // IR Builder - Convenient API for constructing IR
-// Similar to Cranelift's FunctionBuilder
+// SSA function builder
 
 ///|
 /// IRBuilder - helps construct IR functions
@@ -443,21 +443,21 @@ pub fn IRBuilder::uextend(self : IRBuilder, ty : Type, a : Value) -> Value {
 
 ///|
 /// Sign extend from 8 bits (in-place, keeps the same type)
-/// Like Cranelift's ireduce(I8) + sextend(ty)
+/// Similar to ireduce(I8) + sextend(ty)
 pub fn IRBuilder::sextend8(self : IRBuilder, ty : Type, a : Value) -> Value {
   self.emit_inst(ty, Opcode::Sextend8, [a])
 }
 
 ///|
 /// Sign extend from 16 bits (in-place, keeps the same type)
-/// Like Cranelift's ireduce(I16) + sextend(ty)
+/// Similar to ireduce(I16) + sextend(ty)
 pub fn IRBuilder::sextend16(self : IRBuilder, ty : Type, a : Value) -> Value {
   self.emit_inst(ty, Opcode::Sextend16, [a])
 }
 
 ///|
 /// Sign extend from 32 bits to 64 bits
-/// Like Cranelift's ireduce(I32) + sextend(I64)
+/// Similar to ireduce(I32) + sextend(I64)
 pub fn IRBuilder::sextend32(self : IRBuilder, a : Value) -> Value {
   self.emit_inst(Type::I64, Opcode::Sextend32, [a])
 }
@@ -945,7 +945,7 @@ pub fn IRBuilder::store_ptr_narrow(
 /// Call via function pointer with multiple return values
 /// For trampolines calling WASM functions
 ///
-/// Following Cranelift's design: callee_vmctx and caller_vmctx are explicit
+/// Design: callee_vmctx and caller_vmctx are explicit
 /// arguments, allowing the register allocator to properly handle values that
 /// need to survive across the call (like values_vec in trampolines).
 ///

--- a/ir/func_env.mbt
+++ b/ir/func_env.mbt
@@ -1,6 +1,6 @@
 // FuncEnvironment - handles Wasm semantic operations by desugaring to IR primitives
 //
-// This module implements Cranelift-style desugaring where high-level Wasm operations
+// This module implements Standard desugaring where high-level Wasm operations
 // (global.get, table.get, etc.) are translated to lower-level IR primitives
 // (LoadPtr, StorePtr, CallPtr) during IR translation, not during lowering.
 //

--- a/ir/ir.mbt
+++ b/ir/ir.mbt
@@ -1,5 +1,5 @@
 // Intermediate Representation (IR) for WebAssembly
-// Based on SSA (Static Single Assignment) form, similar to Cranelift's CLIF
+// Based on SSA (Static Single Assignment) form
 
 ///|
 /// IR Value - represents a virtual register in SSA form
@@ -206,7 +206,7 @@ pub enum Opcode {
   UintToFcvt // Unsigned int to float
   Bitcast // Reinterpret bits
 
-  // In-place sign extension (like Cranelift's ireduce + sextend)
+  // In-place sign extension 
   // These sign-extend the low N bits to fill the full register
   Sextend8 // Sign extend from 8 bits (i32 or i64)
   Sextend16 // Sign extend from 16 bits (i32 or i64)
@@ -241,7 +241,7 @@ pub enum Opcode {
   GetFuncRef(Int) // Get function reference (function index) - returns tagged func_ptr
 
   // Raw pointer operations (for trampolines, no bounds checking)
-  // These follow Cranelift's approach for host code generation
+  // Used for host code generation
   LoadPtr(Type) // Load from pointer+offset (operand 0 = base ptr)
   StorePtr(Type) // Store to pointer+offset (operand 0 = base ptr, operand 1 = value)
   // Narrow load/store from raw pointer (result_type, bits, signed)

--- a/ir/printer.mbt
+++ b/ir/printer.mbt
@@ -1,5 +1,5 @@
 // IR Printer - Pretty prints IR in a readable text format
-// Similar to Cranelift's textual IR format
+// Textual IR format for debugging
 
 ///|
 /// Print a type

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -96,7 +96,7 @@ pub fn Translator::new(
   tags? : Array[@types.TagType] = [],
 ) -> Translator {
   let builder = IRBuilder::new(name)
-  // Following Cranelift: add vmctx as explicit params
+  // Note: add vmctx as explicit params
   // - params[0] = callee_vmctx (X0)
   // - params[1] = caller_vmctx (X1)
   // These are referenced for desugaring global/table/memory operations
@@ -814,7 +814,7 @@ fn Translator::translate_instruction(
       let result = self.builder.uextend(Type::I64, a)
       self.push(result)
     }
-    // In-place sign extension instructions (like Cranelift's ireduce + sextend)
+    // In-place sign extension instructions 
     I32Extend8S => {
       let a = self.pop()
       let result = self.builder.sextend8(Type::I32, a)
@@ -3227,7 +3227,7 @@ fn Translator::translate_loop(
 ///|
 /// Translate an if-else construct
 ///
-/// Following Cranelift's approach:
+/// On-demand loading:
 /// - Support block params (multi-value extension)
 /// - Pass params to both then and else blocks
 /// - Pass all mutable locals through continuation for SSA phi nodes
@@ -3250,7 +3250,7 @@ fn Translator::translate_if(
     self.pop()
   }
 
-  // Pop param values from stack (following Cranelift: params are below condition)
+  // Pop param values from stack (Note: params are below condition)
   let param_values : Array[Value] = []
   if !outer_is_unreachable {
     for _ in 0..<param_types.length() {
@@ -3280,7 +3280,7 @@ fn Translator::translate_if(
   }
 
   // Branch with param values (only if not unreachable)
-  // Following Cranelift: pass params to both then and else blocks
+  // Note: pass params to both then and else blocks
   if !outer_is_unreachable {
     if param_values.is_empty() {
       // No params, use simple branch
@@ -4069,7 +4069,7 @@ fn Translator::translate_return_call(self : Translator, func_idx : Int) -> Unit 
     // Remap function index for cross-module calls
     let global_func_idx = self.remap_func_idx(func_idx)
     // Emit return_call instruction (tail call - does not return to caller)
-    // Following Cranelift: emit a single ReturnCall IR instruction, not call + return
+    // Note: emit a single ReturnCall IR instruction, not call + return
     self.builder.return_call_multi(global_func_idx, args)
     // Mark as unreachable since this is a terminator (does not return to this function)
     self.is_unreachable = true
@@ -4098,7 +4098,7 @@ fn Translator::translate_return_call_indirect(
     args.rev_in_place()
 
     // Emit return_call_indirect instruction (tail call - does not return to caller)
-    // Following Cranelift: emit a single ReturnCallIndirect IR instruction, not call + return
+    // Note: emit a single ReturnCallIndirect IR instruction, not call + return
     self.builder.return_call_indirect_multi(type_idx, table_idx, elem_idx, args)
     // Mark as unreachable since this is a terminator (does not return to this function)
     self.is_unreachable = true
@@ -4145,7 +4145,7 @@ fn Translator::translate_return_call_ref(
     args.rev_in_place()
 
     // Emit return_call_ref instruction (tail call - does not return to caller)
-    // Following Cranelift: emit a single ReturnCallRef IR instruction, not call + return
+    // Note: emit a single ReturnCallRef IR instruction, not call + return
     self.builder.return_call_ref_multi(type_idx, func_ref, args)
     // Mark as unreachable since this is a terminator (does not return to this function)
     self.is_unreachable = true

--- a/jit/ffi_jit.mbt
+++ b/jit/ffi_jit.mbt
@@ -44,7 +44,7 @@ pub fn check_trap() -> Unit raise JITTrap {
 
 ///|
 /// JIT execution context (v3 ABI) - GC managed
-/// Uses Cranelift-style on-demand loading from vmctx:
+/// Uses Standard on-demand loading from vmctx:
 /// +0: memory_base, +8: memory_size, +16: func_table, +24: table0_base
 /// Only X19 caches vmctx; all other values are loaded on-demand.
 /// Memory is automatically freed when the object is garbage collected
@@ -467,7 +467,7 @@ pub fn ExecCode::ptr(self : ExecCode) -> Int64 {
 
 ///|
 /// Call a JIT function with multiple return values (v3 ABI)
-/// Uses JIT-generated trampolines following Cranelift's approach.
+/// Uses JIT-generated trampolines on-demand.
 /// X19 = ctx_ptr (vmctx), all other values loaded on-demand from vmctx.
 /// Returns 0 on success, trap code on error
 fn JITContext::call_multi_return(
@@ -547,7 +547,7 @@ fn JITContext::call_multi_return(
     values_vec[i] = args[i]
   }
 
-  // Call via trampoline (Cranelift-style: all ABI complexity in JIT code)
+  // Call via trampoline (Standard: all ABI complexity in JIT code)
   // Use stack-switching call if a WASM stack has been allocated
   let trap_code = if self.has_wasm_stack() {
     @jit_ffi.c_jit_call_with_stack_switch_managed(

--- a/jit/jit_ffi/jit_ffi.h
+++ b/jit/jit_ffi/jit_ffi.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-// ============ JIT Context v3 (Cranelift-style ABI) ============
+// ============ JIT Context v3 ============
 // New ABI passes vmctx via X0 (callee_vmctx) and X1 (caller_vmctx)
 // User integer params in X2-X7 (up to 6 in registers)
 // Float params in V0-V7 (S for f32, D for f64)

--- a/vcode/abi/abi.mbt
+++ b/vcode/abi/abi.mbt
@@ -1,7 +1,7 @@
 // ABI Constants and Definitions
 // Centralized definition of JIT calling convention
 //
-// Wasmoon JIT ABI v3 (Cranelift-style):
+// Wasmoon JIT ABI v3 (Standard):
 // - X0: callee_vmctx (callee's VMContext)
 // - X1: caller_vmctx (caller's VMContext)
 // - X2-X7: User integer parameters (up to 6 in registers)

--- a/vcode/abi/reg.mbt
+++ b/vcode/abi/reg.mbt
@@ -44,7 +44,7 @@ pub impl Show for Reg with output(self, logger) {
 
 ///|
 /// Operand constraint for register allocation
-/// Following Cranelift's design for fixed register constraints
+/// Fixed register constraint handling
 pub(all) enum OperandConstraint {
   Any // Any register is acceptable
   FixedReg(PReg) // Must use specific physical register

--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -41,7 +41,7 @@ fn collect_used_callee_saved(
   for block in func.get_blocks() {
     for inst in block.insts {
       // Check if this instruction is a function call
-      // Following Cranelift's design: use call_type() to determine if an instruction
+      // Design: use call_type() to determine if an instruction
       // behaves like a call (clobbers caller-saved registers)
       if inst.opcode.call_type() is @instr.Regular {
         has_calls = true
@@ -56,7 +56,7 @@ fn collect_used_callee_saved(
     }
   }
   // If the function makes any calls, we must save LR (X30)
-  // Note: X20-X24 are no longer pre-loaded in prologue (following Cranelift's approach)
+  // Note: X20-X24 are no longer pre-loaded in prologue (on-demand)
   // They are loaded on-demand from vmctx and only need saving if used by regalloc
   if has_calls {
     used.add(30) // LR
@@ -128,7 +128,7 @@ fn collect_used_callee_saved_fprs(func : @lower.VCodeFunction) -> Array[Int] {
 /// - X1 = caller_vmctx (unused in current impl)
 /// - X2-X7 = user integer params (up to 6)
 /// - V0-V7 = user float params (S for f32, D for f64)
-/// Emit stack pointer adjustment for arbitrary sizes (Cranelift-style)
+/// Emit stack pointer adjustment for arbitrary sizes (Standard)
 ///
 /// Handles any size by using:
 /// - ADD/SUB with imm12 for values <= 4095
@@ -170,7 +170,7 @@ fn MachineCode::emit_prologue(
   let saved_gprs = stack_frame.saved_gprs
   let saved_fprs = stack_frame.saved_fprs
 
-  // Cranelift-style prologue:
+  // Standard prologue:
   // 1. Save FP/LR with fixed -16 pre-indexed (avoids SImm7 overflow)
   // 2. Save clobbered GPRs with -16 pre-indexed pushes
   // 3. Save clobbered FPRs with -16 pre-indexed pushes
@@ -184,8 +184,8 @@ fn MachineCode::emit_prologue(
     self.emit_mov_reg(29, 31)
   }
 
-  // Step 2: Save callee-saved GPRs with pre-indexed pushes (Cranelift style)
-  // Cranelift approach: handle remainder first, then reverse iterate pairs
+  // Step 2: Save callee-saved GPRs with pre-indexed pushes (Standard style)
+  // Approach: handle remainder first, then reverse iterate pairs
   // This ensures save/restore order matches perfectly
   let num_gprs = saved_gprs.length()
   if num_gprs > 0 {
@@ -208,8 +208,8 @@ fn MachineCode::emit_prologue(
     }
   }
 
-  // Step 3: Save callee-saved FPRs with pre-indexed pushes (Cranelift style)
-  // Cranelift approach: handle remainder first, then reverse iterate pairs
+  // Step 3: Save callee-saved FPRs with pre-indexed pushes (Standard style)
+  // Approach: handle remainder first, then reverse iterate pairs
   let num_fprs = saved_fprs.length()
   if num_fprs > 0 {
     // Handle remainder first (if odd number of registers)
@@ -238,14 +238,14 @@ fn MachineCode::emit_prologue(
     self.emit_sp_adjust(-remaining_size)
   }
 
-  // Step 5: Cache vmctx to X19 (the only pinned register, like Cranelift's X21)
-  // Following Cranelift: vmctx is params[0], passed in X0
+  // Step 5: Cache vmctx to X19 (the only pinned register)
+  // Note: vmctx is params[0], passed in X0
   // All other values (memory_base, memory_size, func_table, table0_base) are
-  // loaded on-demand from vmctx, following Cranelift's approach.
+  // loaded on-demand from vmctx, on-demand.
   self.emit_mov_reg(19, 0)
 
   // Step 6: Move arguments from ABI registers to allocated registers
-  // Following Cranelift: all params use X0-X7 (int) or V0-V7 (float)
+  // Note: all params use X0-X7 (int) or V0-V7 (float)
   // vmctx is params[0] and comes in X0, already cached to X19 above
   let max_int_params = @abi.MAX_REG_PARAMS // 8
   let max_float_params = @abi.MAX_FLOAT_REG_PARAMS // 8
@@ -1004,7 +1004,7 @@ fn MachineCode::emit_instruction(
     TrapIfDivOverflow(is_64, trap_code) => {
       // Trap if signed division would overflow (INT_MIN / -1)
       // Uses: [lhs, rhs]
-      // Following Cranelift's approach (no scratch registers needed):
+      // On-demand loading (no scratch registers needed):
       //   ADDS XZR, rhs, #1      ; Check rhs == -1 (sets Z if rhs == -1)
       //   CCMP lhs, #1, #0, Eq   ; If Z set, do CMP lhs-1 (sets V if overflow), else NZCV=0
       //   B.VC +8                ; Skip BRK if V clear
@@ -1129,7 +1129,7 @@ fn MachineCode::emit_instruction(
       self.emit_mneg(rd, rn, rm)
     }
     ReturnCallIndirect(_num_args, _num_results) => {
-      // Tail call optimization following Cranelift's design
+      // Tail call optimization
       // Parameters are already set up by lowering phase via:
       // - StoreToStack for overflow arguments
       // - add_use_fixed constraints for register arguments (X17=func_ptr, X0/X1=vmctx, X2-X7/V0-V7=args)
@@ -1138,7 +1138,7 @@ fn MachineCode::emit_instruction(
       // 2. BR to function pointer (doesn't save return address, callee returns to our caller)
 
       // Epilogue - restore callee-saved registers and frame pointer
-      // Following Cranelift's emit_return_call_common_sequence
+      // Tail call common sequence
       self.emit_epilogue(stack_frame)
 
       // BR (not BLR) - jump to function without saving return address
@@ -1204,7 +1204,7 @@ fn MachineCode::emit_instruction(
       }
     }
     LoadStackParam(param_idx, class, int_overflow_count) => {
-      // Load stack parameter from stack (Cranelift-style layout)
+      // Load stack parameter from stack (Standard layout)
       //
       // Stack layout from callee's perspective:
       // ┌───────────────────────────┐
@@ -1347,7 +1347,7 @@ fn MachineCode::emit_instruction(
       self.emit_load_imm64(result_reg, func_ptr)
     }
     CallPtr(_, _, _call_conv) =>
-      // Cranelift-style call: all arguments are already in place
+      // Standard call: all arguments are already in place
       //
       // The lower phase generates:
       // - AdjustSP to allocate stack space for overflow args
@@ -1374,7 +1374,7 @@ fn MachineCode::emit_instruction(
       self.emit_blr(17)
     AdjustSP(delta) =>
       // Adjust stack pointer by delta bytes
-      // Used in Cranelift-style call lowering for outgoing args
+      // Used in Standard call lowering for outgoing args
       if delta > 0 {
         self.emit_add_imm(31, 31, delta)
       } else if delta < 0 {
@@ -1383,7 +1383,7 @@ fn MachineCode::emit_instruction(
     // delta == 0: nop
     StoreToStack(offset) => {
       // Store value to [SP + outgoing_args_offset + offset]
-      // Used in Cranelift-style call lowering for overflow args
+      // Used in Standard call lowering for overflow args
       // The outgoing args area is pre-allocated in prologue, so SP doesn't change
       let actual_offset = stack_frame.outgoing_args_offset + offset
       let src = reg_num(inst.uses[0])
@@ -2740,9 +2740,9 @@ fn fcmp_kind_to_cond(kind : @instr.FCmpKind) -> Int {
 }
 
 ///|
-/// Emit epilogue for ABI v3 (Cranelift-style)
+/// Emit epilogue for ABI v3 (Standard)
 ///
-/// Reverses the prologue operations in reverse order (Cranelift style):
+/// Reverses the prologue operations in reverse order (Standard style):
 /// 1. Deallocate remaining stack space (spill + outgoing)
 /// 2. Restore callee-saved FPRs with post-indexed pops (forward pairs, then remainder)
 /// 3. Restore callee-saved GPRs with post-indexed pops (forward pairs, then remainder)
@@ -2760,8 +2760,8 @@ fn MachineCode::emit_epilogue(
     self.emit_sp_adjust(remaining_size)
   }
 
-  // Step 2: Restore callee-saved FPRs with post-indexed pops (Cranelift style)
-  // Cranelift approach: forward iterate pairs, then handle remainder
+  // Step 2: Restore callee-saved FPRs with post-indexed pops (Standard style)
+  // Approach: forward iterate pairs, then handle remainder
   // This mirrors the prologue which does: remainder first, then reverse pairs
   let num_fprs = saved_fprs.length()
   if num_fprs > 0 {
@@ -2784,8 +2784,8 @@ fn MachineCode::emit_epilogue(
     }
   }
 
-  // Step 3: Restore callee-saved GPRs with post-indexed pops (Cranelift style)
-  // Cranelift approach: forward iterate pairs, then handle remainder
+  // Step 3: Restore callee-saved GPRs with post-indexed pops (Standard style)
+  // Approach: forward iterate pairs, then handle remainder
   let num_gprs = saved_gprs.length()
   if num_gprs > 0 {
     // Forward iterate pairs

--- a/vcode/emit/disasm_wbtest.mbt
+++ b/vcode/emit/disasm_wbtest.mbt
@@ -411,7 +411,7 @@ test "cmp_imm_truncates_large_values" {
 }
 
 ///|
-/// Test Cranelift-style pre-indexed stores for prologue
+/// Test Standard pre-indexed stores for prologue
 test "emit_str_pre - GPR pre-indexed store" {
   let mc = MachineCode::new()
   // STR X19, [SP, #-16]! - single GPR push
@@ -430,7 +430,7 @@ test "emit_str_pre - GPR pre-indexed store" {
 }
 
 ///|
-/// Test Cranelift-style pre-indexed stores for FPR pairs
+/// Test Standard pre-indexed stores for FPR pairs
 test "emit_stp_d_pre - FPR pair pre-indexed store" {
   let mc = MachineCode::new()
   // STP D8, D9, [SP, #-16]! - FPR pair push
@@ -449,7 +449,7 @@ test "emit_stp_d_pre - FPR pair pre-indexed store" {
 }
 
 ///|
-/// Test Cranelift-style pre-indexed store for single FPR
+/// Test Standard pre-indexed store for single FPR
 test "emit_str_d_pre - FPR pre-indexed store" {
   let mc = MachineCode::new()
   // STR D8, [SP, #-16]! - single FPR push
@@ -468,7 +468,7 @@ test "emit_str_d_pre - FPR pre-indexed store" {
 }
 
 ///|
-/// Test Cranelift-style post-indexed loads for epilogue
+/// Test Standard post-indexed loads for epilogue
 test "emit_ldr_post - GPR post-indexed load" {
   let mc = MachineCode::new()
   // LDR X19, [SP], #16 - single GPR pop
@@ -487,7 +487,7 @@ test "emit_ldr_post - GPR post-indexed load" {
 }
 
 ///|
-/// Test Cranelift-style post-indexed loads for FPR pairs
+/// Test Standard post-indexed loads for FPR pairs
 test "emit_ldp_d_post - FPR pair post-indexed load" {
   let mc = MachineCode::new()
   // LDP D8, D9, [SP], #16 - FPR pair pop
@@ -506,7 +506,7 @@ test "emit_ldp_d_post - FPR pair post-indexed load" {
 }
 
 ///|
-/// Test Cranelift-style post-indexed load for single FPR
+/// Test Standard post-indexed load for single FPR
 test "emit_ldr_d_post - FPR post-indexed load" {
   let mc = MachineCode::new()
   // LDR D8, [SP], #16 - single FPR pop
@@ -575,8 +575,8 @@ test "emit_stp_ldp_d_offset - FPR pairs with offset" {
 }
 
 ///|
-/// Test complete Cranelift-style prologue sequence
-test "cranelift_style_prologue_sequence" {
+/// Test complete Standard prologue sequence
+test "standard_prologue_sequence" {
   let mc = MachineCode::new()
   // Step 1: Save FP/LR with fixed -16 pre-indexed
   mc.emit_stp_pre(29, 30, 31, -16)
@@ -607,8 +607,8 @@ test "cranelift_style_prologue_sequence" {
 }
 
 ///|
-/// Test complete Cranelift-style epilogue sequence
-test "cranelift_style_epilogue_sequence" {
+/// Test complete Standard epilogue sequence
+test "standard_epilogue_sequence" {
   let mc = MachineCode::new()
   // Step 1: Deallocate remaining stack
   mc.emit_add_imm(31, 31, 64)

--- a/vcode/emit/instructions.mbt
+++ b/vcode/emit/instructions.mbt
@@ -93,11 +93,11 @@ enum Instruction {
   LdpOffset(Int, Int, Int, Int) // rt1, rt2, rn, offset
   StpDOffset(Int, Int, Int, Int) // rt1(d), rt2(d), rn, offset (FPR)
   LdpDOffset(Int, Int, Int, Int) // rt1(d), rt2(d), rn, offset (FPR)
-  // Pre-indexed stores (Cranelift-style prologue)
+  // Pre-indexed stores (Standard prologue)
   StrPre(Int, Int, Int) // rt, rn, simm9 - STR Xt, [Xn, #simm9]!
   StpDPre(Int, Int, Int, Int) // rt1, rt2, rn, imm7 - STP Dt1, Dt2, [Xn, #imm7]!
   StrDPre(Int, Int, Int) // rt, rn, simm9 - STR Dt, [Xn, #simm9]!
-  // Post-indexed loads (Cranelift-style epilogue)
+  // Post-indexed loads (Standard epilogue)
   LdrPost(Int, Int, Int) // rt, rn, simm9 - LDR Xt, [Xn], #simm9
   LdpDPost(Int, Int, Int, Int) // rt1, rt2, rn, imm7 - LDP Dt1, Dt2, [Xn], #imm7
   LdrDPost(Int, Int, Int) // rt, rn, simm9 - LDR Dt, [Xn], #simm9
@@ -4880,7 +4880,7 @@ pub fn MachineCode::emit_addv_b(self : MachineCode, rd : Int, rn : Int) -> Unit 
 ///|
 /// Check if a register is a callee-saved allocatable GPR (X19-X28)
 /// All callee-saved registers are now available for allocation since
-/// we use Cranelift-style on-demand loading from vmctx (X19).
+/// we use Standard on-demand loading from vmctx (X19).
 fn is_callee_saved_alloc(reg : Int) -> Bool {
   reg >= 19 && reg <= 28
 }

--- a/vcode/emit/stackframe.mbt
+++ b/vcode/emit/stackframe.mbt
@@ -1,7 +1,7 @@
-// JIT Stack Frame Layout (ABI v3 - Cranelift style)
+// JIT Stack Frame Layout (ABI v3 - Standard style)
 // Encapsulates stack frame layout computation for JIT-compiled functions
 //
-// Cranelift-style Stack Frame Layout (from high to low address):
+// Standard Stack Frame Layout (from high to low address):
 // ┌───────────────────────────┐
 // │  Caller's Stack Args      │ (if any)
 // ├═══════════════════════════┤ ← SP at function entry
@@ -19,7 +19,7 @@
 // └═══════════════════════════┘ ← SP after prologue
 //
 // Key difference from old layout: FP/LR is at the TOP (highest address),
-// not at SP+0. This matches Cranelift's approach using fixed-size pre-indexed
+// not at SP+0. This approach using fixed-size pre-indexed
 // pushes that avoid SImm7 overflow issues with large frames.
 
 // ============ Constants ============
@@ -103,7 +103,7 @@ pub fn JITStackFrame::build(
   let aligned_outgoing = align_up(outgoing_args_size, 16)
 
   // Calculate frame size (excluding setup area, which is handled separately)
-  // Cranelift-style layout from SP upward:
+  // Standard layout from SP upward:
   // [SP+0]: outgoing args
   // [SP+outgoing]: spill slots
   // [SP+outgoing+spill]: FPR saves
@@ -112,7 +112,7 @@ pub fn JITStackFrame::build(
   let frame_size = gpr_save_size + fpr_save_size + spill_size + aligned_outgoing
 
   // Calculate offsets (from SP after frame allocation)
-  // Cranelift style: outgoing args at bottom, FP/LR at top
+  // Standard style: outgoing args at bottom, FP/LR at top
   let outgoing_args_offset = 0
   let spill_offset = aligned_outgoing
   let fpr_save_offset = spill_offset + spill_size

--- a/vcode/emit/trampoline.mbt
+++ b/vcode/emit/trampoline.mbt
@@ -1,7 +1,7 @@
-// Entry Trampoline Generation (Cranelift-style)
+// Entry Trampoline Generation (Standard)
 // Generates JIT trampolines for calling WASM functions from host code
 //
-// Following Cranelift's approach:
+// On-demand loading:
 // 1. Generate the trampoline as IR
 // 2. Compile through the normal pipeline (lower → regalloc → emit)
 // 3. Let the register allocator decide which registers to use
@@ -27,7 +27,7 @@
 ///   param_types: Array of parameter types (0=I32, 1=I64, 2=F32, 3=F64, 4=V128)
 ///   result_types: Array of result types
 ///
-/// This follows Cranelift's approach: generate IR, then compile through the
+/// Approach: generate IR, then compile through the
 /// normal pipeline. The register allocator will automatically choose callee-saved
 /// registers when needed, eliminating the need for hardcoded X23/X24.
 pub fn emit_entry_trampoline(
@@ -47,7 +47,7 @@ pub fn emit_entry_trampoline(
 
 ///|
 /// Generate IR function for the trampoline
-/// This is the Cranelift way: express the trampoline in IR, not machine code
+/// Approach: express the trampoline in IR, not machine code
 fn generate_trampoline_ir(
   param_types : Array[Int],
   result_types : Array[Int],

--- a/vcode/emit_wbtest.mbt
+++ b/vcode/emit_wbtest.mbt
@@ -162,7 +162,7 @@ test "emit: full function" {
   // Emit machine code
   let mc = @emit.emit_function(func)
 
-  // Cranelift-style prologue/epilogue:
+  // Standard prologue/epilogue:
   // Prologue: stp x29,x30 + mov x29,sp + str x19 + sub sp + mov x19,x0 = 5 inst
   // Body: add x0,x0,x1 = 1 inst
   // Epilogue: add sp + ldr x19 + ldp x29,x30 + ret = 4 inst

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -1,6 +1,6 @@
 ///|
 /// Call type - classifies instructions that behave like calls
-/// Following Cranelift's CallType enum
+/// CallType enum for different call variants
 pub(all) enum CallType {
   None // Not a call instruction
   Regular // Regular call that returns to caller
@@ -9,7 +9,7 @@ pub(all) enum CallType {
 
 ///|
 /// Calling convention for function calls
-/// Following Cranelift's CallConv design
+/// Calling convention specification
 pub(all) enum CallConv {
   Wasm // Wasm calling convention: X0=callee_vmctx, X1=caller_vmctx, X2-X7=user_args
   C // Standard C calling convention: X0-X7=args, no vmctx
@@ -65,7 +65,7 @@ pub(all) enum ExceptionLibcall {
 
 ///|
 /// VCode instruction - a machine-level instruction with virtual registers
-/// Following Cranelift's design with operand constraints for fixed register allocation
+/// Operand constraints for fixed register allocation
 pub(all) struct VCodeInst {
   opcode : VCodeOpcode
   defs : Array[@abi.Writable] // Registers defined (written)
@@ -356,14 +356,14 @@ pub(all) enum VCodeOpcode {
   // Parameters: num_args, num_results, calling convention
   CallPtr(Int, Int, CallConv)
 
-  // Stack pointer adjustment for outgoing call arguments (Cranelift-style)
+  // Stack pointer adjustment for outgoing call arguments (Standard)
   // AdjustSP(delta): Adjust SP by delta bytes
   //   delta > 0: deallocate (add to SP)
   //   delta < 0: allocate (sub from SP)
   // Used in call lowering to allocate space for overflow args
   AdjustSP(Int)
 
-  // Store to outgoing call argument area (Cranelift-style)
+  // Store to outgoing call argument area (Standard)
   // StoreToStack(offset): Store use[0] to [SP + offset]
   // Used in call lowering to store overflow args before the call
   // Uses: [value], Defs: []
@@ -1271,7 +1271,7 @@ pub impl Show for IntToFloatKind with output(self, logger) {
 
 ///|
 /// AArch64 condition codes (for conditional branches and traps)
-/// Following Cranelift's Cond enum
+/// Condition codes for comparisons
 pub(all) enum Cond {
   Eq // Equal (Z=1)
   Ne // Not equal (Z=0)
@@ -1391,11 +1391,11 @@ pub impl Show for VCodeTerminator with output(self, logger) {
 
 ///|
 /// Get the call type for this opcode
-/// Following Cranelift's design: instructions that clobber caller-saved registers
+/// Design: instructions that clobber caller-saved registers
 /// are classified as calls for register allocation purposes
 pub fn VCodeOpcode::call_type(self : VCodeOpcode) -> CallType {
   match self {
-    // Direct and indirect function calls (Cranelift-style via CallPtr)
+    // Direct and indirect function calls (Standard via CallPtr)
     CallPtr(_, _, _) => Regular
     // Tail calls that don't return to caller
     ReturnCallIndirect(_, _) => TailCall

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -382,7 +382,7 @@ fn lower_inst(
     @ir.Opcode::CallIndirect(type_idx, table_idx) =>
       lower_call_indirect(ctx, inst, block, type_idx, table_idx)
     @ir.Opcode::CallRef(type_idx) => lower_call_ref(ctx, inst, block, type_idx)
-    // Tail calls - use dedicated lowering functions with Cranelift-style parameter handling
+    // Tail calls - use dedicated lowering functions with Standard parameter handling
     @ir.Opcode::ReturnCall(func_idx) =>
       lower_return_call(ctx, inst, block, func_idx)
     @ir.Opcode::ReturnCallIndirect(type_idx, table_idx) =>
@@ -1246,7 +1246,7 @@ fn lower_call(
   load_inst.add_use(Virtual(func_table))
   block.add_inst(load_inst)
 
-  // Use Cranelift-style call lowering
+  // Use Standard call lowering
   lower_wasm_call(ctx, block, func_ptr_vreg, arg_vregs, result_vregs)
 }
 

--- a/vcode/lower/lower_call.mbt
+++ b/vcode/lower/lower_call.mbt
@@ -1,7 +1,7 @@
-// ============ Wasm Call Lowering (Cranelift-style) ============
+// ============ Wasm Call Lowering (Standard) ============
 
 ///|
-/// Lower a Wasm function call using Cranelift-style approach.
+/// Lower a Wasm function call using Standard approach.
 /// All argument placement is done in lowering via FixedReg constraints.
 /// The emit phase just emits BLR X17.
 ///
@@ -170,11 +170,11 @@ fn lower_wasm_call(
   block.add_inst(call_inst)
 }
 
-// ============ Tail Call Lowering (Cranelift-style) ============
+// ============ Tail Call Lowering (Standard) ============
 
 ///|
 /// Lower direct return_call (tail call optimization)
-/// Following Cranelift: parameters are handled in lowering phase
+/// Note: parameters are handled in lowering phase
 /// - Overflow args: StoreToStack instructions
 /// - Register args: Fixed register constraints via add_use_fixed
 /// - ReturnCallIndirect instruction only contains func_ptr use
@@ -300,7 +300,7 @@ fn lower_return_call(
 
 ///|
 /// Lower return_call_indirect (indirect tail call)
-/// Following Cranelift: parameters handled in lowering via StoreToStack and add_use_fixed
+/// Note: parameters handled in lowering via StoreToStack and add_use_fixed
 fn lower_return_call_indirect(
   ctx : LoweringContext,
   inst : @ir.Inst,
@@ -493,7 +493,7 @@ fn lower_return_call_indirect(
 ///|
 /// Lower return_call_ref (tail call through function reference)
 /// The func_ref is a tagged pointer (func_ptr | FUNCREF_TAG where FUNCREF_TAG = 0x2000000000000000)
-/// Following Cranelift: parameters handled in lowering
+/// Note: parameters handled in lowering
 fn lower_return_call_ref(
   ctx : LoweringContext,
   inst : @ir.Inst,
@@ -639,7 +639,7 @@ fn lower_call_indirect(
 
   // Multi-table support: determine which table pointer to use
   // Both table_idx == 0 and table_idx != 0 load the table pointer on-demand
-  // following Cranelift's approach (no pre-loaded registers for table pointers)
+  // on-demand (no pre-loaded registers for table pointers)
   let table_ptr_vreg : @abi.VReg = if table_idx == 0 {
     // Fast path for table 0: load table0_base from vmctx on-demand
     emit_load_table0_base(ctx, block)
@@ -694,7 +694,7 @@ fn lower_call_indirect(
   block.add_inst(mul_inst)
 
   // Step 2: Calculate address = table_ptr + offset (64-bit pointer arithmetic)
-  // table_ptr is loaded on-demand from vmctx (following Cranelift's approach)
+  // table_ptr is loaded on-demand from vmctx (on-demand)
   let addr_vreg = ctx.vcode_func.new_vreg(Int)
   let add_inst = @instr.VCodeInst::new(Add(true))
   add_inst.add_def({ reg: Virtual(addr_vreg) })
@@ -747,7 +747,7 @@ fn lower_call_indirect(
     None,
   )
 
-  // Step 6: Use Cranelift-style call lowering
+  // Step 6: Use Standard call lowering
   lower_wasm_call(ctx, block, func_ptr_vreg, arg_vregs, result_vregs)
 }
 
@@ -795,7 +795,7 @@ fn lower_call_ref(
   and_inst.add_use(Virtual(mask_vreg))
   block.add_inst(and_inst)
 
-  // Step 2: Use Cranelift-style call lowering
+  // Step 2: Use Standard call lowering
   lower_wasm_call(ctx, block, func_ptr_vreg, arg_vregs, result_vregs)
 }
 
@@ -819,13 +819,13 @@ fn add_call_clobbers(call_inst : @instr.VCodeInst) -> Unit {
 /// Lower call_ptr instruction (call through a function pointer)
 /// Used in trampolines to call the target WASM function
 ///
-/// Operand layout (following Cranelift):
+/// Operand layout:
 ///   operand 0 = function pointer
 ///   operand 1 = callee_vmctx (X0)
 ///   operand 2 = caller_vmctx (X1)
 ///   operands 3..n = user arguments
 ///
-/// Cranelift-style ABI refactoring:
+/// Standard ABI refactoring:
 /// - Stack args are handled in lower phase via StoreToStack instructions
 /// - Register args use FixedReg constraints to tell regalloc which physical registers to use
 /// - X17 is used for func_ptr (constraint ensures no conflicts)
@@ -874,7 +874,7 @@ fn lower_call_ptr(
   // Align to 16 bytes
   let aligned_stack_space = (stack_arg_space + 15) / 16 * 16
 
-  // Update max_outgoing_args_size (Cranelift-style: pre-allocate in prologue)
+  // Update max_outgoing_args_size (Standard: pre-allocate in prologue)
   // This ensures SP doesn't move during call sequences, avoiding spill slot issues
   ctx.vcode_func.update_max_outgoing_args_size(aligned_stack_space)
 
@@ -977,7 +977,7 @@ fn lower_call_ptr(
   // No AdjustSP needed - outgoing args space is pre-allocated in prologue
 }
 
-// ============ C Libcall Lowering (Cranelift-style) ============
+// ============ C Libcall Lowering (Standard) ============
 
 ///|
 /// Lower a simple C libcall with up to 8 integer arguments.

--- a/vcode/lower/lower_convert.mbt
+++ b/vcode/lower/lower_convert.mbt
@@ -84,7 +84,7 @@ fn lower_truncate(
 
 ///|
 /// Lower float to int conversion (trapping version)
-/// Cranelift-style lowering: expand to multiple primitive instructions
+/// Standard lowering: expand to multiple primitive instructions
 ///
 /// Generated sequence:
 /// 1. FpuCmp(src, src) - compare with self to check for NaN

--- a/vcode/lower/lower_memory.mbt
+++ b/vcode/lower/lower_memory.mbt
@@ -2,7 +2,7 @@
 // Memory bounds checking is now done at IR translation time via FuncEnvironment
 
 ///|
-/// Emit instruction to load func_table from vmctx on-demand (Cranelift-style)
+/// Emit instruction to load func_table from vmctx on-demand (Standard)
 /// Returns a virtual register containing func_table pointer
 /// This is called before function calls to get the function table base address
 fn emit_load_func_table(
@@ -18,7 +18,7 @@ fn emit_load_func_table(
 }
 
 ///|
-/// Emit instruction to load table0_base from vmctx on-demand (Cranelift-style)
+/// Emit instruction to load table0_base from vmctx on-demand (Standard)
 /// Returns a virtual register containing table0_base pointer
 /// This is called before indirect calls to get the indirect table base address
 fn emit_load_table0_base(

--- a/vcode/lower/lower_numeric.mbt
+++ b/vcode/lower/lower_numeric.mbt
@@ -454,7 +454,7 @@ fn lower_bxor(
 
 ///|
 /// Lower rotate left instruction
-/// Cranelift-style lowering: expand to primitive instructions here
+/// Standard lowering: expand to primitive instructions here
 /// rotl(x, n) = rotr(x, 0 - n)
 ///
 /// AArch64 ROR only looks at lower bits of shift amount, so negating
@@ -499,7 +499,7 @@ fn lower_rotl(
 
 ///|
 /// Lower count trailing zeros instruction
-/// Cranelift-style lowering: expand to primitive instructions here
+/// Standard lowering: expand to primitive instructions here
 /// ctz(x) = clz(rbit(x))
 ///
 /// Generated sequence:
@@ -644,7 +644,7 @@ fn lower_unary_int(
 
 ///|
 /// Lower integer remainder: rem = a - (a / b) * b
-/// Cranelift-style lowering: expand to primitive instructions here
+/// Standard lowering: expand to primitive instructions here
 ///
 /// AArch64 doesn't have a direct remainder instruction, so we expand:
 ///   div = a / b  (SDIV or UDIV)

--- a/vcode/lower/patterns.mbt
+++ b/vcode/lower/patterns.mbt
@@ -1,5 +1,5 @@
 // Pattern Matching for Instruction Selection
-// Implements pattern-based lowering rules similar to Cranelift's ISLE DSL
+// Implements pattern-based lowering rules SSA-based IR DSL
 //
 // This module provides:
 // 1. Pattern definitions for matching IR instruction trees

--- a/vcode/lower/regalloc.mbt
+++ b/vcode/lower/regalloc.mbt
@@ -338,7 +338,7 @@ fn collect_defs_uses(func : VCodeFunction, result : LivenessResult) -> Unit {
     // Process instructions
     for inst_idx, inst in block.insts {
       // Record call points for caller-saved register handling
-      // Following Cranelift's design: use call_type() to determine if an instruction
+      // Design: use call_type() to determine if an instruction
       // behaves like a call (clobbers caller-saved registers)
       if inst.opcode.call_type() is @instr.Regular {
         result.call_points.push({ block: block_idx, inst: inst_idx, pos: After })
@@ -619,7 +619,7 @@ fn build_intervals(func : VCodeFunction, result : LivenessResult) -> Unit {
 
 ///|
 /// A register move instruction (from regalloc constraint processing)
-/// Following Cranelift's Edit::Move design
+/// Move operation between registers
 pub(all) struct RegMove {
   from : @abi.PReg // Source register (or spill slot encoded as negative index)
   to : @abi.PReg // Destination register
@@ -638,7 +638,7 @@ pub impl Show for RegMove with output(self, logger) {
 
 ///|
 /// Edits to insert before/after an instruction
-/// Following Cranelift's Edits design for constraint handling
+/// Register constraint handling
 pub(all) struct InstEdits {
   before : Array[RegMove] // Moves to insert before the instruction
   after : Array[RegMove] // Moves to insert after the instruction
@@ -779,7 +779,7 @@ pub(all) struct RegAllocResult {
   spills : Array[SpillInfo]
   reloads : Array[ReloadInfo]
   // Constraint edits: (block_idx, inst_idx) -> edits to insert
-  // Following Cranelift's design for fixed register constraints
+  // Fixed register constraint handling
   inst_edits : Map[(Int, Int), InstEdits]
 }
 
@@ -817,7 +817,7 @@ pub(all) struct LinearScanAllocator {
   block_order : Map[Int, Int]
   // Reserved registers at each instruction point (for FixedReg constraints)
   // Key: (block_idx, inst_idx), Value: set of reserved register indices
-  // Following Cranelift: constraints must be respected during allocation
+  // Note: constraints must be respected during allocation
   reserved_int_regs : Map[(Int, Int), Set[Int]]
   reserved_float_regs : Map[(Int, Int), Set[Int]]
 }
@@ -846,7 +846,7 @@ pub fn LinearScanAllocator::new(
 /// Collect FixedReg constraints from all instructions
 /// This must be called before allocation so that constrained registers
 /// can be avoided during the allocation process.
-/// Following Cranelift's design: constraints are known before allocation.
+/// Design: constraints are known before allocation.
 fn LinearScanAllocator::collect_constraints(
   self : LinearScanAllocator,
   func : VCodeFunction,
@@ -954,7 +954,7 @@ pub fn LinearScanAllocator::allocate(
   }
 
   // Pre-assign function parameters to ABI registers
-  // Following Cranelift: all params use X0-X7 (int) or V0-V7 (float)
+  // Note: all params use X0-X7 (int) or V0-V7 (float)
   // vmctx is an explicit param in the function signature, not special-cased here
   // NOTE: Only pre-assign if the parameter doesn't cross a call, otherwise
   // it will be handled by the normal allocation process (which will use callee-saved)
@@ -1106,7 +1106,7 @@ fn reg_class_eq(a : @abi.RegClass, b : @abi.RegClass) -> Bool {
 
 ///|
 /// Try to allocate a physical register for an interval
-/// Following Cranelift: avoid registers that are reserved by constraints
+/// Note: avoid registers that are reserved by constraints
 fn LinearScanAllocator::try_allocate_reg(
   self : LinearScanAllocator,
   interval : LiveInterval,
@@ -1181,7 +1181,7 @@ fn LinearScanAllocator::spill_interval(
 
 ///|
 /// Process operand constraints and generate RegMove edits
-/// Following Cranelift's design: constraints are processed after allocation
+/// Design: constraints are processed after allocation
 /// and moves are inserted when the allocated register doesn't match the constraint
 pub fn process_constraints(
   func : VCodeFunction,
@@ -1285,7 +1285,7 @@ pub fn apply_allocation(
   new_func.set_num_spill_slots(alloc.num_spill_slots)
 
   // Convert function parameters
-  // Following Cranelift: all params use X0-X7 (int) or V0-V7 (float)
+  // Note: all params use X0-X7 (int) or V0-V7 (float)
   // vmctx is an explicit param in the function signature
   let max_int_params = @abi.MAX_REG_PARAMS // 8
   let max_float_params = @abi.MAX_FLOAT_REG_PARAMS // 8
@@ -1543,7 +1543,7 @@ pub fn apply_allocation(
       }
 
       // Process constraint edits: insert moves before the instruction
-      // Following Cranelift's design for fixed register constraints
+      // Fixed register constraint handling
       // Use parallel move resolver to handle cyclic dependencies
       if alloc.inst_edits.get((block_idx, inst_idx)) is Some(edits) {
         let resolved_moves = resolve_parallel_moves(edits.before)
@@ -1863,7 +1863,7 @@ pub fn allocate_registers_aarch64(func : VCodeFunction) -> VCodeFunction {
   let alloc_result = allocator.allocate(func, liveness)
 
   // Process constraints and generate RegMove edits
-  // Following Cranelift's design: constraints are resolved after allocation
+  // Design: constraints are resolved after allocation
   process_constraints(func, alloc_result)
 
   // Apply allocation

--- a/vcode/lower/regalloc_wbtest.mbt
+++ b/vcode/lower/regalloc_wbtest.mbt
@@ -1463,7 +1463,7 @@ test "regalloc: @instr.CallIndirect with 8 f64 arguments" {
   ptr_inst.add_def({ reg: @abi.Virtual(func_ptr) })
   block.add_inst(ptr_inst)
 
-  // CallPtr with 8 f64 args, 1 f64 result (Cranelift-style)
+  // CallPtr with 8 f64 args, 1 f64 result (Standard)
   let call_inst = @instr.VCodeInst::new(@instr.CallPtr(8, 1, @instr.Wasm))
   let call_result = func.new_vreg(@abi.Float64)
   call_inst.add_def({ reg: @abi.Virtual(call_result) })
@@ -1564,7 +1564,7 @@ test "regalloc: f32 value live across @instr.CallIndirect" {
   ptr_inst.add_def({ reg: @abi.Virtual(func_ptr) })
   block.add_inst(ptr_inst)
 
-  // CallPtr with 1 f64 arg, returns 1 f64 (Cranelift-style)
+  // CallPtr with 1 f64 arg, returns 1 f64 (Standard)
   // The f32_val must survive across this call
   let call_inst = @instr.VCodeInst::new(@instr.CallPtr(1, 1, @instr.Wasm))
   let call_result = func.new_vreg(@abi.Float64)


### PR DESCRIPTION
## Summary
Remove all references to Cranelift in comments and documentation since wasmoon is an independent project with its own design.

## Changes
- Replace "Following Cranelift's design" comments with descriptive alternatives
- Replace "Cranelift-style" with "Standard" or context-appropriate descriptions  
- Rename test functions from `cranelift_style_*` to `standard_*`
- Update `docs/architecture.md` section title from "Cranelift-style VCode" to "VCode (Virtual Code)"
- Update `docs/jit-abi.md` to use "custom calling convention"

## Files changed
26 files across ir/, vcode/, jit/, and docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)