### PR TITLE
feat(jit): enable immediate operand selection for add/sub

### DIFF
--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -393,6 +393,15 @@ fn MachineCode::emit_instruction(
         self.emit_sub_reg32(rd, rn, rm)
       }
     }
+    SubImm(imm, is_64) => {
+      let rd = wreg_num(inst.defs[0])
+      let rn = reg_num(inst.uses[0])
+      if is_64 {
+        self.emit_sub_imm(rd, rn, imm)
+      } else {
+        self.emit_sub_imm32(rd, rn, imm)
+      }
+    }
     Mul(is_64) => {
       let rd = wreg_num(inst.defs[0])
       let rn = reg_num(inst.uses[0])

--- a/vcode/emit/instructions.mbt
+++ b/vcode/emit/instructions.mbt
@@ -37,6 +37,7 @@ enum Instruction {
   SubReg32(Int, Int, Int) // 32-bit subtract
   AddReg32(Int, Int, Int) // 32-bit add
   AddImm32(Int, Int, Int) // 32-bit add immediate
+  SubImm32(Int, Int, Int) // 32-bit sub immediate
   Mul32(Int, Int, Int) // 32-bit multiply
   // Bitwise - Register
   AndReg(Int, Int, Int)
@@ -518,6 +519,7 @@ fn Instruction::annotate(self : Instruction) -> String {
     SubReg32(rd, rn, rm) => "sub w\{rd}, w\{rn}, w\{rm}"
     AddReg32(rd, rn, rm) => "add w\{rd}, w\{rn}, w\{rm}"
     AddImm32(rd, rn, imm) => "add w\{rd}, w\{rn}, #\{imm}"
+    SubImm32(rd, rn, imm) => "sub w\{rd}, w\{rn}, #\{imm}"
     Mul32(rd, rn, rm) => "mul w\{rd}, w\{rn}, w\{rm}"
     AndReg(rd, rn, rm) => "and x\{rd}, x\{rn}, x\{rm}"
     AndShifted(rd, rn, rm, shift, amount) => {
@@ -1150,6 +1152,14 @@ fn Instruction::instr_bytes(self : Instruction) -> (Int, Int, Int, Int) {
       let b1 = ((rn >> 3) & 3) | ((imm & 0x3F) << 2)
       let b2 = (imm >> 6) & 0x3F
       let b3 = 0x11 // ADD imm 32-bit: sf=0
+      (b0, b1, b2, b3)
+    }
+    SubImm32(rd, rn, imm) => {
+      // SUB Wd, Wn, #imm (32-bit)
+      let b0 = (rd & 31) | ((rn & 7) << 5)
+      let b1 = ((rn >> 3) & 3) | ((imm & 0x3F) << 2)
+      let b2 = (imm >> 6) & 0x3F
+      let b3 = 0x51 // SUB imm 32-bit: sf=0, op=1
       (b0, b1, b2, b3)
     }
     Mul32(rd, rn, rm) => {
@@ -3724,6 +3734,16 @@ pub fn MachineCode::emit_add_imm32(
   imm : Int,
 ) -> Unit {
   AddImm32(rd, rn, imm).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_sub_imm32(
+  self : MachineCode,
+  rd : Int,
+  rn : Int,
+  imm : Int,
+) -> Unit {
+  SubImm32(rd, rn, imm).emit(self)
 }
 
 ///|

--- a/vcode/emit/pkg.generated.mbti
+++ b/vcode/emit/pkg.generated.mbti
@@ -228,6 +228,7 @@ pub fn MachineCode::emit_str_w_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_strb_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_strh_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_sub_imm(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_sub_imm32(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_sub_reg(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_sub_reg32(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_sub_shifted(Self, Int, Int, Int, @instr.ShiftType, Int) -> Unit

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -164,6 +164,7 @@ pub(all) enum VCodeOpcode {
   Add(Bool) // ADD with size: true = 64-bit, false = 32-bit
   AddImm(Int, Bool) // ADD Xd, Xn, #imm with size: true = 64-bit, false = 32-bit
   Sub(Bool) // SUB with size: true = 64-bit, false = 32-bit
+  SubImm(Int, Bool) // SUB Xd, Xn, #imm with size: true = 64-bit, false = 32-bit
   Mul(Bool) // MUL with size: true = 64-bit, false = 32-bit
   SDiv(Bool) // SDIV with size: true = 64-bit, false = 32-bit
   UDiv(Bool) // UDIV with size: true = 64-bit, false = 32-bit
@@ -795,6 +796,7 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     Add(is_64) => if is_64 { "add" } else { "add32" }
     AddImm(imm, is_64) => if is_64 { "add #\{imm}" } else { "add32 #\{imm}" }
     Sub(is_64) => if is_64 { "sub" } else { "sub32" }
+    SubImm(imm, is_64) => if is_64 { "sub #\{imm}" } else { "sub32 #\{imm}" }
     Mul(is_64) => if is_64 { "mul" } else { "mul32" }
     SDiv(is_64) => if is_64 { "sdiv" } else { "sdiv32" }
     UDiv(is_64) => if is_64 { "udiv" } else { "udiv32" }

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -220,6 +220,7 @@ pub(all) enum VCodeOpcode {
   Add(Bool)
   AddImm(Int, Bool)
   Sub(Bool)
+  SubImm(Int, Bool)
   Mul(Bool)
   SDiv(Bool)
   UDiv(Bool)

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -166,6 +166,19 @@ fn is_const_zero_value(ctx : LoweringContext, value : @ir.Value) -> Bool {
 }
 
 ///|
+/// Check if a value is a constant and return the value if valid for ADD/SUB immediate
+/// Returns Some(val) if the value is a constant in valid 12-bit immediate range
+fn match_add_imm_value(ctx : LoweringContext, value : @ir.Value) -> Int64? {
+  if find_defining_inst(ctx, value) is Some(inst) &&
+    inst.opcode is @ir.Opcode::Iconst(val) {
+    if is_valid_add_imm(val) {
+      return Some(val)
+    }
+  }
+  None
+}
+
+///|
 /// Lower an entire IR function to VCode
 pub fn lower_function(ir_func : @ir.Function) -> VCodeFunction {
   let ctx = LoweringContext::new(ir_func)

--- a/vcode/lower/lower_numeric.mbt
+++ b/vcode/lower/lower_numeric.mbt
@@ -218,6 +218,28 @@ fn lower_iadd(
     return
   }
 
+  // Pattern: add(x, const) -> AddImm where const is valid 12-bit immediate
+  if match_add_imm_value(ctx, rhs_val) is Some(imm_val) {
+    let lhs = ctx.get_vreg_for_use(lhs_val, block)
+    let is_64 = result.ty is @ir.Type::I64
+    let vcode_inst = @instr.VCodeInst::new(AddImm(imm_val.to_int(), is_64))
+    vcode_inst.add_def({ reg: Virtual(dst) })
+    vcode_inst.add_use(Virtual(lhs))
+    block.add_inst(vcode_inst)
+    return
+  }
+
+  // Pattern: add(const, x) -> AddImm (commutative)
+  if match_add_imm_value(ctx, lhs_val) is Some(imm_val) {
+    let rhs = ctx.get_vreg_for_use(rhs_val, block)
+    let is_64 = result.ty is @ir.Type::I64
+    let vcode_inst = @instr.VCodeInst::new(AddImm(imm_val.to_int(), is_64))
+    vcode_inst.add_def({ reg: Virtual(dst) })
+    vcode_inst.add_use(Virtual(rhs))
+    block.add_inst(vcode_inst)
+    return
+  }
+
   // Default: regular add
   let lhs = ctx.get_vreg_for_use(lhs_val, block)
   let rhs = ctx.get_vreg_for_use(rhs_val, block)
@@ -299,6 +321,17 @@ fn lower_isub(
     vcode_inst.add_def({ reg: Virtual(dst) })
     vcode_inst.add_use(Virtual(rn))
     vcode_inst.add_use(Virtual(rm))
+    block.add_inst(vcode_inst)
+    return
+  }
+
+  // Pattern: sub(x, const) -> SubImm where const is valid 12-bit immediate
+  if match_add_imm_value(ctx, rhs_val) is Some(imm_val) {
+    let lhs = ctx.get_vreg_for_use(lhs_val, block)
+    let is_64 = result.ty is @ir.Type::I64
+    let vcode_inst = @instr.VCodeInst::new(SubImm(imm_val.to_int(), is_64))
+    vcode_inst.add_def({ reg: Virtual(dst) })
+    vcode_inst.add_use(Virtual(lhs))
     block.add_inst(vcode_inst)
     return
   }

--- a/vcode/lower/lower_wbtest.mbt
+++ b/vcode/lower/lower_wbtest.mbt
@@ -73,7 +73,7 @@ test "lower constants" {
       #|block0:
       #|    v0 = ldi 10
       #|    v1 = ldi 20
-      #|    v2 = add32 v0, v1
+      #|    v2 = add32 #20 v0
       #|    ret v2
       #|}
       #|
@@ -200,7 +200,7 @@ test "lower memory operations" {
       #|    v1 = ldi 0
       #|    v2 = load_ptr.i32 +0 v0
       #|    v3 = ldi 1
-      #|    v4 = add32 v2, v3
+      #|    v4 = add32 #1 v2
       #|    v5 = ldi 4
       #|    store_ptr.i32 +4 v0, v4
       #|    ret v4

--- a/vcode/lower/patterns_wbtest.mbt
+++ b/vcode/lower/patterns_wbtest.mbt
@@ -266,7 +266,7 @@ test "optimized vs non-optimized comparison" {
       #|vcode comparison(v0:int) -> int {
       #|block0:
       #|    v1 = ldi 0
-      #|    v2 = add32 v0, v1
+      #|    v2 = add32 #0 v0
       #|    ret v2
       #|}
       #|


### PR DESCRIPTION
## Summary
- Add `match_add_imm_value()` helper to detect valid 12-bit immediates
- Use `AddImm` in `lower_iadd` when RHS is a constant in valid range (0-4095 or shifted form)
- Add `SubImm` opcode to `VCodeOpcode` and implement emit code
- Use `SubImm` in `lower_isub` when RHS is a constant in valid range

## Example
Before:
```
v0 = ldi 1
v1 = add v2, v0    ; load constant then add register
```

After:
```
v1 = add #1 v2     ; add immediate directly
```

## Test plan
- [x] All 20028 WAST tests pass in both interpreter and JIT mode
- [x] vcode/lower unit tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)