### PR TITLE
refactor(regalloc): improve visibility and remove dead code

### DIFF
--- a/vcode/regalloc/backtrack.mbt
+++ b/vcode/regalloc/backtrack.mbt
@@ -28,7 +28,7 @@ struct QueueEntry {
 
 ///|
 /// The backtracking register allocator
-pub(all) struct BacktrackingAllocator {
+struct BacktrackingAllocator {
   // Core data
   ranges : LiveRangeSet
   bundles : BundleSet
@@ -637,8 +637,6 @@ pub fn BacktrackingAllocator::generate_result(
     assignments: {},
     spill_slots: {},
     num_spill_slots: self.bundles.next_spill_slot,
-    spills: [],
-    reloads: [],
     inst_edits: {},
   }
 

--- a/vcode/regalloc/bundle.mbt
+++ b/vcode/regalloc/bundle.mbt
@@ -5,7 +5,7 @@
 /// A Bundle groups related LiveRanges that should ideally be allocated
 /// to the same physical register. Bundles are formed by merging LiveRanges
 /// connected by Move instructions, block arguments, or tied operands.
-pub(all) struct Bundle {
+struct Bundle {
   id : Int
   range_ids : Array[Int] // Indices into LiveRangeSet
   mut spill_weight : Double // Priority for allocation (higher = more important)
@@ -141,7 +141,7 @@ pub fn Bundle::to_string(self : Bundle, _ranges : LiveRangeSet) -> String {
 /// A SpillBundle tracks a shared spill slot for split bundles.
 /// When a bundle is split, both parts share the same SpillBundle
 /// so they use the same stack slot.
-pub(all) struct SpillBundle {
+struct SpillBundle {
   id : Int
   slot : Int // Stack slot index
   bundle_ids : Array[Int] // Bundle IDs that share this spill slot
@@ -160,7 +160,7 @@ fn SpillBundle::add_bundle(self : SpillBundle, bundle_id : Int) -> Unit {
 
 ///|
 /// Collection of Bundles
-pub(all) struct BundleSet {
+struct BundleSet {
   bundles : Array[Bundle]
   spill_bundles : Array[SpillBundle]
   mut next_spill_slot : Int
@@ -301,7 +301,6 @@ pub fn compute_spill_weight(
       let base = match use_pos.kind {
         Def => 1.0
         Use => 1.0
-        DefUse => 2.0
       }
 
       // Loop depth multiplier (10x per nesting level)

--- a/vcode/regalloc/function.mbt
+++ b/vcode/regalloc/function.mbt
@@ -2,7 +2,7 @@
 
 ///|
 /// VCode function - a complete function in VCode form
-pub(all) struct VCodeFunction {
+pub struct VCodeFunction {
   name : String
   params : Array[@abi.VReg] // Function parameters
   results : Array[@abi.RegClass] // Result types (for return value allocation)

--- a/vcode/regalloc/liverange.mbt
+++ b/vcode/regalloc/liverange.mbt
@@ -4,7 +4,7 @@
 
 ///|
 /// A contiguous program point range (start inclusive, end exclusive)
-pub(all) struct ProgPointRange {
+struct ProgPointRange {
   start : ProgPoint
   end : ProgPoint
 }
@@ -51,10 +51,11 @@ pub fn ProgPointRange::contains(
 
 ///|
 /// Kind of use at a program point
-pub(all) enum UseKind {
+/// Note: For tied operands (same reg as both def and use), add a DefUse variant
+/// when VCodeInst supports tied operand representation.
+enum UseKind {
   Def // Definition (value produced)
   Use // Use (value consumed)
-  DefUse // Both def and use (e.g., tied operand)
 }
 
 ///|
@@ -62,7 +63,6 @@ fn UseKind::to_string(self : UseKind) -> String {
   match self {
     Def => "def"
     Use => "use"
-    DefUse => "def+use"
   }
 }
 
@@ -93,7 +93,7 @@ pub impl Show for OperandConstraint with output(self, logger) {
 
 ///|
 /// A use position within a LiveRange
-pub(all) struct UsePosition {
+struct UsePosition {
   point : ProgPoint
   kind : UseKind
   constraint : OperandConstraint
@@ -143,7 +143,7 @@ pub impl Show for Allocation with output(self, logger) {
 ///|
 /// A LiveRange represents the liveness of a single virtual register
 /// with precise span information and use constraints.
-pub(all) struct LiveRange {
+struct LiveRange {
   id : Int
   vreg : @abi.VReg
   ranges : Array[ProgPointRange] // Multiple non-overlapping spans
@@ -310,7 +310,7 @@ pub impl Show for LiveRange with output(self, logger) {
 
 ///|
 /// Collection of LiveRanges built from liveness analysis
-pub(all) struct LiveRangeSet {
+struct LiveRangeSet {
   ranges : Array[LiveRange]
   vreg_to_range : Map[Int, Int] // vreg.id -> range index
   block_order : FixedArray[Int] // Block execution order (O(1) lookup)

--- a/vcode/regalloc/pkg.generated.mbti
+++ b/vcode/regalloc/pkg.generated.mbti
@@ -47,31 +47,18 @@ pub fn process_constraints(VCodeFunction, RegAllocResult) -> Unit
 // Errors
 
 // Types and methods
-pub(all) struct AArch64StackFrame {
-  frame : StackFrame
-  use_fp : Bool
-  mut lr_slot : Int?
-  mut fp_slot : Int?
-}
+type AArch64StackFrame
 pub fn AArch64StackFrame::alloc_spill(Self, @abi.VReg) -> Int
 pub fn AArch64StackFrame::finalize(Self) -> Unit
 pub fn AArch64StackFrame::gen_epilogue(Self) -> Array[@instr.VCodeInst]
 pub fn AArch64StackFrame::gen_prologue(Self) -> Array[@instr.VCodeInst]
 pub fn AArch64StackFrame::new() -> Self
 pub fn AArch64StackFrame::save_callee_reg(Self, @abi.PReg) -> Int
-pub fn AArch64StackFrame::set_has_calls(Self) -> Unit
 pub fn AArch64StackFrame::setup(Self) -> Unit
 pub fn AArch64StackFrame::size(Self) -> Int
 pub impl Show for AArch64StackFrame
 
-pub(all) struct AllocStats {
-  mut num_vregs : Int
-  mut num_spill_slots : Int
-  num_spills : Int
-  num_reloads : Int
-  num_moves : Int
-  total_insts : Int
-}
+type AllocStats
 pub impl Show for AllocStats
 
 pub enum Allocation {
@@ -81,34 +68,12 @@ pub enum Allocation {
 }
 pub impl Show for Allocation
 
-pub(all) struct BacktrackingAllocator {
-  ranges : LiveRangeSet
-  bundles : BundleSet
-  int_reg_allocs : Map[Int, Array[ProgPointRange]]
-  float_reg_allocs : Map[Int, Array[ProgPointRange]]
-  int_reg_bundles : Map[Int, @set.Set[Int]]
-  float_reg_bundles : Map[Int, @set.Set[Int]]
-  mut queue : Array[QueueEntry]
-  int_regs : Array[@abi.PReg]
-  float_regs : Array[@abi.PReg]
-  callee_saved_int : Array[@abi.PReg]
-  callee_saved_float : Array[@abi.PReg]
-  block_order : FixedArray[Int]
-  func : VCodeFunction
-}
+type BacktrackingAllocator
 pub fn BacktrackingAllocator::allocate(Self) -> Unit
 pub fn BacktrackingAllocator::generate_result(Self) -> RegAllocResult
 pub fn BacktrackingAllocator::new(VCodeFunction, LiveRangeSet, BundleSet, Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg]) -> Self
 
-pub(all) struct Bundle {
-  id : Int
-  range_ids : Array[Int]
-  mut spill_weight : Double
-  mut spill_bundle_id : Int
-  mut allocation : Allocation
-  reg_class : @abi.RegClass
-  mut is_pinned : Bool
-}
+type Bundle
 pub fn Bundle::contains_range(Self, Int) -> Bool
 pub fn Bundle::crosses_call(Self, LiveRangeSet) -> Bool
 pub fn Bundle::get_fixed_reg(Self, LiveRangeSet) -> @abi.PReg?
@@ -118,45 +83,23 @@ pub fn Bundle::overlaps(Self, Self, LiveRangeSet) -> Bool
 pub fn Bundle::to_string(Self, LiveRangeSet) -> String
 pub fn Bundle::total_length(Self, LiveRangeSet) -> Int
 
-pub(all) struct BundleSet {
-  bundles : Array[Bundle]
-  spill_bundles : Array[SpillBundle]
-  mut next_spill_slot : Int
-}
+type BundleSet
 pub fn BundleSet::get(Self, Int) -> Bundle
 pub fn BundleSet::length(Self) -> Int
 pub fn BundleSet::new() -> Self
 
-pub(all) struct CoalescingInfo {
-  forward_hints : Map[Int, Int]
-  reverse_hints : Map[Int, Int]
-}
+type InstEdits
 
-pub(all) struct InstEdits {
-  before : Array[RegMove]
-  after : Array[RegMove]
-}
-
-pub(all) struct LinearScanAllocator {
-  int_regs : Array[@abi.PReg]
-  float_regs : Array[@abi.PReg]
-  callee_saved_int_regs : Array[@abi.PReg]
-  callee_saved_float_regs : Array[@abi.PReg]
-  mut active : Array[LiveInterval]
-  mut next_spill_slot : Int
-  mut block_order : FixedArray[Int]
-  reserved_int_regs : Map[(Int, Int), @set.Set[Int]]
-  reserved_float_regs : Map[(Int, Int), @set.Set[Int]]
-}
+type LinearScanAllocator
 pub fn LinearScanAllocator::allocate(Self, VCodeFunction, LivenessResult) -> RegAllocResult
 pub fn LinearScanAllocator::new(Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], callee_saved_float_regs? : Array[@abi.PReg]) -> Self
 
-pub(all) struct LiveInterval {
+pub struct LiveInterval {
   vreg : @abi.VReg
   start : ProgPoint
   mut end : ProgPoint
   uses : Array[ProgPoint]
-  mut hint : @abi.PReg?
+  hint : @abi.PReg?
   mut hint_vreg : Int?
   mut assigned : @abi.PReg?
   mut spill_slot : Int?
@@ -164,15 +107,7 @@ pub(all) struct LiveInterval {
 }
 pub impl Show for LiveInterval
 
-pub(all) struct LiveRange {
-  id : Int
-  vreg : @abi.VReg
-  ranges : Array[ProgPointRange]
-  uses : Array[UsePosition]
-  mut bundle_id : Int
-  mut allocation : Allocation
-  mut crosses_call : Bool
-}
+type LiveRange
 pub fn LiveRange::end(Self, FixedArray[Int]) -> ProgPoint?
 pub fn LiveRange::get_fixed_reg(Self) -> @abi.PReg?
 pub fn LiveRange::has_fixed_constraint(Self) -> Bool
@@ -182,16 +117,12 @@ pub fn LiveRange::start(Self, FixedArray[Int]) -> ProgPoint?
 pub fn LiveRange::total_length(Self) -> Int
 pub impl Show for LiveRange
 
-pub(all) struct LiveRangeSet {
-  ranges : Array[LiveRange]
-  vreg_to_range : Map[Int, Int]
-  block_order : FixedArray[Int]
-}
+type LiveRangeSet
 pub fn LiveRangeSet::get(Self, Int) -> LiveRange
 pub fn LiveRangeSet::get_by_vreg(Self, Int) -> LiveRange?
 pub fn LiveRangeSet::length(Self) -> Int
 
-pub(all) struct LivenessResult {
+pub struct LivenessResult {
   intervals : Map[Int, LiveInterval]
   use_def : Map[Int, UseDefInfo]
   live_in : Array[@set.Set[Int]]
@@ -206,18 +137,11 @@ pub enum OperandConstraint {
 }
 pub impl Show for OperandConstraint
 
-pub(all) struct ProgPoint {
-  block : Int
-  inst : Int
-  pos : ProgPos
-}
+type ProgPoint
 pub impl Eq for ProgPoint
 pub impl Show for ProgPoint
 
-pub(all) struct ProgPointRange {
-  start : ProgPoint
-  end : ProgPoint
-}
+type ProgPointRange
 pub fn ProgPointRange::contains(Self, ProgPoint, FixedArray[Int]) -> Bool
 pub impl Show for ProgPointRange
 
@@ -230,51 +154,20 @@ pub impl Eq for ProgPos
 type QueueEntry
 pub impl Eq for QueueEntry
 
-pub(all) struct RegAllocResult {
+pub struct RegAllocResult {
   assignments : Map[Int, @abi.PReg]
   spill_slots : Map[Int, Int]
   mut num_spill_slots : Int
-  spills : Array[SpillInfo]
-  reloads : Array[ReloadInfo]
   inst_edits : Map[(Int, Int), InstEdits]
 }
 
-pub(all) struct RegMove {
-  from : @abi.PReg
-  to : @abi.PReg
-  class : @abi.RegClass
-}
+type RegMove
 pub impl Show for RegMove
 
-pub(all) struct ReloadInfo {
-  vreg : @abi.VReg
-  slot : Int
-  preg : @abi.PReg
-  point : ProgPoint
-}
-
-pub(all) struct SpillBundle {
-  id : Int
-  slot : Int
-  bundle_ids : Array[Int]
-}
+type SpillBundle
 pub fn SpillBundle::new(Int, Int) -> Self
 
-pub(all) struct SpillInfo {
-  vreg : @abi.VReg
-  slot : Int
-  point : ProgPoint
-}
-
-pub(all) struct StackFrame {
-  slots : Array[StackSlot]
-  mut frame_size : Int
-  frame_align : Int
-  mut next_spill_offset : Int
-  mut next_arg_offset : Int
-  callee_saved_regs : Array[@abi.PReg]
-  mut has_calls : Bool
-}
+type StackFrame
 pub fn StackFrame::add_callee_saved(Self, @abi.PReg) -> Int
 pub fn StackFrame::alloc_local(Self, Int, Int, Int) -> Int
 pub fn StackFrame::alloc_outgoing_arg(Self, Int, Int, Int) -> Int
@@ -286,12 +179,7 @@ pub fn StackFrame::print(Self) -> String
 pub fn StackFrame::size(Self) -> Int
 pub impl Show for StackFrame
 
-pub(all) struct StackSlot {
-  offset : Int
-  size : Int
-  align : Int
-  kind : StackSlotKind
-}
+type StackSlot
 pub impl Show for StackSlot
 
 pub enum StackSlotKind {
@@ -302,10 +190,7 @@ pub enum StackSlotKind {
 }
 pub impl Show for StackSlotKind
 
-pub(all) struct UnionFind {
-  parent : Array[Int]
-  rank : Array[Int]
-}
+type UnionFind
 pub fn UnionFind::find(Self, Int) -> Int
 pub fn UnionFind::get_all_sets(Self) -> Array[Array[Int]]
 pub fn UnionFind::get_set(Self, Int) -> Array[Int]
@@ -315,27 +200,15 @@ pub fn UnionFind::num_sets(Self) -> Int
 pub fn UnionFind::same_set(Self, Int, Int) -> Bool
 pub fn UnionFind::union(Self, Int, Int) -> Bool
 
-pub(all) struct UseDefInfo {
-  vreg : @abi.VReg
-  mut def_point : ProgPoint?
-  use_points : Array[ProgPoint]
-}
+type UseDefInfo
 
-pub(all) enum UseKind {
-  Def
-  Use
-  DefUse
-}
+type UseKind
 pub impl Show for UseKind
 
-pub(all) struct UsePosition {
-  point : ProgPoint
-  kind : UseKind
-  constraint : OperandConstraint
-}
+type UsePosition
 pub impl Show for UsePosition
 
-pub(all) struct VCodeFunction {
+pub struct VCodeFunction {
   name : String
   params : Array[@abi.VReg]
   results : Array[@abi.RegClass]

--- a/vcode/regalloc/regalloc.mbt
+++ b/vcode/regalloc/regalloc.mbt
@@ -13,7 +13,7 @@
 /// A program point - identifies a position in the VCode
 /// Using #valtype for stack allocation - this struct is created/compared frequently
 #valtype
-pub(all) struct ProgPoint {
+struct ProgPoint {
   block : Int // Block index
   inst : Int // Instruction index within block (-1 for block params)
   pos : ProgPos // Before or after the instruction
@@ -67,14 +67,14 @@ pub impl Show for ProgPoint with output(self, logger) {
 
 ///|
 /// A live interval - the range where a virtual register is live
-pub(all) struct LiveInterval {
+pub struct LiveInterval {
   vreg : @abi.VReg
   start : ProgPoint // First use or definition
   mut end : ProgPoint // Last use
   // Use positions within the interval (for spill cost calculation)
   uses : Array[ProgPoint]
   // Register hint (e.g., from a move instruction)
-  mut hint : @abi.PReg?
+  hint : @abi.PReg?
   // Hint vreg: prefer to use the same register as this vreg (for copy coalescing)
   mut hint_vreg : Int?
   // Assigned physical register (filled by allocator)
@@ -136,7 +136,7 @@ pub impl Show for LiveInterval with output(self, logger) {
 
 ///|
 /// Use-def information for a single vreg
-pub(all) struct UseDefInfo {
+struct UseDefInfo {
   vreg : @abi.VReg
   mut def_point : ProgPoint? // Where this vreg is defined
   use_points : Array[ProgPoint] // Where this vreg is used
@@ -282,7 +282,7 @@ pub fn debug_liveness(liveness : LivenessResult) -> String {
 
 ///|
 /// Liveness analysis result
-pub(all) struct LivenessResult {
+pub struct LivenessResult {
   // Live intervals for each vreg
   intervals : Map[Int, LiveInterval]
   // Use-def chains
@@ -736,7 +736,7 @@ fn build_intervals(func : VCodeFunction, result : LivenessResult) -> Unit {
 ///|
 /// Coalescing pairs: maps vreg id -> list of vregs it wants to coalesce with
 /// Used for bidirectional hint propagation
-pub(all) struct CoalescingInfo {
+priv struct CoalescingInfo {
   // Forward hints: dst wants to use src's register (dst = mov src)
   forward_hints : Map[Int, Int]
   // Reverse hints: src wants to use dst's register (for cases where dst is allocated first)
@@ -825,7 +825,7 @@ fn resolve_vreg_hint(
 ///|
 /// A register move instruction (from regalloc constraint processing)
 /// Move operation between registers
-pub(all) struct RegMove {
+struct RegMove {
   from : @abi.PReg // Source register (or spill slot encoded as negative index)
   to : @abi.PReg // Destination register
   class : @abi.RegClass
@@ -844,7 +844,7 @@ pub impl Show for RegMove with output(self, logger) {
 ///|
 /// Edits to insert before/after an instruction
 /// Register constraint handling
-pub(all) struct InstEdits {
+struct InstEdits {
   before : Array[RegMove] // Moves to insert before the instruction
   after : Array[RegMove] // Moves to insert after the instruction
 }
@@ -973,41 +973,21 @@ fn resolve_parallel_moves(moves : Array[RegMove]) -> Array[RegMove] {
 
 ///|
 /// Register allocation result
-pub(all) struct RegAllocResult {
+pub struct RegAllocResult {
   // Map from vreg id to assigned physical register
   assignments : Map[Int, @abi.PReg]
   // Map from vreg id to spill slot (if spilled)
   spill_slots : Map[Int, Int]
   // Total number of spill slots used
   mut num_spill_slots : Int
-  // Instructions to insert (for spills/reloads)
-  spills : Array[SpillInfo]
-  reloads : Array[ReloadInfo]
   // Constraint edits: (block_idx, inst_idx) -> edits to insert
   // Fixed register constraint handling
   inst_edits : Map[(Int, Int), InstEdits]
 }
 
 ///|
-/// Information about a spill
-pub(all) struct SpillInfo {
-  vreg : @abi.VReg
-  slot : Int
-  point : ProgPoint
-}
-
-///|
-/// Information about a reload
-pub(all) struct ReloadInfo {
-  vreg : @abi.VReg
-  slot : Int
-  preg : @abi.PReg
-  point : ProgPoint
-}
-
-///|
 /// Linear scan register allocator
-pub(all) struct LinearScanAllocator {
+struct LinearScanAllocator {
   // Available physical registers by class
   int_regs : Array[@abi.PReg]
   float_regs : Array[@abi.PReg]
@@ -1154,8 +1134,6 @@ pub fn LinearScanAllocator::allocate(
     assignments: {},
     spill_slots: {},
     num_spill_slots: 0,
-    spills: [],
-    reloads: [],
     inst_edits: {},
   }
 
@@ -1368,29 +1346,8 @@ fn LinearScanAllocator::spill_interval(
   self.next_spill_slot = slot + 1
   interval.spill_slot = Some(slot)
   result.spill_slots.set(interval.vreg.id, slot)
-
-  // Record spill at definition point
-  if interval.start.pos is After {
-    result.spills.push({ vreg: interval.vreg, slot, point: interval.start })
-  }
-
-  // For each use, we need to reload into a temporary
-  // This is a simplified approach - a real allocator would be smarter
-  for use_point in interval.uses {
-    // Get a register for this reload (use first available)
-    let avail_regs = match interval.vreg.class {
-      @abi.Int => self.int_regs
-      @abi.Float32 | @abi.Float64 | @abi.Vector => self.float_regs
-    }
-    if avail_regs.length() > 0 {
-      result.reloads.push({
-        vreg: interval.vreg,
-        slot,
-        preg: avail_regs[0],
-        point: use_point,
-      })
-    }
-  }
+  // Note: Actual spill/reload instruction insertion happens in apply_allocation
+  // by inspecting spill_slots and inserting StackLoad/StackStore as needed
 }
 
 // ============ Constraint Processing ============
@@ -2178,7 +2135,7 @@ pub fn allocate_registers_backtracking(func : VCodeFunction) -> VCodeFunction {
 
 ///|
 /// Allocation statistics for comparison
-pub(all) struct AllocStats {
+struct AllocStats {
   mut num_vregs : Int // Total virtual registers
   mut num_spill_slots : Int // Number of spill slots used
   num_spills : Int // Number of spill operations

--- a/vcode/regalloc/stacklayout.mbt
+++ b/vcode/regalloc/stacklayout.mbt
@@ -11,7 +11,7 @@
 
 ///|
 /// A stack slot - a location on the stack
-pub(all) struct StackSlot {
+struct StackSlot {
   // Offset from frame pointer (negative = below FP, positive = above FP)
   offset : Int
   // Size in bytes
@@ -65,7 +65,7 @@ pub impl Show for StackSlot with output(self, logger) {
 
 ///|
 /// Stack frame layout for a function
-pub(all) struct StackFrame {
+struct StackFrame {
   // All stack slots
   slots : Array[StackSlot]
   // Total frame size (must be aligned)
@@ -78,8 +78,6 @@ pub(all) struct StackFrame {
   mut next_arg_offset : Int
   // Callee-saved registers used in this function
   callee_saved_regs : Array[@abi.PReg]
-  // Whether this function makes calls (affects stack layout)
-  mut has_calls : Bool
 }
 
 ///|
@@ -91,7 +89,6 @@ pub fn StackFrame::new(frame_align : Int) -> StackFrame {
     next_spill_offset: 0,
     next_arg_offset: 0,
     callee_saved_regs: [],
-    has_calls: false,
   }
 }
 
@@ -236,7 +233,7 @@ fn align_up(value : Int, align : Int) -> Int {
 
 ///|
 /// AArch64-specific stack frame configuration
-pub(all) struct AArch64StackFrame {
+struct AArch64StackFrame {
   frame : StackFrame
   // Whether to use frame pointer
   use_fp : Bool
@@ -283,12 +280,6 @@ pub fn AArch64StackFrame::alloc_spill(
     Vector => 16 // 128-bit SIMD vector
   }
   self.frame.alloc_spill_slot(vreg, size, size)
-}
-
-///|
-/// Mark that this function makes calls
-pub fn AArch64StackFrame::set_has_calls(self : AArch64StackFrame) -> Unit {
-  self.frame.has_calls = true
 }
 
 ///|
@@ -433,16 +424,6 @@ pub fn build_stack_layout_aarch64(
     }
   }
 
-  // Check if function makes any calls
-  for block in func.blocks {
-    for inst in block.insts {
-      if is_call_instruction(inst) {
-        frame.set_has_calls()
-        break
-      }
-    }
-  }
-
   // Finalize the frame
   frame.finalize()
   frame
@@ -467,12 +448,4 @@ fn find_vreg_by_id(func : VCodeFunction, id : Int) -> @abi.VReg? {
     }
   }
   None
-}
-
-///|
-fn is_call_instruction(inst : @instr.VCodeInst) -> Bool {
-  // For now, we don't have explicit call instructions in VCode
-  // This would be extended when we add call support
-  ignore(inst)
-  false
 }

--- a/vcode/regalloc/stacklayout_wbtest.mbt
+++ b/vcode/regalloc/stacklayout_wbtest.mbt
@@ -175,8 +175,6 @@ test "build_stack_layout: from regalloc result" {
     assignments: {},
     spill_slots: {},
     num_spill_slots: 0,
-    spills: [],
-    reloads: [],
     inst_edits: {},
   }
 

--- a/vcode/regalloc/union_find.mbt
+++ b/vcode/regalloc/union_find.mbt
@@ -4,7 +4,7 @@
 
 ///|
 /// Union-Find data structure for grouping LiveRanges into Bundles
-pub(all) struct UnionFind {
+struct UnionFind {
   parent : Array[Int] // Parent pointer (or self if root)
   rank : Array[Int] // Rank for union by rank heuristic
 }


### PR DESCRIPTION
## Summary

- Change type visibility from `pub(all)` to abstract for internal types
- Use `pub struct` (readonly) for types that need external field access: `VCodeFunction`, `LivenessResult`, `RegAllocResult`, `LiveInterval`
- Remove dead code that was never used:
  - `SpillInfo`/`ReloadInfo` structs and arrays
  - `has_calls` field and `set_has_calls()` function
  - `DefUse` enum variant (comment added for future tied operand support)
  - `is_call_instruction` helper function

## Test plan

- [x] `moon check` passes with no errors
- [x] `moon test -p vcode/regalloc` passes (43/43 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)