### PR TITLE
refactor: introduce MemoryInfo struct for memory parameters

### DIFF
--- a/jit/ffi_jit.mbt
+++ b/jit/ffi_jit.mbt
@@ -40,6 +40,26 @@ pub fn check_trap() -> Unit raise JITTrap {
   }
 }
 
+// ============ Memory Info ============
+
+///|
+/// Memory information for JIT execution
+pub struct MemoryInfo {
+  ptr : Int64 // Memory base pointer
+  size : Int64 // Current size in bytes
+  max_pages : Int? // Max pages (None = unlimited)
+}
+
+///|
+/// Create a new MemoryInfo
+pub fn MemoryInfo::new(
+  ptr : Int64,
+  size : Int64,
+  max_pages : Int?,
+) -> MemoryInfo {
+  { ptr, size, max_pages }
+}
+
 // ============ JIT Context Wrapper ============
 
 ///|
@@ -164,27 +184,22 @@ fn JITContext::set_table_pointers(
 
 ///|
 /// Set multiple memories (for multi-memory support)
-/// memory_ptrs: Array of Int64 (memory base pointers)
-/// memory_sizes: Array of Int64 (memory sizes in bytes)
-/// memory_max_pages: Array of Int? (max sizes in pages, None = unlimited)
 fn JITContext::set_memory_pointers(
   self : JITContext,
-  memory_ptrs : Array[Int64],
-  memory_sizes : Array[Int64],
-  memory_max_pages : Array[Int?],
+  memories : Array[MemoryInfo],
 ) -> Unit {
-  if memory_ptrs.is_empty() {
+  if memories.is_empty() {
     return
   }
-  let count = memory_ptrs.length()
+  let count = memories.length()
   // Convert to FixedArrays for FFI
   let ptrs = FixedArray::make(count, 0L)
   let sizes = FixedArray::make(count, 0L)
   let max_sizes = FixedArray::make(count, -1) // -1 = unlimited
-  for i in 0..<count {
-    ptrs[i] = memory_ptrs[i]
-    sizes[i] = memory_sizes[i]
-    max_sizes[i] = memory_max_pages[i].unwrap_or(-1)
+  for i, mem in memories {
+    ptrs[i] = mem.ptr
+    sizes[i] = mem.size
+    max_sizes[i] = mem.max_pages.unwrap_or(-1)
   }
   @jit_ffi.c_jit_ctx_set_memory_pointers(
     self.ptr(),

--- a/jit/jit_runtime.mbt
+++ b/jit/jit_runtime.mbt
@@ -348,12 +348,10 @@ pub fn JITModule::set_globals(self : JITModule, globals_ptr : Int64) -> Unit {
 /// Set multiple memories for the JIT context (multi-memory support)
 pub fn JITModule::set_memory_pointers(
   self : JITModule,
-  memory_ptrs : Array[Int64],
-  memory_sizes : Array[Int64],
-  memory_max_pages : Array[Int?],
+  memories : Array[MemoryInfo],
 ) -> Unit {
   if self.context is Some(ctx) {
-    ctx.set_memory_pointers(memory_ptrs, memory_sizes, memory_max_pages)
+    ctx.set_memory_pointers(memories)
   }
 }
 

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -314,7 +314,7 @@ pub fn JITModule::load_with_imports(@cwasm.PrecompiledModule, Array[(Array[@type
 pub fn JITModule::new() -> Self
 pub fn JITModule::set_globals(Self, Int64) -> Unit
 pub fn JITModule::set_memory(Self, Int64, Int64) -> Unit
-pub fn JITModule::set_memory_pointers(Self, Array[Int64], Array[Int64], Array[Int?]) -> Unit
+pub fn JITModule::set_memory_pointers(Self, Array[MemoryInfo]) -> Unit
 
 type JITTable
 pub fn JITTable::get_max(Self) -> Int?
@@ -322,6 +322,13 @@ pub fn JITTable::get_size(Self) -> Int
 pub fn JITTable::new(Int, Int?) -> Self?
 pub fn JITTable::set(Self, Int, Int64, Int) -> Unit
 pub impl Show for JITTable
+
+pub struct MemoryInfo {
+  ptr : Int64
+  size : Int64
+  max_pages : Int?
+}
+pub fn MemoryInfo::new(Int64, Int64, Int?) -> Self
 
 pub(all) struct Profiler {
   counter : CallCounter

--- a/main/run.mbt
+++ b/main/run.mbt
@@ -853,9 +853,7 @@ fn init_jit_memories(
   if instance.mem_addrs.is_empty() {
     return true // No memories to initialize
   }
-  let memory_ptrs : Array[Int64] = []
-  let memory_sizes : Array[Int64] = []
-  let memory_max_pages : Array[Int?] = []
+  let memories : Array[@jit.MemoryInfo] = []
   // Allocate and copy each memory
   for mem_addr in instance.mem_addrs {
     let mem = store.get_mem(mem_addr) catch { _ => return false }
@@ -868,15 +866,13 @@ fn init_jit_memories(
     }
     // Copy interpreter memory data to JIT memory
     copy_interp_memory_to_jit_indexed(store, mem_addr, mem_ptr)
-    memory_ptrs.push(mem_ptr)
-    memory_sizes.push(size)
-    memory_max_pages.push(max)
+    memories.push(@jit.MemoryInfo::new(mem_ptr, size, max))
   }
   // Set up multi-memory in JIT context
-  jm.set_memory_pointers(memory_ptrs, memory_sizes, memory_max_pages)
+  jm.set_memory_pointers(memories)
   // Also set fast path for memory 0 (backward compatibility)
-  if memory_ptrs.length() > 0 {
-    jm.set_memory(memory_ptrs[0], memory_sizes[0])
+  if memories.length() > 0 {
+    jm.set_memory(memories[0].ptr, memories[0].size)
   }
   true
 }

--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -331,10 +331,8 @@ pub fn run_jit(
       return Err("Failed to allocate memory")
     }
     // Set up multi-memory array (single memory at index 0)
-    let memory_ptrs = [mem_ptr]
-    let memory_sizes = [mem_size]
-    let memory_max_pages : Array[Int?] = [None] // No max limit
-    jm.set_memory_pointers(memory_ptrs, memory_sizes, memory_max_pages)
+    let memories = [@jit.MemoryInfo::new(mem_ptr, mem_size, None)]
+    jm.set_memory_pointers(memories)
     // Also set fast path for memory 0 (backward compatibility)
     jm.set_memory(mem_ptr, mem_size)
 


### PR DESCRIPTION
## Summary
Replace three separate arrays (`memory_ptrs`, `memory_sizes`, `memory_max_pages`) with a single `Array[MemoryInfo]` for cleaner API.

## Changes
- Add `MemoryInfo` struct in `jit/ffi_jit.mbt`:
  ```moonbit
  pub struct MemoryInfo {
    ptr : Int64       // Memory base pointer
    size : Int64      // Current size in bytes
    max_pages : Int?  // Max pages (None = unlimited)
  }
  ```
- Update `set_memory_pointers` to take `Array[MemoryInfo]`
- Update call sites in `main/run.mbt` and `testsuite/compare.mbt`

## Test plan
- [x] Build passes
- [x] memory.wast: 79/79 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)