### PR TITLE
fix(wasi): use real system clock instead of counter

### DIFF
--- a/wasi/functions.mbt
+++ b/wasi/functions.mbt
@@ -289,24 +289,16 @@ pub fn clock_time_get(
   if clock is None {
     return Errno::Inval.to_i32()
   }
-  // Get current time in nanoseconds
-  // For now, we return a monotonically increasing value based on a counter
-  // In a real implementation, this would call system time functions
-  let time_ns = get_current_time_ns()
+  // Get current time in nanoseconds using system clock
+  let time_ns = match clock.unwrap() {
+    Realtime => native_clock_gettime_realtime()
+    Monotonic => native_clock_gettime_monotonic()
+    // For process/thread CPU time, fall back to monotonic clock
+    // since we don't have platform-specific APIs for these yet
+    ProcessCPUTimeId | ThreadCPUTimeId => native_clock_gettime_monotonic()
+  }
   mem.write_i64(time_ptr, time_ns)
   Errno::Success.to_i32()
-}
-
-///|
-/// Simple time counter (placeholder for real system time)
-let time_counter : Ref[Int64] = { val: 0L }
-
-///|
-fn get_current_time_ns() -> Int64 {
-  // Increment counter to simulate time passing
-  // In real implementation, use platform-specific time APIs
-  time_counter.val = time_counter.val + 1000000L // 1ms increments
-  time_counter.val
 }
 
 ///|

--- a/wasi/wasi_wbtest.mbt
+++ b/wasi/wasi_wbtest.mbt
@@ -55,9 +55,9 @@ test "wasi: clock_time_get" {
   let mem = @runtime.Memory::new(1, None)
   let result = clock_time_get(mem, 0, 0L, 0) // Realtime clock
   inspect(result, content="0") // Success
-  // Check that time is non-zero (timestamp written to address 0)
-  let time = mem.read_i32(0)
-  inspect(time > 0, content="true")
+  // Check that time is non-zero (timestamp written to address 0 as i64)
+  let time = mem.read_i64(0)
+  inspect(time > 0L, content="true")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Replace placeholder counter-based `clock_time_get` with actual system time
- Use `native_clock_gettime_realtime()` for CLOCK_REALTIME
- Use `native_clock_gettime_monotonic()` for CLOCK_MONOTONIC
- Fall back to monotonic clock for process/thread CPU time (pending platform-specific APIs)

This fixes the "For now" comment about returning monotonically increasing values based on a counter.

## Test plan
- [x] `moon test -p wasi` passes (800/800 tests)
- [x] Manual test with WASI clock_time_get function works

🤖 Generated with [Claude Code](https://claude.com/claude-code)