### PR TITLE
refactor: improve visibility across ir/, vcode/, and runtime/

### DIFF
--- a/ir/builder.mbt
+++ b/ir/builder.mbt
@@ -4,7 +4,7 @@
 ///|
 /// IRBuilder - helps construct IR functions
 /// Tracks the current block and provides methods for emitting instructions
-pub(all) struct IRBuilder {
+struct IRBuilder {
   func : Function
   mut current_block : Block?
 }

--- a/ir/cfg.mbt
+++ b/ir/cfg.mbt
@@ -4,7 +4,7 @@
 ///|
 /// CFG - Control Flow Graph for a function
 /// Provides predecessor/successor relationships for each block
-pub(all) struct CFG {
+pub struct CFG {
   // Number of blocks in the CFG
   num_blocks : Int
   // Successors for each block (indexed by block ID)
@@ -273,7 +273,7 @@ pub fn CFG::to_dot(self : CFG, func_name : String) -> String {
 
 ///|
 /// Loop - represents a natural loop in the CFG
-pub(all) struct Loop {
+pub struct Loop {
   header : Int // Loop header block (target of back edge)
   blocks : Array[Int] // All blocks in the loop body
   back_edges : Array[(Int, Int)] // Back edges (source, target) for this loop

--- a/ir/egraph/egraph.mbt
+++ b/ir/egraph/egraph.mbt
@@ -123,7 +123,7 @@ pub(all) enum EOpcode {
 
 ///|
 /// E-opcode tag for indexing (ignores parameters like Const value)
-pub(all) enum EOpcodeTag {
+enum EOpcodeTag {
   TConst
   TFconst
   // Arithmetic
@@ -302,7 +302,7 @@ pub(all) struct ENode {
 ///|
 /// E-class: an equivalence class of e-nodes
 #warnings("-unused_field")
-struct EClass {
+priv struct EClass {
   id : EClassId
   mut nodes : Array[ENode] // All equivalent nodes in this class
   // For extraction: best node and its cost (lazily computed)
@@ -312,7 +312,7 @@ struct EClass {
 
 ///|
 /// Union-Find data structure for e-class merging
-struct UnionFind {
+priv struct UnionFind {
   // parent[i] = parent of i, or i if i is a root
   parent : Array[Int]
 }
@@ -365,7 +365,7 @@ let matches_limit : Int = 5 // Max rewrites per add_eager call
 
 ///|
 /// The main E-graph data structure
-pub(all) struct EGraph {
+struct EGraph {
   // Union-find for equivalence classes
   uf : UnionFind
   // All e-classes (indexed by canonical id)
@@ -1385,8 +1385,7 @@ fn EGraph::extract_impl(
 
 ///|
 /// A rewrite rule matches a pattern and produces equivalent expressions
-pub(all) struct RewriteRule {
-  name : String
+struct RewriteRule {
   apply : (EGraph, EClassId) -> Bool // Returns true if any changes were made
 }
 
@@ -1428,13 +1427,13 @@ pub fn EGraph::saturate(
 
 ///|
 /// An indexed rule with its RewriteRule
-struct IndexedRule {
+priv struct IndexedRule {
   rule : RewriteRule
 }
 
 ///|
 /// An indexed rule set for efficient rule application
-pub(all) struct IndexedRuleSet {
+struct IndexedRuleSet {
   // Rules indexed by the opcode they match
   by_opcode : Map[EOpcodeTag, Array[IndexedRule]]
   // Rules that match any opcode (e.g., constant folding)

--- a/ir/egraph/pkg.generated.mbti
+++ b/ir/egraph/pkg.generated.mbti
@@ -1,10 +1,6 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "Milky2018/wasmoon/ir/egraph"
 
-import(
-  "moonbitlang/core/hashset"
-)
-
 // Values
 pub fn remat_rules() -> Array[RewriteRule]
 
@@ -27,8 +23,6 @@ pub fn vector_rules() -> Array[RewriteRule]
 // Errors
 
 // Types and methods
-type EClass
-
 pub(all) struct EClassId(Int)
 #deprecated
 pub fn EClassId::inner(Self) -> Int
@@ -37,17 +31,7 @@ pub impl Eq for EClassId
 pub impl Hash for EClassId
 pub impl Show for EClassId
 
-pub(all) struct EGraph {
-  uf : UnionFind
-  classes : Map[Int, EClass]
-  mut hashcons : Map[ENode, EClassId]
-  mut worklist : Array[EClassId]
-  mut dirty : Bool
-  opcode_index : Map[EOpcodeTag, @hashset.HashSet[Int]]
-  mut pending_rules : Array[(EClassId, EOpcodeTag)]
-  type_map : Map[Int, Int]
-  remat_set : @hashset.HashSet[Int]
-}
+type EGraph
 pub fn EGraph::add(Self, ENode) -> EClassId
 pub fn EGraph::add_add(Self, EClassId, EClassId) -> EClassId
 pub fn EGraph::add_and(Self, EClassId, EClassId) -> EClassId
@@ -206,88 +190,14 @@ pub impl Eq for EOpcode
 pub impl Hash for EOpcode
 pub impl Show for EOpcode
 
-pub(all) enum EOpcodeTag {
-  TConst
-  TFconst
-  TAdd
-  TSub
-  TMul
-  TSdiv
-  TUdiv
-  TSrem
-  TUrem
-  TAnd
-  TOr
-  TXor
-  TShl
-  TSshr
-  TUshr
-  TRotl
-  TRotr
-  TNeg
-  TBnot
-  TClz
-  TCtz
-  TPopcnt
-  TBswap
-  TBitrev
-  TIcmp
-  TEq
-  TNe
-  TSelect
-  TBmask
-  TSmin
-  TSmax
-  TUmin
-  TUmax
-  TIabs
-  TSpaceshipS
-  TSpaceshipU
-  TIreduce
-  TUextend
-  TSextend
-  TFadd
-  TFsub
-  TFmul
-  TFdiv
-  TFmin
-  TFmax
-  TFcopysign
-  TFneg
-  TFabs
-  TFsqrt
-  TFceil
-  TFfloor
-  TFtrunc
-  TFnearest
-  TFcmp
-  TFpromote
-  TFdemote
-  TFcvtToSint
-  TFcvtToUint
-  TSintToFcvt
-  TUintToFcvt
-  TSplat
-  TVconst
-  TVar
-}
+type EOpcodeTag
 pub impl Eq for EOpcodeTag
 pub impl Hash for EOpcodeTag
 pub impl Show for EOpcodeTag
 
-type IndexedRule
+type IndexedRuleSet
 
-pub(all) struct IndexedRuleSet {
-  by_opcode : Map[EOpcodeTag, Array[IndexedRule]]
-  universal : Array[IndexedRule]
-}
-
-pub(all) struct RewriteRule {
-  name : String
-  apply : (EGraph, EClassId) -> Bool
-}
-
-type UnionFind
+type RewriteRule
 
 // Type aliases
 

--- a/ir/egraph/rules_algebraic.mbt
+++ b/ir/egraph/rules_algebraic.mbt
@@ -8,7 +8,6 @@
 /// This helps recognize negation patterns
 fn rule_neg_zero() -> RewriteRule {
   {
-    name: "neg_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -31,7 +30,6 @@ fn rule_neg_zero() -> RewriteRule {
 /// x - (0 - y) = x + y
 fn rule_sub_neg() -> RewriteRule {
   {
-    name: "sub_neg",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -57,7 +55,6 @@ fn rule_sub_neg() -> RewriteRule {
 /// x + (0 - y) = x - y
 fn rule_add_neg() -> RewriteRule {
   {
-    name: "add_neg",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -87,7 +84,6 @@ fn rule_add_neg() -> RewriteRule {
 /// (a * c1) * c2 = a * (c1 * c2) - reassociate multiplication constants
 fn rule_reassoc_mul_const() -> RewriteRule {
   {
-    name: "reassoc_mul_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -116,7 +112,6 @@ fn rule_reassoc_mul_const() -> RewriteRule {
 /// (a - c1) - c2 = a - (c1 + c2)
 fn rule_reassoc_sub_const() -> RewriteRule {
   {
-    name: "reassoc_sub_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -145,7 +140,6 @@ fn rule_reassoc_sub_const() -> RewriteRule {
 /// x * -1 = -x
 fn rule_mul_neg_one() -> RewriteRule {
   {
-    name: "mul_neg_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -173,7 +167,6 @@ fn rule_mul_neg_one() -> RewriteRule {
 /// -x * -y = x * y
 fn rule_neg_mul_neg() -> RewriteRule {
   {
-    name: "neg_mul_neg",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -209,7 +202,6 @@ fn rule_neg_mul_neg() -> RewriteRule {
 /// (x - y) + y = x
 fn rule_sub_add_cancel() -> RewriteRule {
   {
-    name: "sub_add_cancel",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -245,7 +237,6 @@ fn rule_sub_add_cancel() -> RewriteRule {
 /// (x + y) - y = x, (x + y) - x = y
 fn rule_add_sub_cancel() -> RewriteRule {
   {
-    name: "add_sub_cancel",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -275,7 +266,6 @@ fn rule_add_sub_cancel() -> RewriteRule {
 /// (x - y) - x = -y
 fn rule_sub_sub_cancel() -> RewriteRule {
   {
-    name: "sub_sub_cancel",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -301,7 +291,6 @@ fn rule_sub_sub_cancel() -> RewriteRule {
 /// x / -1 = -x (signed division)
 fn rule_sdiv_neg_one() -> RewriteRule {
   {
-    name: "sdiv_neg_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -322,7 +311,6 @@ fn rule_sdiv_neg_one() -> RewriteRule {
 /// x % -1 = 0 (signed remainder)
 fn rule_srem_neg_one() -> RewriteRule {
   {
-    name: "srem_neg_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -343,7 +331,6 @@ fn rule_srem_neg_one() -> RewriteRule {
 /// x / 1 = x (signed and unsigned)
 fn rule_div_one() -> RewriteRule {
   {
-    name: "div_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -367,7 +354,6 @@ fn rule_div_one() -> RewriteRule {
 /// x % 1 = 0 (signed and unsigned)
 fn rule_rem_one() -> RewriteRule {
   {
-    name: "rem_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -392,7 +378,6 @@ fn rule_rem_one() -> RewriteRule {
 /// (!x) + 1 = -x (two's complement negation)
 fn rule_bnot_add_one() -> RewriteRule {
   {
-    name: "bnot_add_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -428,7 +413,6 @@ fn rule_bnot_add_one() -> RewriteRule {
 /// !(x - 1) = -x
 fn rule_bnot_sub_one() -> RewriteRule {
   {
-    name: "bnot_sub_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -453,7 +437,6 @@ fn rule_bnot_sub_one() -> RewriteRule {
 /// !(x + (-1)) = -x
 fn rule_bnot_add_neg_one() -> RewriteRule {
   {
-    name: "bnot_add_neg_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -478,7 +461,6 @@ fn rule_bnot_add_neg_one() -> RewriteRule {
 /// or(x, C) + (-C) = and(x, ~C)
 fn rule_or_add_neg() -> RewriteRule {
   {
-    name: "or_add_neg",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -509,7 +491,6 @@ fn rule_or_add_neg() -> RewriteRule {
 /// (x + y) - (x | y) = x & y
 fn rule_add_sub_or_to_and() -> RewriteRule {
   {
-    name: "add_sub_or_to_and",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -544,7 +525,6 @@ fn rule_add_sub_or_to_and() -> RewriteRule {
 /// x * (1 << y) = x << y
 fn rule_mul_shl_one() -> RewriteRule {
   {
-    name: "mul_shl_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -588,7 +568,6 @@ fn rule_mul_shl_one() -> RewriteRule {
 /// ineg(isub(y, x)) = isub(x, y)
 fn rule_neg_sub_swap() -> RewriteRule {
   {
-    name: "neg_sub_swap",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_bitwise.mbt
+++ b/ir/egraph/rules_bitwise.mbt
@@ -7,7 +7,6 @@
 /// x & 0 = 0
 fn rule_and_zero() -> RewriteRule {
   {
-    name: "and_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -29,7 +28,6 @@ fn rule_and_zero() -> RewriteRule {
 /// x | 0 = x
 fn rule_or_zero() -> RewriteRule {
   {
-    name: "or_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -52,7 +50,6 @@ fn rule_or_zero() -> RewriteRule {
 /// x ^ 0 = x
 fn rule_xor_zero() -> RewriteRule {
   {
-    name: "xor_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -75,7 +72,6 @@ fn rule_xor_zero() -> RewriteRule {
 /// x & -1 = x (all bits set)
 fn rule_and_all_ones() -> RewriteRule {
   {
-    name: "and_all_ones",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -98,7 +94,6 @@ fn rule_and_all_ones() -> RewriteRule {
 /// x | -1 = -1
 fn rule_or_all_ones() -> RewriteRule {
   {
-    name: "or_all_ones",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -120,7 +115,6 @@ fn rule_or_all_ones() -> RewriteRule {
 /// x | x = x (or idempotent)
 fn rule_or_self() -> RewriteRule {
   {
-    name: "or_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -140,7 +134,6 @@ fn rule_or_self() -> RewriteRule {
 /// x ^ ~x = -1, ~x ^ x = -1
 fn rule_xor_not() -> RewriteRule {
   {
-    name: "xor_not",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -178,7 +171,6 @@ fn rule_xor_not() -> RewriteRule {
 /// x | ~x = -1, ~x | x = -1
 fn rule_or_not() -> RewriteRule {
   {
-    name: "or_not",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -216,7 +208,6 @@ fn rule_or_not() -> RewriteRule {
 /// x & ~x = 0, ~x & x = 0
 fn rule_and_not() -> RewriteRule {
   {
-    name: "and_not",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -254,7 +245,6 @@ fn rule_and_not() -> RewriteRule {
 /// ~~x = x (double negation)
 fn rule_double_bnot() -> RewriteRule {
   {
-    name: "double_bnot",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -276,7 +266,6 @@ fn rule_double_bnot() -> RewriteRule {
 /// DeMorgan: ~(x | y) = ~x & ~y
 fn rule_demorgan_or() -> RewriteRule {
   {
-    name: "demorgan_or",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -301,7 +290,6 @@ fn rule_demorgan_or() -> RewriteRule {
 /// DeMorgan: ~(x & y) = ~x | ~y
 fn rule_demorgan_and() -> RewriteRule {
   {
-    name: "demorgan_and",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -326,7 +314,6 @@ fn rule_demorgan_and() -> RewriteRule {
 /// x ^ -1 = ~x
 fn rule_xor_all_ones() -> RewriteRule {
   {
-    name: "xor_all_ones",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -351,7 +338,6 @@ fn rule_xor_all_ones() -> RewriteRule {
 /// (x & y) ^ (x ^ y) = x | y
 fn rule_and_xor_xor() -> RewriteRule {
   {
-    name: "and_xor_xor",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -413,7 +399,6 @@ fn rule_and_xor_xor() -> RewriteRule {
 /// (x | y) ^ (x & y) = x ^ y
 fn rule_or_xor_and() -> RewriteRule {
   {
-    name: "or_xor_and",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -475,7 +460,6 @@ fn rule_or_xor_and() -> RewriteRule {
 /// (x & y) | x = x (absorption)
 fn rule_and_or_absorb() -> RewriteRule {
   {
-    name: "and_or_absorb",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -513,7 +497,6 @@ fn rule_and_or_absorb() -> RewriteRule {
 /// (x ^ y) ^ y = x
 fn rule_xor_xor_cancel() -> RewriteRule {
   {
-    name: "xor_xor_cancel",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -555,7 +538,6 @@ fn rule_xor_xor_cancel() -> RewriteRule {
 /// (z & x) ^ (z & y) = z & (x ^ y)
 fn rule_factor_and_xor() -> RewriteRule {
   {
-    name: "factor_and_xor",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -599,7 +581,6 @@ fn rule_factor_and_xor() -> RewriteRule {
 /// (x & y) + (x ^ y) = x | y
 fn rule_and_add_xor() -> RewriteRule {
   {
-    name: "and_add_xor",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -661,7 +642,6 @@ fn rule_and_add_xor() -> RewriteRule {
 /// (x | y) + (x & y) = x + y
 fn rule_or_add_and() -> RewriteRule {
   {
-    name: "or_add_and",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -724,7 +704,6 @@ fn rule_or_add_and() -> RewriteRule {
 /// (x & y) | ~y = x | ~y
 fn rule_or_and_not() -> RewriteRule {
   {
-    name: "or_and_not",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -786,7 +765,6 @@ fn rule_or_and_not() -> RewriteRule {
 /// (x | y) | x = x | y (or absorption with nested or)
 fn rule_or_or_absorb() -> RewriteRule {
   {
-    name: "or_or_absorb",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -826,7 +804,6 @@ fn rule_or_or_absorb() -> RewriteRule {
 /// (x & y) & x = x & y (and absorption with nested and)
 fn rule_and_and_absorb() -> RewriteRule {
   {
-    name: "and_and_absorb",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -866,7 +843,6 @@ fn rule_and_and_absorb() -> RewriteRule {
 /// (x ^ ~y) & x = x & y
 fn rule_xor_not_and() -> RewriteRule {
   {
-    name: "xor_not_and",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -946,7 +922,6 @@ fn rule_xor_not_and() -> RewriteRule {
 /// (x & y) | ~x = y | ~x
 fn rule_and_or_not() -> RewriteRule {
   {
-    name: "and_or_not",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_comm.mbt
+++ b/ir/egraph/rules_comm.mbt
@@ -7,7 +7,6 @@
 /// x + y = y + x (commutativity of addition)
 fn rule_add_comm() -> RewriteRule {
   {
-    name: "add_comm",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -26,7 +25,6 @@ fn rule_add_comm() -> RewriteRule {
 /// x * y = y * x (commutativity of multiplication)
 fn rule_mul_comm() -> RewriteRule {
   {
-    name: "mul_comm",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -45,7 +43,6 @@ fn rule_mul_comm() -> RewriteRule {
 /// x & y = y & x (commutativity of and)
 fn rule_and_comm() -> RewriteRule {
   {
-    name: "and_comm",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -64,7 +61,6 @@ fn rule_and_comm() -> RewriteRule {
 /// x | y = y | x (commutativity of or)
 fn rule_or_comm() -> RewriteRule {
   {
-    name: "or_comm",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -83,7 +79,6 @@ fn rule_or_comm() -> RewriteRule {
 /// x ^ y = y ^ x (commutativity of xor)
 fn rule_xor_comm() -> RewriteRule {
   {
-    name: "xor_comm",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_const.mbt
+++ b/ir/egraph/rules_const.mbt
@@ -3,7 +3,6 @@
 ///|
 fn rule_mul_pow2() -> RewriteRule {
   {
-    name: "mul_pow2",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -37,7 +36,6 @@ fn rule_mul_pow2() -> RewriteRule {
 /// x + x = x * 2 = x << 1
 fn rule_double() -> RewriteRule {
   {
-    name: "double",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -60,7 +58,6 @@ fn rule_double() -> RewriteRule {
 /// Constant folding for binary and unary operations
 fn rule_const_fold() -> RewriteRule {
   {
-    name: "const_fold",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -223,7 +220,6 @@ fn bitrev64(x : Int64) -> Int64 {
 /// (a | c1) | c2 = a | (c1 | c2) - reassociate or constants
 fn rule_reassoc_or_const() -> RewriteRule {
   {
-    name: "reassoc_or_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -252,7 +248,6 @@ fn rule_reassoc_or_const() -> RewriteRule {
 /// (a & c1) & c2 = a & (c1 & c2) - reassociate and constants
 fn rule_reassoc_and_const() -> RewriteRule {
   {
-    name: "reassoc_and_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -281,7 +276,6 @@ fn rule_reassoc_and_const() -> RewriteRule {
 /// (a ^ c1) ^ c2 = a ^ (c1 ^ c2) - reassociate xor constants
 fn rule_reassoc_xor_const() -> RewriteRule {
   {
-    name: "reassoc_xor_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -310,7 +304,6 @@ fn rule_reassoc_xor_const() -> RewriteRule {
 /// (a + c1) + c2 = a + (c1 + c2) - reassociate constants
 fn rule_reassoc_add_const() -> RewriteRule {
   {
-    name: "reassoc_add_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -342,7 +335,6 @@ fn rule_reassoc_add_const() -> RewriteRule {
 /// (sub (add x k1) k2) = add x (k1 - k2) when k1 > k2
 fn rule_reassoc_sub_add_const() -> RewriteRule {
   {
-    name: "reassoc_sub_add_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -371,7 +363,6 @@ fn rule_reassoc_sub_add_const() -> RewriteRule {
 /// (add (sub x k1) k2) = add x (k2 - k1)
 fn rule_reassoc_add_sub_const() -> RewriteRule {
   {
-    name: "reassoc_add_sub_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -400,7 +391,6 @@ fn rule_reassoc_add_sub_const() -> RewriteRule {
 /// (sub (sub k1 x) k2) = sub (k1 - k2) x
 fn rule_reassoc_sub_sub_const_left() -> RewriteRule {
   {
-    name: "reassoc_sub_sub_const_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -429,7 +419,6 @@ fn rule_reassoc_sub_sub_const_left() -> RewriteRule {
 /// (add (sub k1 x) k2) = sub (k1 + k2) x
 fn rule_reassoc_add_sub_const_left() -> RewriteRule {
   {
-    name: "reassoc_add_sub_const_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -458,7 +447,6 @@ fn rule_reassoc_add_sub_const_left() -> RewriteRule {
 /// Shift reassociation: ((A shl b) shl C) => ((A shl C) shl b) when A is const
 fn rule_reassoc_shl_const() -> RewriteRule {
   {
-    name: "reassoc_shl_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -491,7 +479,6 @@ fn rule_reassoc_shl_const() -> RewriteRule {
 /// Shift reassociation: ((A ushr b) ushr C) => ((A ushr C) ushr b) when A is const
 fn rule_reassoc_ushr_const() -> RewriteRule {
   {
-    name: "reassoc_ushr_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -525,7 +512,6 @@ fn rule_reassoc_ushr_const() -> RewriteRule {
 /// Shift reassociation: ((A sshr b) sshr C) => ((A sshr C) sshr b) when A is const
 fn rule_reassoc_sshr_const() -> RewriteRule {
   {
-    name: "reassoc_sshr_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -560,7 +546,6 @@ fn rule_reassoc_sshr_const() -> RewriteRule {
 /// select(0, _, y) -> y
 fn rule_select_const() -> RewriteRule {
   {
-    name: "select_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -587,7 +572,6 @@ fn rule_select_const() -> RewriteRule {
 /// This helps simplify patterns like x - (-5) -> x + 5
 fn rule_sub_neg_const() -> RewriteRule {
   {
-    name: "sub_neg_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -613,7 +597,6 @@ fn rule_sub_neg_const() -> RewriteRule {
 /// where B and D are constants
 fn rule_rebalance_add_consts() -> RewriteRule {
   {
-    name: "rebalance_add_consts",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -647,7 +630,6 @@ fn rule_rebalance_add_consts() -> RewriteRule {
 /// Tree rebalancing for mul: ((a * B) * (c * D)) -> ((a * c) * (B * D))
 fn rule_rebalance_mul_consts() -> RewriteRule {
   {
-    name: "rebalance_mul_consts",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -680,7 +662,6 @@ fn rule_rebalance_mul_consts() -> RewriteRule {
 /// Tree rebalancing for and: ((a & B) & (c & D)) -> ((a & c) & (B & D))
 fn rule_rebalance_and_consts() -> RewriteRule {
   {
-    name: "rebalance_and_consts",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -713,7 +694,6 @@ fn rule_rebalance_and_consts() -> RewriteRule {
 /// Tree rebalancing for or: ((a | B) | (c | D)) -> ((a | c) | (B | D))
 fn rule_rebalance_or_consts() -> RewriteRule {
   {
-    name: "rebalance_or_consts",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -746,7 +726,6 @@ fn rule_rebalance_or_consts() -> RewriteRule {
 /// Tree rebalancing for xor: ((a ^ B) ^ (c ^ D)) -> ((a ^ c) ^ (B ^ D))
 fn rule_rebalance_xor_consts() -> RewriteRule {
   {
-    name: "rebalance_xor_consts",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_extends.mbt
+++ b/ir/egraph/rules_extends.mbt
@@ -6,7 +6,6 @@
 /// Chained unsigned extends can be collapsed
 fn rule_uextend_uextend() -> RewriteRule {
   {
-    name: "uextend_uextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -42,7 +41,6 @@ fn rule_uextend_uextend() -> RewriteRule {
 /// Chained signed extends can be collapsed
 fn rule_sextend_sextend() -> RewriteRule {
   {
-    name: "sextend_sextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -78,7 +76,6 @@ fn rule_sextend_sextend() -> RewriteRule {
 /// Once unsigned extended, sign-extending is the same as zero-extending
 fn rule_sextend_uextend() -> RewriteRule {
   {
-    name: "sextend_uextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -114,7 +111,6 @@ fn rule_sextend_uextend() -> RewriteRule {
 /// icmp results are 0 or 1, so sign-extending is the same as zero-extending
 fn rule_sextend_icmp() -> RewriteRule {
   {
-    name: "sextend_icmp",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -149,7 +145,6 @@ fn rule_sextend_icmp() -> RewriteRule {
 /// Reduction of an extend back to original type is identity
 fn rule_ireduce_uextend() -> RewriteRule {
   {
-    name: "ireduce_uextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -185,7 +180,6 @@ fn rule_ireduce_uextend() -> RewriteRule {
 /// Reduction of an extend back to original type is identity
 fn rule_ireduce_sextend() -> RewriteRule {
   {
-    name: "ireduce_sextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -220,7 +214,6 @@ fn rule_ireduce_sextend() -> RewriteRule {
 /// Bitwise AND can be pushed inside uextends
 fn rule_band_uextend() -> RewriteRule {
   {
-    name: "band_uextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -264,7 +257,6 @@ fn rule_band_uextend() -> RewriteRule {
 /// Bitwise OR can be pushed inside uextends
 fn rule_bor_uextend() -> RewriteRule {
   {
-    name: "bor_uextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -308,7 +300,6 @@ fn rule_bor_uextend() -> RewriteRule {
 /// Bitwise XOR can be pushed inside uextends
 fn rule_bxor_uextend() -> RewriteRule {
   {
-    name: "bxor_uextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -352,7 +343,6 @@ fn rule_bxor_uextend() -> RewriteRule {
 /// Reduction can be pushed inside negation
 fn rule_ireduce_ineg() -> RewriteRule {
   {
-    name: "ireduce_ineg",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -385,7 +375,6 @@ fn rule_ireduce_ineg() -> RewriteRule {
 /// Reduction can be pushed inside bitwise NOT
 fn rule_ireduce_bnot() -> RewriteRule {
   {
-    name: "ireduce_bnot",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -418,7 +407,6 @@ fn rule_ireduce_bnot() -> RewriteRule {
 /// Reduction can be pushed inside addition
 fn rule_ireduce_iadd() -> RewriteRule {
   {
-    name: "ireduce_iadd",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -458,7 +446,6 @@ fn rule_ireduce_iadd() -> RewriteRule {
 /// Reduction can be pushed inside subtraction
 fn rule_ireduce_isub() -> RewriteRule {
   {
-    name: "ireduce_isub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -498,7 +485,6 @@ fn rule_ireduce_isub() -> RewriteRule {
 /// Reduction can be pushed inside multiplication
 fn rule_ireduce_imul() -> RewriteRule {
   {
-    name: "ireduce_imul",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -538,7 +524,6 @@ fn rule_ireduce_imul() -> RewriteRule {
 /// Reduction can be pushed inside bitwise AND
 fn rule_ireduce_band() -> RewriteRule {
   {
-    name: "ireduce_band",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -578,7 +563,6 @@ fn rule_ireduce_band() -> RewriteRule {
 /// Reduction can be pushed inside bitwise OR
 fn rule_ireduce_bor() -> RewriteRule {
   {
-    name: "ireduce_bor",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -618,7 +602,6 @@ fn rule_ireduce_bor() -> RewriteRule {
 /// Reduction can be pushed inside bitwise XOR
 fn rule_ireduce_bxor() -> RewriteRule {
   {
-    name: "ireduce_bxor",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -658,7 +641,6 @@ fn rule_ireduce_bxor() -> RewriteRule {
 /// Sign-extending can't change whether a number is zero
 fn rule_eq_sextend_zero() -> RewriteRule {
   {
-    name: "eq_sextend_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -716,7 +698,6 @@ fn rule_eq_sextend_zero() -> RewriteRule {
 /// Sign-extending can't change whether a number is zero
 fn rule_ne_sextend_zero() -> RewriteRule {
   {
-    name: "ne_sextend_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -781,7 +762,6 @@ fn is_signed_cc(cc : Int) -> Bool {
 /// Sign-extending doesn't change signed comparisons with zero
 fn rule_icmp_sextend_zero() -> RewriteRule {
   {
-    name: "icmp_sextend_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -822,7 +802,6 @@ fn rule_icmp_sextend_zero() -> RewriteRule {
 /// Chained reduces can be collapsed (use outermost from_bits and innermost to_bits)
 fn rule_ireduce_ireduce() -> RewriteRule {
   {
-    name: "ireduce_ireduce",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -859,7 +838,6 @@ fn rule_ireduce_ireduce() -> RewriteRule {
 /// Note: This is only valid when the result type is large enough to not overflow
 fn rule_iadd_uextend() -> RewriteRule {
   {
-    name: "iadd_uextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -903,7 +881,6 @@ fn rule_iadd_uextend() -> RewriteRule {
 /// Subtraction of uextended values produces a signed result
 fn rule_isub_uextend() -> RewriteRule {
   {
-    name: "isub_uextend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -947,7 +924,6 @@ fn rule_isub_uextend() -> RewriteRule {
 /// Shift amount doesn't need to be reduced, only the value being shifted
 fn rule_ireduce_ishl() -> RewriteRule {
   {
-    name: "ireduce_ishl",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -983,7 +959,6 @@ fn rule_ireduce_ishl() -> RewriteRule {
 /// Zero-extended values are always non-negative, so slt with 0 is always false
 fn rule_slt_uextend_zero() -> RewriteRule {
   {
-    name: "slt_uextend_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1019,7 +994,6 @@ fn rule_slt_uextend_zero() -> RewriteRule {
 /// Zero-extended values are always non-negative, so sge with 0 is always true
 fn rule_sge_uextend_zero() -> RewriteRule {
   {
-    name: "sge_uextend_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1061,7 +1035,6 @@ fn is_type_mask(c : Int64) -> Bool {
 /// If masking with 0xFF/0xFFFF/0xFFFFFFFF and value is uextended, mask is no-op
 fn rule_band_uextend_mask() -> RewriteRule {
   {
-    name: "band_uextend_mask",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1118,7 +1091,6 @@ fn rule_band_uextend_mask() -> RewriteRule {
 /// Masking out the sign-extended bits turns sextend into uextend
 fn rule_band_sextend_mask() -> RewriteRule {
   {
-    name: "band_sextend_mask",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1195,7 +1167,6 @@ fn mask_for_bits(bits : Int) -> Int64 {
 /// Constant folding through integer reduction - truncate constant to target width
 fn rule_ireduce_const() -> RewriteRule {
   {
-    name: "ireduce_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1229,7 +1200,6 @@ fn rule_ireduce_const() -> RewriteRule {
 /// Extending to the same width is a no-op
 fn rule_uextend_identity() -> RewriteRule {
   {
-    name: "uextend_identity",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1253,7 +1223,6 @@ fn rule_uextend_identity() -> RewriteRule {
 /// Extending to the same width is a no-op
 fn rule_sextend_identity() -> RewriteRule {
   {
-    name: "sextend_identity",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1277,7 +1246,6 @@ fn rule_sextend_identity() -> RewriteRule {
 /// Reducing to the same width is a no-op
 fn rule_ireduce_identity() -> RewriteRule {
   {
-    name: "ireduce_identity",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1301,7 +1269,6 @@ fn rule_ireduce_identity() -> RewriteRule {
 /// More precise version that uses actual bit width information
 fn rule_band_uextend_mask_precise() -> RewriteRule {
   {
-    name: "band_uextend_mask_precise",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1359,7 +1326,6 @@ fn rule_band_uextend_mask_precise() -> RewriteRule {
 /// If we're reducing to a size smaller than the original, skip the extend
 fn rule_ireduce_uextend_skip() -> RewriteRule {
   {
-    name: "ireduce_uextend_skip",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1396,7 +1362,6 @@ fn rule_ireduce_uextend_skip() -> RewriteRule {
 /// If we're reducing to a size smaller than the original, skip the extend
 fn rule_ireduce_sextend_skip() -> RewriteRule {
   {
-    name: "ireduce_sextend_skip",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1433,7 +1398,6 @@ fn rule_ireduce_sextend_skip() -> RewriteRule {
 /// If we're "reducing" to a larger size than the original, it's actually an extend
 fn rule_ireduce_uextend_to_extend() -> RewriteRule {
   {
-    name: "ireduce_uextend_to_extend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1470,7 +1434,6 @@ fn rule_ireduce_uextend_to_extend() -> RewriteRule {
 /// If we're "reducing" to a larger size than the original, it's actually a sign extend
 fn rule_ireduce_sextend_to_extend() -> RewriteRule {
   {
-    name: "ireduce_sextend_to_extend",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_float.mbt
+++ b/ir/egraph/rules_float.mbt
@@ -6,7 +6,6 @@
 /// Only folds when the result is not NaN (except fneg/fabs/fcopysign)
 fn rule_fconst_fold_binary() -> RewriteRule {
   {
-    name: "fconst_fold_binary",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -89,7 +88,6 @@ fn rule_fconst_fold_binary() -> RewriteRule {
 /// Float constant folding for unary operations
 fn rule_fconst_fold_unary() -> RewriteRule {
   {
-    name: "fconst_fold_unary",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -159,7 +157,6 @@ fn rule_fconst_fold_unary() -> RewriteRule {
 /// fneg(fneg(x)) = x (double negation)
 fn rule_fneg_fneg() -> RewriteRule {
   {
-    name: "fneg_fneg",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -182,7 +179,6 @@ fn rule_fneg_fneg() -> RewriteRule {
 /// fabs(fneg(x)) = fabs(x)
 fn rule_fabs_fneg() -> RewriteRule {
   {
-    name: "fabs_fneg",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -206,7 +202,6 @@ fn rule_fabs_fneg() -> RewriteRule {
 /// fabs(fabs(x)) = fabs(x) (idempotent)
 fn rule_fabs_fabs() -> RewriteRule {
   {
-    name: "fabs_fabs",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -230,7 +225,6 @@ fn rule_fabs_fabs() -> RewriteRule {
 /// This is the reverse direction
 fn rule_fneg_fabs() -> RewriteRule {
   {
-    name: "fneg_fabs",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_icmp.mbt
+++ b/ir/egraph/rules_icmp.mbt
@@ -77,7 +77,6 @@ fn intcc_swap(cc : Int) -> Int {
 /// eq(x, x) → 1
 fn rule_eq_self() -> RewriteRule {
   {
-    name: "eq_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -100,7 +99,6 @@ fn rule_eq_self() -> RewriteRule {
 /// ne(x, x) → 0
 fn rule_ne_self() -> RewriteRule {
   {
-    name: "ne_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -125,7 +123,6 @@ fn rule_ne_self() -> RewriteRule {
 /// Loose inequalities (sle, sge, ule, uge) are true
 fn rule_icmp_self() -> RewriteRule {
   {
-    name: "icmp_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -163,7 +160,6 @@ fn rule_icmp_self() -> RewriteRule {
 /// e.g. ne(ugt(x, y), 0) == ugt(x, y)
 fn rule_ne_icmp_zero() -> RewriteRule {
   {
-    name: "ne_icmp_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -229,7 +225,6 @@ fn rule_ne_icmp_zero() -> RewriteRule {
 /// e.g. eq(ugt(x, y), 0) == ule(x, y)
 fn rule_eq_icmp_zero() -> RewriteRule {
   {
-    name: "eq_icmp_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -319,7 +314,6 @@ fn rule_eq_icmp_zero() -> RewriteRule {
 /// e.g. ne(ugt(x, y), 1) == ule(x, y)
 fn rule_ne_icmp_one() -> RewriteRule {
   {
-    name: "ne_icmp_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -371,7 +365,6 @@ fn rule_ne_icmp_one() -> RewriteRule {
 /// e.g. eq(ugt(x, y), 1) == ugt(x, y)
 fn rule_eq_icmp_one() -> RewriteRule {
   {
-    name: "eq_icmp_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -414,7 +407,6 @@ fn rule_eq_icmp_one() -> RewriteRule {
 /// Masking comparison result with 1 is a no-op
 fn rule_band_icmp_one() -> RewriteRule {
   {
-    name: "band_icmp_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -485,7 +477,6 @@ fn rule_band_icmp_one() -> RewriteRule {
 /// ult(x, 0) → false
 fn rule_ult_zero() -> RewriteRule {
   {
-    name: "ult_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -512,7 +503,6 @@ fn rule_ult_zero() -> RewriteRule {
 /// ule(x, 0) → eq(x, 0)
 fn rule_ule_zero() -> RewriteRule {
   {
-    name: "ule_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -543,7 +533,6 @@ fn rule_ule_zero() -> RewriteRule {
 /// ugt(x, 0) → ne(x, 0)
 fn rule_ugt_zero() -> RewriteRule {
   {
-    name: "ugt_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -574,7 +563,6 @@ fn rule_ugt_zero() -> RewriteRule {
 /// uge(x, 0) → true
 fn rule_uge_zero() -> RewriteRule {
   {
-    name: "uge_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -605,7 +593,6 @@ fn rule_uge_zero() -> RewriteRule {
 /// uge(x, 1) → ne(x, 0)
 fn rule_uge_one_to_ne_zero() -> RewriteRule {
   {
-    name: "uge_one_to_ne_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -637,7 +624,6 @@ fn rule_uge_one_to_ne_zero() -> RewriteRule {
 /// ult(x, 1) → eq(x, 0)
 fn rule_ult_one_to_eq_zero() -> RewriteRule {
   {
-    name: "ult_one_to_eq_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -669,7 +655,6 @@ fn rule_ult_one_to_eq_zero() -> RewriteRule {
 /// sge(x, 1) → sgt(x, 0)
 fn rule_sge_one_to_sgt_zero() -> RewriteRule {
   {
-    name: "sge_one_to_sgt_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -701,7 +686,6 @@ fn rule_sge_one_to_sgt_zero() -> RewriteRule {
 /// slt(x, 1) → sle(x, 0)
 fn rule_slt_one_to_sle_zero() -> RewriteRule {
   {
-    name: "slt_one_to_sle_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -733,7 +717,6 @@ fn rule_slt_one_to_sle_zero() -> RewriteRule {
 /// sgt(x, -1) → sge(x, 0)
 fn rule_sgt_neg_one_to_sge_zero() -> RewriteRule {
   {
-    name: "sgt_neg_one_to_sge_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -765,7 +748,6 @@ fn rule_sgt_neg_one_to_sge_zero() -> RewriteRule {
 /// sle(x, -1) → slt(x, 0)
 fn rule_sle_neg_one_to_slt_zero() -> RewriteRule {
   {
-    name: "sle_neg_one_to_slt_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -802,7 +784,6 @@ fn rule_sle_neg_one_to_slt_zero() -> RewriteRule {
 /// Adding same value to both sides doesn't change equality
 fn rule_eq_add_cancel() -> RewriteRule {
   {
-    name: "eq_add_cancel",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -861,7 +842,6 @@ fn rule_eq_add_cancel() -> RewriteRule {
 /// ne(a+k, b+k) → ne(a, b)
 fn rule_ne_add_cancel() -> RewriteRule {
   {
-    name: "ne_add_cancel",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -922,7 +902,6 @@ fn rule_ne_add_cancel() -> RewriteRule {
 /// eq(x, bxor(x, y)) → eq(y, 0)
 fn rule_eq_xor_self() -> RewriteRule {
   {
-    name: "eq_xor_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -989,7 +968,6 @@ fn rule_eq_xor_self() -> RewriteRule {
 /// ne(x, bxor(x, y)) → ne(y, 0)
 fn rule_ne_xor_self() -> RewriteRule {
   {
-    name: "ne_xor_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1059,7 +1037,6 @@ fn rule_ne_xor_self() -> RewriteRule {
 /// Unsigned overflow detection pattern
 fn rule_ugt_sub_self() -> RewriteRule {
   {
-    name: "ugt_sub_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1094,7 +1071,6 @@ fn rule_ugt_sub_self() -> RewriteRule {
 /// ule(x - y, x) → ule(y, x)
 fn rule_ule_sub_self() -> RewriteRule {
   {
-    name: "ule_sub_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1133,7 +1109,6 @@ fn rule_ule_sub_self() -> RewriteRule {
 /// ult(bnot(x), bnot(y)) → ugt(x, y)
 fn rule_ult_bnot_swap() -> RewriteRule {
   {
-    name: "ult_bnot_swap",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1168,7 +1143,6 @@ fn rule_ult_bnot_swap() -> RewriteRule {
 /// slt(bnot(x), bnot(y)) → sgt(x, y)
 fn rule_slt_bnot_swap() -> RewriteRule {
   {
-    name: "slt_bnot_swap",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1208,7 +1182,6 @@ fn rule_slt_bnot_swap() -> RewriteRule {
 /// a < b ^^ a > b => (a ≠ b)
 fn rule_xor_cmp_to_ne() -> RewriteRule {
   {
-    name: "xor_cmp_to_ne",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1276,7 +1249,6 @@ fn rule_xor_cmp_to_ne() -> RewriteRule {
 /// a < b && a > b = false
 fn rule_band_contradictory_cmp() -> RewriteRule {
   {
-    name: "band_contradictory_cmp",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1331,7 +1303,6 @@ fn rule_band_contradictory_cmp() -> RewriteRule {
 /// eq(x + k1, k2) → eq(x, k2 - k1)
 fn rule_eq_add_const() -> RewriteRule {
   {
-    name: "eq_add_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1363,7 +1334,6 @@ fn rule_eq_add_const() -> RewriteRule {
 /// ne(x + k1, k2) → ne(x, k2 - k1)
 fn rule_ne_add_const() -> RewriteRule {
   {
-    name: "ne_add_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1395,7 +1365,6 @@ fn rule_ne_add_const() -> RewriteRule {
 /// eq(x - k1, k2) → eq(x, k2 + k1)
 fn rule_eq_sub_const() -> RewriteRule {
   {
-    name: "eq_sub_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1427,7 +1396,6 @@ fn rule_eq_sub_const() -> RewriteRule {
 /// ne(x - k1, k2) → ne(x, k2 + k1)
 fn rule_ne_sub_const() -> RewriteRule {
   {
-    name: "ne_sub_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1463,7 +1431,6 @@ fn rule_ne_sub_const() -> RewriteRule {
 /// select(uextend(icmp(...)), x, y) → select(icmp(...), x, y)
 fn rule_select_uextend_icmp() -> RewriteRule {
   {
-    name: "select_uextend_icmp",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1507,7 +1474,6 @@ fn rule_select_uextend_icmp() -> RewriteRule {
 /// Canonical form: push constants to the right
 fn rule_icmp_swap_const() -> RewriteRule {
   {
-    name: "icmp_swap_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1567,7 +1533,6 @@ fn rule_icmp_swap_const() -> RewriteRule {
 /// eq(x + K1, y + K2) → eq(x, y + (K2 - K1))
 fn rule_eq_add_add_const() -> RewriteRule {
   {
-    name: "eq_add_add_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1604,7 +1569,6 @@ fn rule_eq_add_add_const() -> RewriteRule {
 /// ne(x + K1, y + K2) → ne(x, y + (K2 - K1))
 fn rule_ne_add_add_const() -> RewriteRule {
   {
-    name: "ne_add_add_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1647,7 +1611,6 @@ fn rule_ne_add_add_const() -> RewriteRule {
 /// Nothing can be greater than the maximum unsigned value
 fn rule_ugt_umax() -> RewriteRule {
   {
-    name: "ugt_umax",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1678,7 +1641,6 @@ fn rule_ugt_umax() -> RewriteRule {
 /// Only UMAX is >= UMAX
 fn rule_uge_umax() -> RewriteRule {
   {
-    name: "uge_umax",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1711,7 +1673,6 @@ fn rule_uge_umax() -> RewriteRule {
 /// Everything is <= UMAX
 fn rule_ule_umax() -> RewriteRule {
   {
-    name: "ule_umax",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1741,7 +1702,6 @@ fn rule_ule_umax() -> RewriteRule {
 /// Nothing can be greater than the maximum signed value
 fn rule_sgt_smax() -> RewriteRule {
   {
-    name: "sgt_smax",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1771,7 +1731,6 @@ fn rule_sgt_smax() -> RewriteRule {
 /// Only SMAX is >= SMAX
 fn rule_sge_smax() -> RewriteRule {
   {
-    name: "sge_smax",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1804,7 +1763,6 @@ fn rule_sge_smax() -> RewriteRule {
 /// Nothing can be less than the minimum signed value
 fn rule_slt_smin() -> RewriteRule {
   {
-    name: "slt_smin",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1834,7 +1792,6 @@ fn rule_slt_smin() -> RewriteRule {
 /// Only SMIN is <= SMIN
 fn rule_sle_smin() -> RewriteRule {
   {
-    name: "sle_smin",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1867,7 +1824,6 @@ fn rule_sle_smin() -> RewriteRule {
 /// Everything is >= SMIN
 fn rule_sge_smin() -> RewriteRule {
   {
-    name: "sge_smin",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -1897,7 +1853,6 @@ fn rule_sge_smin() -> RewriteRule {
 /// Everything is <= SMAX
 fn rule_sle_smax() -> RewriteRule {
   {
-    name: "sle_smax",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_identity.mbt
+++ b/ir/egraph/rules_identity.mbt
@@ -29,7 +29,6 @@ fn EGraph::find_fconst(self : EGraph, id : EClassId) -> UInt64? {
 /// x + 0 = x
 fn rule_add_zero() -> RewriteRule {
   {
-    name: "add_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -55,7 +54,6 @@ fn rule_add_zero() -> RewriteRule {
 /// x - 0 = x
 fn rule_sub_zero() -> RewriteRule {
   {
-    name: "sub_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -76,7 +74,6 @@ fn rule_sub_zero() -> RewriteRule {
 /// x * 1 = x
 fn rule_mul_one() -> RewriteRule {
   {
-    name: "mul_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -99,7 +96,6 @@ fn rule_mul_one() -> RewriteRule {
 /// x * 0 = 0
 fn rule_mul_zero() -> RewriteRule {
   {
-    name: "mul_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -121,7 +117,6 @@ fn rule_mul_zero() -> RewriteRule {
 /// x & x = x, x | x = x
 fn rule_idempotent() -> RewriteRule {
   {
-    name: "idempotent",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -141,7 +136,6 @@ fn rule_idempotent() -> RewriteRule {
 /// x ^ x = 0
 fn rule_xor_self() -> RewriteRule {
   {
-    name: "xor_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -162,7 +156,6 @@ fn rule_xor_self() -> RewriteRule {
 /// x - x = 0
 fn rule_sub_self() -> RewriteRule {
   {
-    name: "sub_self",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_rebalance.mbt
+++ b/ir/egraph/rules_rebalance.mbt
@@ -3,7 +3,6 @@
 ///|
 fn rule_rebalance_add_right() -> RewriteRule {
   {
-    name: "rebalance_add_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -37,7 +36,6 @@ fn rule_rebalance_add_right() -> RewriteRule {
 /// Tree rebalancing for iadd: (((a + b) + c) + d) => ((a + b) + (c + d))
 fn rule_rebalance_add_left() -> RewriteRule {
   {
-    name: "rebalance_add_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -70,7 +68,6 @@ fn rule_rebalance_add_left() -> RewriteRule {
 /// Tree rebalancing for imul: (a * (b * (c * d))) => ((a * b) * (c * d))
 fn rule_rebalance_mul_right() -> RewriteRule {
   {
-    name: "rebalance_mul_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -103,7 +100,6 @@ fn rule_rebalance_mul_right() -> RewriteRule {
 /// Tree rebalancing for imul: (((a * b) * c) * d) => ((a * b) * (c * d))
 fn rule_rebalance_mul_left() -> RewriteRule {
   {
-    name: "rebalance_mul_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -136,7 +132,6 @@ fn rule_rebalance_mul_left() -> RewriteRule {
 /// Tree rebalancing for band: (a & (b & (c & d))) => ((a & b) & (c & d))
 fn rule_rebalance_and_right() -> RewriteRule {
   {
-    name: "rebalance_and_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -169,7 +164,6 @@ fn rule_rebalance_and_right() -> RewriteRule {
 /// Tree rebalancing for band: (((a & b) & c) & d) => ((a & b) & (c & d))
 fn rule_rebalance_and_left() -> RewriteRule {
   {
-    name: "rebalance_and_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -202,7 +196,6 @@ fn rule_rebalance_and_left() -> RewriteRule {
 /// Tree rebalancing for bxor: (a ^ (b ^ (c ^ d))) => ((a ^ b) ^ (c ^ d))
 fn rule_rebalance_xor_right() -> RewriteRule {
   {
-    name: "rebalance_xor_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -235,7 +228,6 @@ fn rule_rebalance_xor_right() -> RewriteRule {
 /// Tree rebalancing for bxor: (((a ^ b) ^ c) ^ d) => ((a ^ b) ^ (c ^ d))
 fn rule_rebalance_xor_left() -> RewriteRule {
   {
-    name: "rebalance_xor_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_rebalance_addsub.mbt
+++ b/ir/egraph/rules_rebalance_addsub.mbt
@@ -8,7 +8,6 @@
 /// a - (b - (c - d)) = (a - b) + (c - d)
 fn rule_rebalance_sub_sub_sub() -> RewriteRule {
   {
-    name: "rebalance_sub_sub_sub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -41,7 +40,6 @@ fn rule_rebalance_sub_sub_sub() -> RewriteRule {
 /// a - (b - (c + d)) = (a - b) + (c + d)
 fn rule_rebalance_sub_sub_add() -> RewriteRule {
   {
-    name: "rebalance_sub_sub_add",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -74,7 +72,6 @@ fn rule_rebalance_sub_sub_add() -> RewriteRule {
 /// a - (b + (c - d)) = (a - b) - (c - d)
 fn rule_rebalance_sub_add_sub() -> RewriteRule {
   {
-    name: "rebalance_sub_add_sub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -107,7 +104,6 @@ fn rule_rebalance_sub_add_sub() -> RewriteRule {
 /// a - (b + (c + d)) = (a - b) - (c + d)
 fn rule_rebalance_sub_add_add() -> RewriteRule {
   {
-    name: "rebalance_sub_add_add",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -140,7 +136,6 @@ fn rule_rebalance_sub_add_add() -> RewriteRule {
 /// a + (b - (c - d)) = (a + b) - (c - d)
 fn rule_rebalance_add_sub_sub() -> RewriteRule {
   {
-    name: "rebalance_add_sub_sub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -173,7 +168,6 @@ fn rule_rebalance_add_sub_sub() -> RewriteRule {
 /// a + (b - (c + d)) = (a + b) - (c + d)
 fn rule_rebalance_add_sub_add() -> RewriteRule {
   {
-    name: "rebalance_add_sub_add",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -206,7 +200,6 @@ fn rule_rebalance_add_sub_add() -> RewriteRule {
 /// a + (b + (c - d)) = (a + b) + (c - d)
 fn rule_rebalance_add_add_sub() -> RewriteRule {
   {
-    name: "rebalance_add_add_sub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -239,7 +232,6 @@ fn rule_rebalance_add_add_sub() -> RewriteRule {
 /// ((a - b) - c) - d = (a - b) - (c + d)
 fn rule_rebalance_left_sub_sub_sub() -> RewriteRule {
   {
-    name: "rebalance_left_sub_sub_sub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -272,7 +264,6 @@ fn rule_rebalance_left_sub_sub_sub() -> RewriteRule {
 /// ((a - b) - c) + d = (a - b) - (c - d)
 fn rule_rebalance_left_sub_sub_add() -> RewriteRule {
   {
-    name: "rebalance_left_sub_sub_add",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -305,7 +296,6 @@ fn rule_rebalance_left_sub_sub_add() -> RewriteRule {
 /// ((a - b) + c) - d = (a - b) + (c - d)
 fn rule_rebalance_left_sub_add_sub() -> RewriteRule {
   {
-    name: "rebalance_left_sub_add_sub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -338,7 +328,6 @@ fn rule_rebalance_left_sub_add_sub() -> RewriteRule {
 /// ((a - b) + c) + d = (a - b) + (c + d)
 fn rule_rebalance_left_sub_add_add() -> RewriteRule {
   {
-    name: "rebalance_left_sub_add_add",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -371,7 +360,6 @@ fn rule_rebalance_left_sub_add_add() -> RewriteRule {
 /// ((a + b) - c) - d = (a + b) - (c + d)
 fn rule_rebalance_left_add_sub_sub() -> RewriteRule {
   {
-    name: "rebalance_left_add_sub_sub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -404,7 +392,6 @@ fn rule_rebalance_left_add_sub_sub() -> RewriteRule {
 /// ((a + b) - c) + d = (a + b) - (c - d)
 fn rule_rebalance_left_add_sub_add() -> RewriteRule {
   {
-    name: "rebalance_left_add_sub_add",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -437,7 +424,6 @@ fn rule_rebalance_left_add_sub_add() -> RewriteRule {
 /// ((a + b) + c) - d = (a + b) + (c - d)
 fn rule_rebalance_left_add_add_sub() -> RewriteRule {
   {
-    name: "rebalance_left_add_add_sub",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_remat.mbt
+++ b/ir/egraph/rules_remat.mbt
@@ -91,7 +91,6 @@ fn EGraph::has_const_child(self : EGraph, node : ENode) -> Bool {
 /// Mark iadd(iconst, x) as rematerializable
 fn rule_remat_iadd_iconst_left() -> RewriteRule {
   {
-    name: "remat_iadd_iconst_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -111,7 +110,6 @@ fn rule_remat_iadd_iconst_left() -> RewriteRule {
 /// Mark iadd(x, iconst) as rematerializable
 fn rule_remat_iadd_iconst_right() -> RewriteRule {
   {
-    name: "remat_iadd_iconst_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -131,7 +129,6 @@ fn rule_remat_iadd_iconst_right() -> RewriteRule {
 /// Mark isub(iconst, x) as rematerializable
 fn rule_remat_isub_iconst_left() -> RewriteRule {
   {
-    name: "remat_isub_iconst_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -151,7 +148,6 @@ fn rule_remat_isub_iconst_left() -> RewriteRule {
 /// Mark isub(x, iconst) as rematerializable
 fn rule_remat_isub_iconst_right() -> RewriteRule {
   {
-    name: "remat_isub_iconst_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -171,7 +167,6 @@ fn rule_remat_isub_iconst_right() -> RewriteRule {
 /// Mark band(iconst, x) as rematerializable
 fn rule_remat_band_iconst_left() -> RewriteRule {
   {
-    name: "remat_band_iconst_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -191,7 +186,6 @@ fn rule_remat_band_iconst_left() -> RewriteRule {
 /// Mark band(x, iconst) as rematerializable
 fn rule_remat_band_iconst_right() -> RewriteRule {
   {
-    name: "remat_band_iconst_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -211,7 +205,6 @@ fn rule_remat_band_iconst_right() -> RewriteRule {
 /// Mark bor(iconst, x) as rematerializable
 fn rule_remat_bor_iconst_left() -> RewriteRule {
   {
-    name: "remat_bor_iconst_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -231,7 +224,6 @@ fn rule_remat_bor_iconst_left() -> RewriteRule {
 /// Mark bor(x, iconst) as rematerializable
 fn rule_remat_bor_iconst_right() -> RewriteRule {
   {
-    name: "remat_bor_iconst_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -251,7 +243,6 @@ fn rule_remat_bor_iconst_right() -> RewriteRule {
 /// Mark bxor(iconst, x) as rematerializable
 fn rule_remat_bxor_iconst_left() -> RewriteRule {
   {
-    name: "remat_bxor_iconst_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -271,7 +262,6 @@ fn rule_remat_bxor_iconst_left() -> RewriteRule {
 /// Mark bxor(x, iconst) as rematerializable
 fn rule_remat_bxor_iconst_right() -> RewriteRule {
   {
-    name: "remat_bxor_iconst_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -291,7 +281,6 @@ fn rule_remat_bxor_iconst_right() -> RewriteRule {
 /// Mark bnot(x) as rematerializable
 fn rule_remat_bnot() -> RewriteRule {
   {
-    name: "remat_bnot",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -309,7 +298,6 @@ fn rule_remat_bnot() -> RewriteRule {
 /// Mark iconst as rematerializable
 fn rule_remat_iconst() -> RewriteRule {
   {
-    name: "remat_iconst",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -327,7 +315,6 @@ fn rule_remat_iconst() -> RewriteRule {
 /// Mark f32const/f64const as rematerializable
 fn rule_remat_fconst() -> RewriteRule {
   {
-    name: "remat_fconst",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_select.mbt
+++ b/ir/egraph/rules_select.mbt
@@ -9,7 +9,6 @@
 /// When both branches are the same, the condition doesn't matter
 fn rule_select_same() -> RewriteRule {
   {
-    name: "select_same",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -31,7 +30,6 @@ fn rule_select_same() -> RewriteRule {
 /// When selecting between 1 and 0 based on a comparison, just use the comparison result
 fn rule_select_icmp_one_zero() -> RewriteRule {
   {
-    name: "select_icmp_one_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -64,7 +62,6 @@ fn rule_select_icmp_one_zero() -> RewriteRule {
 /// Push zeroes to the right by complementing the condition
 fn rule_select_icmp_zero_one() -> RewriteRule {
   {
-    name: "select_icmp_zero_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -103,7 +100,6 @@ fn rule_select_icmp_zero_one() -> RewriteRule {
 /// Nested select with same condition - inner true branch is unreachable
 fn rule_select_nested_same_cond_right() -> RewriteRule {
   {
-    name: "select_nested_same_cond_right",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -136,7 +132,6 @@ fn rule_select_nested_same_cond_right() -> RewriteRule {
 /// Nested select with same condition - inner false branch is unreachable
 fn rule_select_nested_same_cond_left() -> RewriteRule {
   {
-    name: "select_nested_same_cond_left",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -169,7 +164,6 @@ fn rule_select_nested_same_cond_left() -> RewriteRule {
 /// Remove unnecessary uextend on condition
 fn rule_select_uextend_cond() -> RewriteRule {
   {
-    name: "select_uextend_cond",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -213,7 +207,6 @@ fn rule_select_uextend_cond() -> RewriteRule {
 /// Fold add into select branches
 fn rule_add_select_const() -> RewriteRule {
   {
-    name: "add_select_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -275,7 +268,6 @@ fn rule_add_select_const() -> RewriteRule {
 /// select(sge(x, y), x, y) = smax(x, y)
 fn rule_select_to_smax() -> RewriteRule {
   {
-    name: "select_to_smax",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -310,7 +302,6 @@ fn rule_select_to_smax() -> RewriteRule {
 /// select(sle(x, y), x, y) = smin(x, y)
 fn rule_select_to_smin() -> RewriteRule {
   {
-    name: "select_to_smin",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -345,7 +336,6 @@ fn rule_select_to_smin() -> RewriteRule {
 /// select(uge(x, y), x, y) = umax(x, y)
 fn rule_select_to_umax() -> RewriteRule {
   {
-    name: "select_to_umax",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -380,7 +370,6 @@ fn rule_select_to_umax() -> RewriteRule {
 /// select(ule(x, y), x, y) = umin(x, y)
 fn rule_select_to_umin() -> RewriteRule {
   {
-    name: "select_to_umin",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -420,7 +409,6 @@ fn rule_select_to_umin() -> RewriteRule {
 /// select(sle(x, y), y, x) = smax(x, y)
 fn rule_select_to_smax_swapped() -> RewriteRule {
   {
-    name: "select_to_smax_swapped",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -454,7 +442,6 @@ fn rule_select_to_smax_swapped() -> RewriteRule {
 /// select(sge(x, y), y, x) = smin(x, y)
 fn rule_select_to_smin_swapped() -> RewriteRule {
   {
-    name: "select_to_smin_swapped",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -488,7 +475,6 @@ fn rule_select_to_smin_swapped() -> RewriteRule {
 /// select(ule(x, y), y, x) = umax(x, y)
 fn rule_select_to_umax_swapped() -> RewriteRule {
   {
-    name: "select_to_umax_swapped",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -522,7 +508,6 @@ fn rule_select_to_umax_swapped() -> RewriteRule {
 /// select(uge(x, y), y, x) = umin(x, y)
 fn rule_select_to_umin_swapped() -> RewriteRule {
   {
-    name: "select_to_umin_swapped",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -560,7 +545,6 @@ fn rule_select_to_umin_swapped() -> RewriteRule {
 /// select(sge(x, 0), x, -x) = iabs(x)
 fn rule_select_to_iabs_positive() -> RewriteRule {
   {
-    name: "select_to_iabs_positive",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -602,7 +586,6 @@ fn rule_select_to_iabs_positive() -> RewriteRule {
 /// select(sle(x, 0), -x, x) = iabs(x)
 fn rule_select_to_iabs_negative() -> RewriteRule {
   {
-    name: "select_to_iabs_negative",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -648,7 +631,6 @@ fn rule_select_to_iabs_negative() -> RewriteRule {
 /// sgt(smin(x, y), y) = 0  (min is never greater than y)
 fn rule_smin_never_greater() -> RewriteRule {
   {
-    name: "smin_never_greater",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -679,7 +661,6 @@ fn rule_smin_never_greater() -> RewriteRule {
 /// slt(x, smin(y, x)) = 0
 fn rule_never_less_than_smin() -> RewriteRule {
   {
-    name: "never_less_than_smin",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -710,7 +691,6 @@ fn rule_never_less_than_smin() -> RewriteRule {
 /// ugt(umin(x, y), y) = 0  (min is never greater than y)
 fn rule_umin_never_greater() -> RewriteRule {
   {
-    name: "umin_never_greater",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -741,7 +721,6 @@ fn rule_umin_never_greater() -> RewriteRule {
 /// ult(x, umin(y, x)) = 0
 fn rule_never_less_than_umin() -> RewriteRule {
   {
-    name: "never_less_than_umin",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_shift.mbt
+++ b/ir/egraph/rules_shift.mbt
@@ -7,7 +7,6 @@
 /// x << 0 = x
 fn rule_shl_zero() -> RewriteRule {
   {
-    name: "shl_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -27,7 +26,6 @@ fn rule_shl_zero() -> RewriteRule {
 /// x >> 0 = x (both arithmetic and logical)
 fn rule_shr_zero() -> RewriteRule {
   {
-    name: "shr_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -47,7 +45,6 @@ fn rule_shr_zero() -> RewriteRule {
 /// 0 << x = 0, 0 >> x = 0
 fn rule_shift_of_zero() -> RewriteRule {
   {
-    name: "shift_of_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -69,7 +66,6 @@ fn rule_shift_of_zero() -> RewriteRule {
 /// (x << a) << b = x << (a + b) when a + b < 64
 fn rule_shl_shl() -> RewriteRule {
   {
-    name: "shl_shl",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -100,7 +96,6 @@ fn rule_shl_shl() -> RewriteRule {
 /// (x >> a) >> b = x >> (a + b) when a + b < 64 (unsigned)
 fn rule_ushr_ushr() -> RewriteRule {
   {
-    name: "ushr_ushr",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -134,7 +129,6 @@ fn rule_ushr_ushr() -> RewriteRule {
 /// (x >> a) >> b = x >> (a + b) when a + b < 64 (signed)
 fn rule_sshr_sshr() -> RewriteRule {
   {
-    name: "sshr_sshr",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -168,7 +162,6 @@ fn rule_sshr_sshr() -> RewriteRule {
 /// x rotl 0 = x, x rotr 0 = x
 fn rule_rot_zero() -> RewriteRule {
   {
-    name: "rot_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -188,7 +181,6 @@ fn rule_rot_zero() -> RewriteRule {
 /// rotl(rotr(x, y), y) = x
 fn rule_rotl_rotr_cancel() -> RewriteRule {
   {
-    name: "rotl_rotr_cancel",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -213,7 +205,6 @@ fn rule_rotl_rotr_cancel() -> RewriteRule {
 /// rotr(rotl(x, y), y) = x
 fn rule_rotr_rotl_cancel() -> RewriteRule {
   {
-    name: "rotr_rotl_cancel",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -238,7 +229,6 @@ fn rule_rotr_rotl_cancel() -> RewriteRule {
 /// (x >> k) << k = x & mask (masking off bottom k bits)
 fn rule_ushr_shl_mask() -> RewriteRule {
   {
-    name: "ushr_shl_mask",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -270,7 +260,6 @@ fn rule_ushr_shl_mask() -> RewriteRule {
 /// (x << k) >> k = x & mask (unsigned, masking off top k bits)
 fn rule_shl_ushr_mask() -> RewriteRule {
   {
-    name: "shl_ushr_mask",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -303,7 +292,6 @@ fn rule_shl_ushr_mask() -> RewriteRule {
 /// Distribute band through shifts with same amount
 fn rule_band_shl_shl() -> RewriteRule {
   {
-    name: "band_shl_shl",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -335,7 +323,6 @@ fn rule_band_shl_shl() -> RewriteRule {
 /// Distribute sub through shifts with same amount
 fn rule_sub_shl_shl() -> RewriteRule {
   {
-    name: "sub_shl_shl",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -367,7 +354,6 @@ fn rule_sub_shl_shl() -> RewriteRule {
 /// Distribute add through shifts with same amount
 fn rule_add_shl_shl() -> RewriteRule {
   {
-    name: "add_shl_shl",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -398,7 +384,6 @@ fn rule_add_shl_shl() -> RewriteRule {
 /// ushr(band(ishl(x, y), z), y) = band(x, ushr(z, y))
 fn rule_ushr_band_shl() -> RewriteRule {
   {
-    name: "ushr_band_shl",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -446,7 +431,6 @@ fn rule_ushr_band_shl() -> RewriteRule {
 /// Negating a logical right shift by (bits-1) equals arithmetic right shift
 fn rule_neg_ushr_to_sshr() -> RewriteRule {
   {
-    name: "neg_ushr_to_sshr",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -479,7 +463,6 @@ fn rule_neg_ushr_to_sshr() -> RewriteRule {
 /// Shift overflow becomes zero
 fn rule_shl_shl_overflow() -> RewriteRule {
   {
-    name: "shl_shl_overflow",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -511,7 +494,6 @@ fn rule_shl_shl_overflow() -> RewriteRule {
 /// Unsigned shift overflow becomes zero
 fn rule_ushr_ushr_overflow() -> RewriteRule {
   {
-    name: "ushr_ushr_overflow",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -542,7 +524,6 @@ fn rule_ushr_ushr_overflow() -> RewriteRule {
 /// Combine consecutive rotations into single rotation with added amounts
 fn rule_rotl_rotl_combine() -> RewriteRule {
   {
-    name: "rotl_rotl_combine",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -571,7 +552,6 @@ fn rule_rotl_rotl_combine() -> RewriteRule {
 /// Combine consecutive rotations into single rotation with added amounts
 fn rule_rotr_rotr_combine() -> RewriteRule {
   {
-    name: "rotr_rotr_combine",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -600,7 +580,6 @@ fn rule_rotr_rotr_combine() -> RewriteRule {
 /// Convert mixed rotation to single rotation with subtracted amounts
 fn rule_rotr_rotl_to_rotl() -> RewriteRule {
   {
-    name: "rotr_rotl_to_rotl",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -629,7 +608,6 @@ fn rule_rotr_rotl_to_rotl() -> RewriteRule {
 /// Convert mixed rotation to single rotation with subtracted amounts
 fn rule_rotl_rotr_to_rotr() -> RewriteRule {
   {
-    name: "rotl_rotr_to_rotr",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -658,7 +636,6 @@ fn rule_rotl_rotr_to_rotr() -> RewriteRule {
 /// Shift operations only look at lower bits of shift amount
 fn rule_shift_extend_amount() -> RewriteRule {
   {
-    name: "shift_extend_amount",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -696,7 +673,6 @@ fn rule_shift_extend_amount() -> RewriteRule {
 /// Shift operations only look at lower bits of shift amount
 fn rule_shift_reduce_amount() -> RewriteRule {
   {
-    name: "shift_reduce_amount",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -733,7 +709,6 @@ fn rule_shift_reduce_amount() -> RewriteRule {
 /// Convert shift pair to rotate left
 fn rule_shl_ushr_to_rotl() -> RewriteRule {
   {
-    name: "shl_ushr_to_rotl",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_skeleton.mbt
+++ b/ir/egraph/rules_skeleton.mbt
@@ -26,7 +26,6 @@ fn is_power_of_two(n : Int64) -> Int64? {
 /// Convert division by power-of-two select to shift by select
 fn rule_udiv_select_pow2() -> RewriteRule {
   {
-    name: "udiv_select_pow2",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -73,7 +72,6 @@ fn rule_udiv_select_pow2() -> RewriteRule {
 /// (In a full implementation, this would be used to remove overflow traps)
 fn rule_add_uextend_no_overflow() -> RewriteRule {
   {
-    name: "add_uextend_no_overflow",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_spaceship.mbt
+++ b/ir/egraph/rules_spaceship.mbt
@@ -14,7 +14,6 @@ fn is_neg_one(v : Int64) -> Bool {
 /// Three-way comparison equals zero means the operands are equal
 fn rule_spaceship_eq_zero() -> RewriteRule {
   {
-    name: "spaceship_eq_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -59,7 +58,6 @@ fn rule_spaceship_eq_zero() -> RewriteRule {
 /// Three-way comparison not equals zero means the operands are not equal
 fn rule_spaceship_ne_zero() -> RewriteRule {
   {
-    name: "spaceship_ne_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -101,7 +99,6 @@ fn rule_spaceship_ne_zero() -> RewriteRule {
 /// Signed spaceship less than zero means first operand is less
 fn rule_spaceship_s_lt_zero() -> RewriteRule {
   {
-    name: "spaceship_s_lt_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -129,7 +126,6 @@ fn rule_spaceship_s_lt_zero() -> RewriteRule {
 /// Unsigned spaceship less than zero means first operand is less
 fn rule_spaceship_u_lt_zero() -> RewriteRule {
   {
-    name: "spaceship_u_lt_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -156,7 +152,6 @@ fn rule_spaceship_u_lt_zero() -> RewriteRule {
 /// Simplify (a <=>_s b) <= 0 → a <=_s b
 fn rule_spaceship_s_le_zero() -> RewriteRule {
   {
-    name: "spaceship_s_le_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -183,7 +178,6 @@ fn rule_spaceship_s_le_zero() -> RewriteRule {
 /// Simplify (a <=>_u b) <= 0 → a <=_u b
 fn rule_spaceship_u_le_zero() -> RewriteRule {
   {
-    name: "spaceship_u_le_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -210,7 +204,6 @@ fn rule_spaceship_u_le_zero() -> RewriteRule {
 /// Simplify (a <=>_s b) > 0 → a >_s b
 fn rule_spaceship_s_gt_zero() -> RewriteRule {
   {
-    name: "spaceship_s_gt_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -237,7 +230,6 @@ fn rule_spaceship_s_gt_zero() -> RewriteRule {
 /// Simplify (a <=>_u b) > 0 → a >_u b
 fn rule_spaceship_u_gt_zero() -> RewriteRule {
   {
-    name: "spaceship_u_gt_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -264,7 +256,6 @@ fn rule_spaceship_u_gt_zero() -> RewriteRule {
 /// Simplify (a <=>_s b) >= 0 → a >=_s b
 fn rule_spaceship_s_ge_zero() -> RewriteRule {
   {
-    name: "spaceship_s_ge_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -291,7 +282,6 @@ fn rule_spaceship_s_ge_zero() -> RewriteRule {
 /// Simplify (a <=>_u b) >= 0 → a >=_u b
 fn rule_spaceship_u_ge_zero() -> RewriteRule {
   {
-    name: "spaceship_u_ge_zero",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -318,7 +308,6 @@ fn rule_spaceship_u_ge_zero() -> RewriteRule {
 /// Simplify (a <=>_s b) == -1 → a <_s b
 fn rule_spaceship_s_eq_neg_one() -> RewriteRule {
   {
-    name: "spaceship_s_eq_neg_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -346,7 +335,6 @@ fn rule_spaceship_s_eq_neg_one() -> RewriteRule {
 /// Simplify (a <=>_u b) == -1 → a <_u b
 fn rule_spaceship_u_eq_neg_one() -> RewriteRule {
   {
-    name: "spaceship_u_eq_neg_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -374,7 +362,6 @@ fn rule_spaceship_u_eq_neg_one() -> RewriteRule {
 /// Simplify (a <=>_s b) != -1 → a >=_s b
 fn rule_spaceship_s_ne_neg_one() -> RewriteRule {
   {
-    name: "spaceship_s_ne_neg_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -402,7 +389,6 @@ fn rule_spaceship_s_ne_neg_one() -> RewriteRule {
 /// Simplify (a <=>_u b) != -1 → a >=_u b
 fn rule_spaceship_u_ne_neg_one() -> RewriteRule {
   {
-    name: "spaceship_u_ne_neg_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -430,7 +416,6 @@ fn rule_spaceship_u_ne_neg_one() -> RewriteRule {
 /// Simplify (a <=>_s b) == 1 → a >_s b
 fn rule_spaceship_s_eq_one() -> RewriteRule {
   {
-    name: "spaceship_s_eq_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -458,7 +443,6 @@ fn rule_spaceship_s_eq_one() -> RewriteRule {
 /// Simplify (a <=>_u b) == 1 → a >_u b
 fn rule_spaceship_u_eq_one() -> RewriteRule {
   {
-    name: "spaceship_u_eq_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -486,7 +470,6 @@ fn rule_spaceship_u_eq_one() -> RewriteRule {
 /// Simplify (a <=>_s b) != 1 → a <=_s b
 fn rule_spaceship_s_ne_one() -> RewriteRule {
   {
-    name: "spaceship_s_ne_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -514,7 +497,6 @@ fn rule_spaceship_s_ne_one() -> RewriteRule {
 /// Simplify (a <=>_u b) != 1 → a <=_u b
 fn rule_spaceship_u_ne_one() -> RewriteRule {
   {
-    name: "spaceship_u_ne_one",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_strength.mbt
+++ b/ir/egraph/rules_strength.mbt
@@ -8,7 +8,6 @@
 /// Note: This is only valid for unsigned division
 fn rule_udiv_pow2() -> RewriteRule {
   {
-    name: "udiv_pow2",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -32,7 +31,6 @@ fn rule_udiv_pow2() -> RewriteRule {
 /// x % 2^n = x & (2^n - 1) (for unsigned)
 fn rule_urem_pow2() -> RewriteRule {
   {
-    name: "urem_pow2",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -56,7 +54,6 @@ fn rule_urem_pow2() -> RewriteRule {
 /// x * 3 = (x << 1) + x
 fn rule_mul_3() -> RewriteRule {
   {
-    name: "mul_3",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -85,7 +82,6 @@ fn rule_mul_3() -> RewriteRule {
 /// x * 5 = (x << 2) + x
 fn rule_mul_5() -> RewriteRule {
   {
-    name: "mul_5",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -114,7 +110,6 @@ fn rule_mul_5() -> RewriteRule {
 /// x * 7 = (x << 3) - x
 fn rule_mul_7() -> RewriteRule {
   {
-    name: "mul_7",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -143,7 +138,6 @@ fn rule_mul_7() -> RewriteRule {
 /// x * 9 = (x << 3) + x
 fn rule_mul_9() -> RewriteRule {
   {
-    name: "mul_9",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph/rules_vector.mbt
+++ b/ir/egraph/rules_vector.mbt
@@ -55,7 +55,6 @@ fn splat64(n : UInt64) -> Bytes {
 /// Converts splat of constant to vector constant
 fn rule_splat_const() -> RewriteRule {
   {
-    name: "splat_const",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -96,7 +95,6 @@ fn find_splat_child(eg : EGraph, class_id : EClassId) -> EClassId? {
 /// band(splat(x), splat(y)) -> splat(band(x, y))
 fn rule_band_splat_splat() -> RewriteRule {
   {
-    name: "band_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -120,7 +118,6 @@ fn rule_band_splat_splat() -> RewriteRule {
 /// bor(splat(x), splat(y)) -> splat(bor(x, y))
 fn rule_bor_splat_splat() -> RewriteRule {
   {
-    name: "bor_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -143,7 +140,6 @@ fn rule_bor_splat_splat() -> RewriteRule {
 /// bxor(splat(x), splat(y)) -> splat(bxor(x, y))
 fn rule_bxor_splat_splat() -> RewriteRule {
   {
-    name: "bxor_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -166,7 +162,6 @@ fn rule_bxor_splat_splat() -> RewriteRule {
 /// bnot(splat(x)) -> splat(bnot(x))
 fn rule_bnot_splat() -> RewriteRule {
   {
-    name: "bnot_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -188,7 +183,6 @@ fn rule_bnot_splat() -> RewriteRule {
 /// iadd(splat(x), splat(y)) -> splat(iadd(x, y))
 fn rule_iadd_splat_splat() -> RewriteRule {
   {
-    name: "iadd_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -211,7 +205,6 @@ fn rule_iadd_splat_splat() -> RewriteRule {
 /// isub(splat(x), splat(y)) -> splat(isub(x, y))
 fn rule_isub_splat_splat() -> RewriteRule {
   {
-    name: "isub_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -234,7 +227,6 @@ fn rule_isub_splat_splat() -> RewriteRule {
 /// imul(splat(x), splat(y)) -> splat(imul(x, y))
 fn rule_imul_splat_splat() -> RewriteRule {
   {
-    name: "imul_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -257,7 +249,6 @@ fn rule_imul_splat_splat() -> RewriteRule {
 /// ineg(splat(x)) -> splat(ineg(x))
 fn rule_ineg_splat() -> RewriteRule {
   {
-    name: "ineg_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -279,7 +270,6 @@ fn rule_ineg_splat() -> RewriteRule {
 /// iabs(splat(x)) -> splat(iabs(x))
 fn rule_iabs_splat() -> RewriteRule {
   {
-    name: "iabs_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -301,7 +291,6 @@ fn rule_iabs_splat() -> RewriteRule {
 /// popcnt(splat(x)) -> splat(popcnt(x))
 fn rule_popcnt_splat() -> RewriteRule {
   {
-    name: "popcnt_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -323,7 +312,6 @@ fn rule_popcnt_splat() -> RewriteRule {
 /// smin(splat(x), splat(y)) -> splat(smin(x, y))
 fn rule_smin_splat_splat() -> RewriteRule {
   {
-    name: "smin_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -346,7 +334,6 @@ fn rule_smin_splat_splat() -> RewriteRule {
 /// umin(splat(x), splat(y)) -> splat(umin(x, y))
 fn rule_umin_splat_splat() -> RewriteRule {
   {
-    name: "umin_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -369,7 +356,6 @@ fn rule_umin_splat_splat() -> RewriteRule {
 /// smax(splat(x), splat(y)) -> splat(smax(x, y))
 fn rule_smax_splat_splat() -> RewriteRule {
   {
-    name: "smax_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -392,7 +378,6 @@ fn rule_smax_splat_splat() -> RewriteRule {
 /// umax(splat(x), splat(y)) -> splat(umax(x, y))
 fn rule_umax_splat_splat() -> RewriteRule {
   {
-    name: "umax_splat_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -420,7 +405,6 @@ fn rule_umax_splat_splat() -> RewriteRule {
 /// rotl(splat(x), y) -> splat(rotl(x, y))
 fn rule_rotl_splat() -> RewriteRule {
   {
-    name: "rotl_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -443,7 +427,6 @@ fn rule_rotl_splat() -> RewriteRule {
 /// rotr(splat(x), y) -> splat(rotr(x, y))
 fn rule_rotr_splat() -> RewriteRule {
   {
-    name: "rotr_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -466,7 +449,6 @@ fn rule_rotr_splat() -> RewriteRule {
 /// ishl(splat(x), y) -> splat(ishl(x, y))
 fn rule_ishl_splat() -> RewriteRule {
   {
-    name: "ishl_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -489,7 +471,6 @@ fn rule_ishl_splat() -> RewriteRule {
 /// ushr(splat(x), y) -> splat(ushr(x, y))
 fn rule_ushr_splat() -> RewriteRule {
   {
-    name: "ushr_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {
@@ -512,7 +493,6 @@ fn rule_ushr_splat() -> RewriteRule {
 /// sshr(splat(x), y) -> splat(sshr(x, y))
 fn rule_sshr_splat() -> RewriteRule {
   {
-    name: "sshr_splat",
     apply: fn(eg, class_id) {
       let mut changed = false
       for node in eg.get_nodes(class_id) {

--- a/ir/egraph_builder.mbt
+++ b/ir/egraph_builder.mbt
@@ -5,7 +5,7 @@
 
 ///|
 /// Builder for constructing an EGraph from IR instructions
-pub(all) struct EGraphBuilder {
+struct EGraphBuilder {
   egraph : @egraph.EGraph
   // Map from IR Value id to EClassId
   value_map : Map[Int, @egraph.EClassId]

--- a/ir/func_env.mbt
+++ b/ir/func_env.mbt
@@ -67,7 +67,7 @@ pub const TABLE_ENTRY_STRIDE : Int = 16
 ///|
 /// FuncEnvironment holds VMContext layout info used during IR translation to
 /// desugar Wasm operations.
-pub(all) struct FuncEnvironment {
+struct FuncEnvironment {
   // Global variable types (for determining load/store width)
   global_types : Array[@types.GlobalType]
   // Shared trap block for memory out-of-bounds errors

--- a/ir/ir.mbt
+++ b/ir/ir.mbt
@@ -4,7 +4,7 @@
 ///|
 /// IR Value - represents a virtual register in SSA form
 /// Each value is defined exactly once and can be used multiple times
-pub(all) struct Value {
+pub struct Value {
   id : Int // Unique identifier within a function
   ty : Type // The type of this value
 } derive(Show)
@@ -61,7 +61,7 @@ pub fn Type::from_wasm(wasm_type : @types.ValueType) -> Type {
 /// A basic block is a sequence of instructions with:
 /// - One entry point (the first instruction)
 /// - One exit point (the last instruction, a terminator)
-pub(all) struct Block {
+pub struct Block {
   id : Int // Unique block identifier
   params : Array[(Value, Type)] // Block parameters (for phi nodes)
   instructions : Array[Inst] // Instructions in this block
@@ -93,7 +93,7 @@ pub fn Block::set_terminator(self : Block, term : Terminator) -> Unit {
 
 ///|
 /// Instruction - an SSA instruction that produces a value
-pub(all) struct Inst {
+pub struct Inst {
   result : Value? // The primary value produced (None for void instructions)
   extra_results : Array[Value] // Additional results for multi-value returns (e.g., call returning multiple values)
   mut opcode : Opcode // The operation
@@ -685,7 +685,7 @@ pub enum Terminator {
 
 ///|
 /// Function - a complete IR function
-pub(all) struct Function {
+pub struct Function {
   name : String
   params : Array[(Value, Type)] // Function parameters
   results : Array[Type] // Return types

--- a/ir/optimize.mbt
+++ b/ir/optimize.mbt
@@ -3,7 +3,7 @@
 
 ///|
 /// Result of an optimization pass
-pub(all) struct OptResult {
+pub struct OptResult {
   mut changed : Bool // Whether the IR was modified
 }
 

--- a/ir/pkg.generated.mbti
+++ b/ir/pkg.generated.mbti
@@ -76,7 +76,7 @@ pub fn validate_function(Function) -> ValidationResult
 // Errors
 
 // Types and methods
-pub(all) struct Block {
+pub struct Block {
   id : Int
   params : Array[(Value, Type)]
   instructions : Array[Inst]
@@ -87,9 +87,7 @@ pub fn Block::add_param(Self, Value, Type) -> Unit
 pub fn Block::set_terminator(Self, Terminator) -> Unit
 pub impl Show for Block
 
-type BlockFrame
-
-pub(all) struct CFG {
+pub struct CFG {
   num_blocks : Int
   successors : Array[Array[Int]]
   predecessors : Array[Array[Int]]
@@ -108,13 +106,7 @@ pub fn CFG::postorder(Self) -> Array[Int]
 pub fn CFG::reverse_postorder(Self) -> Array[Int]
 pub fn CFG::to_dot(Self, String) -> String
 
-pub(all) struct EGraphBuilder {
-  egraph : @egraph.EGraph
-  value_map : Map[Int, @egraph.EClassId]
-  class_to_value : Map[Int, Value]
-  def_map : Map[Int, Inst]
-  ruleset : @egraph.IndexedRuleSet
-}
+type EGraphBuilder
 pub fn EGraphBuilder::add_value(Self, Value) -> @egraph.EClassId
 pub fn EGraphBuilder::extract(Self, Value) -> (Int, @egraph.ENode)?
 pub fn EGraphBuilder::get_egraph(Self) -> @egraph.EGraph
@@ -134,10 +126,7 @@ pub(all) enum FloatCC {
 }
 pub impl Show for FloatCC
 
-pub(all) struct FuncEnvironment {
-  global_types : Array[@types.GlobalType]
-  mut memory_trap_block : Block?
-}
+type FuncEnvironment
 pub fn FuncEnvironment::emit_bounds_check(Self, IRBuilder, Value, Int, Value, Int64, Int) -> Value
 pub fn FuncEnvironment::new(Array[@types.GlobalType]) -> Self
 pub fn FuncEnvironment::translate_global_get(Self, IRBuilder, Value, Int) -> Value
@@ -154,7 +143,7 @@ pub fn FuncEnvironment::translate_table_get(Self, IRBuilder, Value, Int, Value, 
 pub fn FuncEnvironment::translate_table_set(Self, IRBuilder, Value, Int, Value, Value, is_table64? : Bool) -> Unit
 pub fn FuncEnvironment::translate_table_size(Self, IRBuilder, Value, Int, is_table64? : Bool) -> Value
 
-pub(all) struct Function {
+pub struct Function {
   name : String
   params : Array[(Value, Type)]
   results : Array[Type]
@@ -170,10 +159,7 @@ pub fn Function::new_value(Self, Type) -> Value
 pub fn Function::print(Self) -> String
 pub impl Show for Function
 
-pub(all) struct IRBuilder {
-  func : Function
-  mut current_block : Block?
-}
+type IRBuilder
 pub fn IRBuilder::add_block_param(Self, Block, Type) -> Value
 pub fn IRBuilder::add_param(Self, Type) -> Value
 pub fn IRBuilder::add_result(Self, Type) -> Unit
@@ -347,7 +333,7 @@ pub fn IRBuilder::v128_to_i32(Self, Opcode, Value) -> Value
 pub fn IRBuilder::v128_unary(Self, Opcode, Value) -> Value
 pub fn IRBuilder::v128_xor(Self, Value, Value) -> Value
 
-pub(all) struct Inst {
+pub struct Inst {
   result : Value?
   extra_results : Array[Value]
   mut opcode : Opcode
@@ -371,7 +357,7 @@ pub(all) enum IntCC {
 }
 pub impl Show for IntCC
 
-pub(all) struct Loop {
+pub struct Loop {
   header : Int
   blocks : Array[Int]
   back_edges : Array[(Int, Int)]
@@ -750,7 +736,7 @@ pub enum OptLevel {
 }
 pub fn OptLevel::from_int(Int) -> Self
 
-pub(all) struct OptResult {
+pub struct OptResult {
   mut changed : Bool
 }
 pub fn OptResult::mark_changed(Self) -> Unit
@@ -766,34 +752,7 @@ pub enum Terminator {
 }
 pub impl Show for Terminator
 
-pub(all) struct Translator {
-  builder : IRBuilder
-  value_stack : Array[Value]
-  locals : Array[Value]
-  block_stack : Array[BlockFrame]
-  func_types : Array[@types.FuncType]
-  func_type_indices : Array[Int]
-  num_imports : Int
-  import_func_type_indices : Array[Int]
-  mut is_unreachable : Bool
-  mut return_continuation : Block?
-  func_result_types : Array[Type]
-  memory_max : Int?
-  memory_is_64 : Array[Bool]
-  table_base_offsets : Array[Int]
-  table_sizes : Array[Int]
-  global_types : Array[@types.GlobalType]
-  num_wasm_params : Int
-  canonical_type_indices : Array[Int]
-  func_base : Int
-  import_remap : Array[Int]
-  module_types : Array[@types.SubType]
-  vmctx : Value
-  func_env : FuncEnvironment
-  tags : Array[@types.TagType]
-  mut try_table_depth : Int
-  table_is_64 : Array[Bool]
-}
+type Translator
 pub fn Translator::new(String, @types.FuncType, Array[@types.ValueType], Array[@types.FuncType], Array[Int], Int, Array[Int], memory_max? : Int?, memory_is_64? : Array[Bool], tables? : Array[@types.Table], global_types? : Array[@types.GlobalType], type_rec_groups? : Array[Int], func_base? : Int, import_remap? : Array[Int], module_types? : Array[@types.SubType], tags? : Array[@types.TagType]) -> Self
 pub fn Translator::translate(Self, Array[@types.Instruction]) -> Function
 
@@ -809,13 +768,13 @@ pub(all) enum Type {
 pub fn Type::from_wasm(@types.ValueType) -> Self
 pub impl Show for Type
 
-pub(all) struct ValidationResult {
+pub struct ValidationResult {
   mut valid : Bool
   errors : Array[String]
 }
 pub fn ValidationResult::new() -> Self
 
-pub(all) struct Value {
+pub struct Value {
   id : Int
   ty : Type
 }

--- a/ir/translator.mbt
+++ b/ir/translator.mbt
@@ -3,7 +3,7 @@
 
 ///|
 /// Translator state for converting a single WASM function to IR
-pub(all) struct Translator {
+struct Translator {
   builder : IRBuilder
   // Value stack - simulates WASM's operand stack
   value_stack : Array[Value]
@@ -31,21 +31,12 @@ pub(all) struct Translator {
   // Memory is 64-bit indexed (for memory64 proposal)
   // memory_is_64[i] = true if memory i uses 64-bit addresses
   memory_is_64 : Array[Bool]
-  // Table base offsets for multi-table support
-  // table_base_offsets[i] = starting index of table i in the flattened indirect_table
-  table_base_offsets : Array[Int]
   // Table sizes for bounds checking
   // table_sizes[i] = number of elements in table i
   table_sizes : Array[Int]
-  // Global variable types
-  // global_types[i] = type of global variable i
-  global_types : Array[@types.GlobalType]
   // Number of wasm function parameters (excludes vmctx params)
   // Used to distinguish params from locals in self.locals array
   num_wasm_params : Int
-  // Canonical type indices for structural type equivalence
-  // Structurally equivalent types map to the same canonical index
-  canonical_type_indices : Array[Int]
   // Cross-module support: base index for this module's functions
   // All function indices are offset by this value (default 0)
   func_base : Int
@@ -69,7 +60,7 @@ pub(all) struct Translator {
 
 ///|
 /// Block frame for tracking control flow constructs
-struct BlockFrame {
+priv struct BlockFrame {
   block : Block // The continuation block
   result_types : Array[Type]
   // Stack height at block entry
@@ -95,6 +86,7 @@ pub fn Translator::new(
   module_types? : Array[@types.SubType] = [],
   tags? : Array[@types.TagType] = [],
 ) -> Translator {
+  type_rec_groups |> ignore // Reserved for future canonical type indices
   let builder = IRBuilder::new(name)
   // Note: add vmctx as explicit params
   // - params[0] = callee_vmctx (X0)
@@ -131,31 +123,13 @@ pub fn Translator::new(
   }
   // Calculate table base offsets for multi-table support
   // All tables are flattened into a single indirect_table at runtime
-  // table_base_offsets[i] = starting index of table i in the flattened table
-  let table_base_offsets : Array[Int] = []
   let table_sizes : Array[Int] = []
   let table_is_64 : Array[Bool] = []
-  let mut offset = 0
   for table in tables {
     let size = table.type_.limits.min.to_int() // Tables always use 32-bit limits
-    table_base_offsets.push(offset)
     table_sizes.push(size)
     table_is_64.push(table.type_.is_table64)
-    offset = offset + size
   }
-  // Compute canonical type indices for structural type equivalence
-  // Structurally equivalent types will map to the same canonical index
-  // Use module_types if available (preserves finality and supertypes),
-  // otherwise fall back to converting func_types
-  let types_for_canonical = if module_types.length() > 0 {
-    module_types
-  } else {
-    @types.func_types_to_subtypes(func_types)
-  }
-  let canonical_type_indices = @types.compute_canonical_type_indices(
-    types_for_canonical,
-    type_rec_groups~,
-  )
   {
     builder,
     value_stack: [],
@@ -170,12 +144,9 @@ pub fn Translator::new(
     func_result_types,
     memory_max,
     memory_is_64,
-    table_base_offsets,
     table_sizes,
     table_is_64,
-    global_types,
     num_wasm_params: func_type.params.length(),
-    canonical_type_indices,
     func_base,
     import_remap,
     module_types,

--- a/ir/validator.mbt
+++ b/ir/validator.mbt
@@ -3,7 +3,7 @@
 
 ///|
 /// Result of IR validation
-pub(all) struct ValidationResult {
+pub struct ValidationResult {
   mut valid : Bool
   errors : Array[String]
 }

--- a/runtime/error.mbt
+++ b/runtime/error.mbt
@@ -62,7 +62,7 @@ fn CallStackEntry::to_string(self : CallStackEntry) -> String {
 
 ///|
 /// Runtime error with additional context for debugging
-pub(all) struct RuntimeErrorContext {
+pub struct RuntimeErrorContext {
   error : RuntimeError
   call_stack : Array[CallStackEntry]
   instruction : String? // The instruction that caused the error

--- a/runtime/gc_traits.mbt
+++ b/runtime/gc_traits.mbt
@@ -82,7 +82,7 @@ pub(open) trait GcHeap {
 
 ///|
 /// GC statistics
-pub(all) struct GcStats {
+pub struct GcStats {
   /// Total allocated objects (including freed slots)
   total_slots : Int
   /// Currently live objects

--- a/runtime/heap.mbt
+++ b/runtime/heap.mbt
@@ -33,7 +33,7 @@ pub struct MarkSweepHeap {
 
 ///|
 /// GC statistics
-pub(all) struct GCStats {
+pub struct GCStats {
   total_objects : Int // Total slots in heap
   live_objects : Int // Number of live objects
   free_slots : Int // Number of free slots

--- a/runtime/imports.mbt
+++ b/runtime/imports.mbt
@@ -27,7 +27,7 @@ pub(all) enum ExternVal {
 
 ///|
 /// Import object: maps (module_name, name) to external values
-pub(all) struct Imports {
+struct Imports {
   entries : Array[(String, String, ExternVal)]
 }
 

--- a/runtime/linker.mbt
+++ b/runtime/linker.mbt
@@ -1,6 +1,6 @@
 ///|
 /// Linker for managing multiple module instances and their dependencies
-pub(all) struct Linker {
+struct Linker {
   store : Store
   modules : Array[(String, ModuleInstance)] // (name, instance) pairs
 }

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -43,7 +43,7 @@ pub(all) struct CallStackEntry {
   func_name : String?
 }
 
-pub(all) struct ExnInstance {
+pub struct ExnInstance {
   tag_addr : Int
   values : Array[@types.Value]
 }
@@ -84,7 +84,7 @@ pub(all) enum GCObject {
 }
 pub impl Show for GCObject
 
-pub(all) struct GCStats {
+pub struct GCStats {
   total_objects : Int
   live_objects : Int
   free_slots : Int
@@ -92,7 +92,7 @@ pub(all) struct GCStats {
 }
 pub impl Show for GCStats
 
-pub(all) struct GcStats {
+pub struct GcStats {
   total_slots : Int
   live_objects : Int
   free_slots : Int
@@ -109,9 +109,7 @@ pub fn GlobalInstance::new(@types.GlobalType, @types.Value) -> Self
 pub fn GlobalInstance::set(Self, @types.Value) -> Unit raise RuntimeError
 pub impl Show for GlobalInstance
 
-pub(all) struct Imports {
-  entries : Array[(String, String, ExternVal)]
-}
+type Imports
 pub fn Imports::add_func(Self, String, String, Int) -> Unit
 pub fn Imports::add_global(Self, String, String, Int) -> Unit
 pub fn Imports::add_memory(Self, String, String, Int) -> Unit
@@ -120,10 +118,7 @@ pub fn Imports::add_tag(Self, String, String, Int) -> Unit
 pub fn Imports::new() -> Self
 pub fn Imports::resolve(Self, String, String) -> ExternVal?
 
-pub(all) struct Linker {
-  store : Store
-  modules : Array[(String, ModuleInstance)]
-}
+type Linker
 pub fn Linker::add_global(Self, String, String, GlobalInstance) -> Unit
 pub fn Linker::add_host_func(Self, String, String, (Array[@types.Value]) -> Array[@types.Value] raise RuntimeError, func_type? : @types.FuncType) -> Unit
 pub fn Linker::add_memory(Self, String, String, Memory) -> Unit
@@ -240,7 +235,7 @@ pub fn ModuleInstance::get_struct_type(Self, Int) -> @types.StructType
 pub fn ModuleInstance::new() -> Self
 pub impl Show for ModuleInstance
 
-pub(all) struct RuntimeErrorContext {
+pub struct RuntimeErrorContext {
   error : RuntimeError
   call_stack : Array[CallStackEntry]
   instruction : String?

--- a/runtime/store.mbt
+++ b/runtime/store.mbt
@@ -1,6 +1,6 @@
 ///|
 /// Exception instance - represents a caught exception
-pub(all) struct ExnInstance {
+pub struct ExnInstance {
   tag_addr : Int // Which tag was thrown
   values : Array[@types.Value] // Exception values
 } derive(Show)

--- a/vcode/block/block.mbt
+++ b/vcode/block/block.mbt
@@ -1,6 +1,6 @@
 ///|
 /// VCode block - a basic block in VCode
-pub(all) struct VCodeBlock {
+pub struct VCodeBlock {
   id : Int
   insts : Array[@instr.VCodeInst] // Instructions in this block
   params : Array[@abi.VReg] // Block parameters

--- a/vcode/block/pkg.generated.mbti
+++ b/vcode/block/pkg.generated.mbti
@@ -11,7 +11,7 @@ import(
 // Errors
 
 // Types and methods
-pub(all) struct VCodeBlock {
+pub struct VCodeBlock {
   id : Int
   insts : Array[@instr.VCodeInst]
   params : Array[@abi.VReg]

--- a/vcode/builder.mbt
+++ b/vcode/builder.mbt
@@ -3,7 +3,7 @@
 
 ///|
 /// VCode builder for constructing VCode functions
-pub(all) struct VCodeBuilder {
+struct VCodeBuilder {
   func : @regalloc.VCodeFunction
   mut current_block : @block.VCodeBlock?
 }

--- a/vcode/gc_compiler.mbt
+++ b/vcode/gc_compiler.mbt
@@ -20,7 +20,7 @@
 
 ///|
 /// Information about a GC safepoint in generated code
-pub(all) struct GcSafepoint {
+pub struct GcSafepoint {
   /// Offset in generated machine code where this safepoint is
   code_offset : Int
   /// Which virtual registers contain live GC references at this point
@@ -31,7 +31,7 @@ pub(all) struct GcSafepoint {
 
 ///|
 /// GC compiler capabilities - what features does this GC need?
-pub(all) struct GcCompilerConfig {
+pub struct GcCompilerConfig {
   /// Does this GC need write barriers?
   needs_write_barriers : Bool
   /// Does this GC need read barriers?

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -66,7 +66,7 @@ pub(all) enum ExceptionLibcall {
 ///|
 /// VCode instruction - a machine-level instruction with virtual registers
 /// Operand constraints for fixed register allocation
-pub(all) struct VCodeInst {
+pub struct VCodeInst {
   opcode : VCodeOpcode
   defs : Array[@abi.Writable] // Registers defined (written)
   uses : Array[@abi.Reg] // Registers used (read)

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -202,7 +202,7 @@ pub(all) enum ShiftType {
 }
 pub impl Show for ShiftType
 
-pub(all) struct VCodeInst {
+pub struct VCodeInst {
   opcode : VCodeOpcode
   defs : Array[@abi.Writable]
   uses : Array[@abi.Reg]

--- a/vcode/lower/aarch64_patterns_wbtest.mbt
+++ b/vcode/lower/aarch64_patterns_wbtest.mbt
@@ -208,7 +208,6 @@ test "apply_aarch64_rule: add_shifted" {
     values: [],
     int_consts: [3L], // shift by 3
     float_consts: [],
-    matched_inst: None,
   }
   // Create a minimal function to get a context
   let builder = @ir.IRBuilder::new("test")
@@ -235,12 +234,7 @@ test "apply_aarch64_rule: add_shifted" {
 
 ///|
 test "apply_aarch64_rule: madd" {
-  let result : MatchResult = {
-    values: [],
-    int_consts: [],
-    float_consts: [],
-    matched_inst: None,
-  }
+  let result : MatchResult = { values: [], int_consts: [], float_consts: [] }
   let builder = @ir.IRBuilder::new("test")
   builder.add_result(@ir.Type::I32)
   let entry = builder.create_block()

--- a/vcode/lower/div_const.mbt
+++ b/vcode/lower/div_const.mbt
@@ -4,7 +4,7 @@
 
 ///|
 /// Magic numbers for unsigned 32-bit division
-pub(all) struct MagicU32 {
+priv struct MagicU32 {
   mul_by : UInt
   do_add : Bool
   shift_by : Int
@@ -12,7 +12,7 @@ pub(all) struct MagicU32 {
 
 ///|
 /// Magic numbers for unsigned 64-bit division
-pub(all) struct MagicU64 {
+priv struct MagicU64 {
   mul_by : UInt64
   do_add : Bool
   shift_by : Int
@@ -20,14 +20,14 @@ pub(all) struct MagicU64 {
 
 ///|
 /// Magic numbers for signed 32-bit division
-pub(all) struct MagicS32 {
+priv struct MagicS32 {
   mul_by : Int
   shift_by : Int
 }
 
 ///|
 /// Magic numbers for signed 64-bit division
-pub(all) struct MagicS64 {
+priv struct MagicS64 {
   mul_by : Int64
   shift_by : Int
 }
@@ -35,7 +35,7 @@ pub(all) struct MagicS64 {
 ///|
 /// Compute magic numbers for unsigned 32-bit division by constant d
 /// Requires: d != 0 && d != 1
-pub fn magic_u32(d : UInt) -> MagicU32 {
+fn magic_u32(d : UInt) -> MagicU32 {
   let mut do_add = false
   let mut p = 31
   // nc = (2^32 - 1) - (2^32 - 1) % d = largest multiple of d <= 2^32 - 1
@@ -77,7 +77,7 @@ pub fn magic_u32(d : UInt) -> MagicU32 {
 ///|
 /// Compute magic numbers for unsigned 64-bit division by constant d
 /// Requires: d != 0 && d != 1
-pub fn magic_u64(d : UInt64) -> MagicU64 {
+fn magic_u64(d : UInt64) -> MagicU64 {
   let mut do_add = false
   let mut p = 63
   let nc = 0xFFFFFFFFFFFFFFFFUL - (0UL - d) % d
@@ -118,7 +118,7 @@ pub fn magic_u64(d : UInt64) -> MagicU64 {
 ///|
 /// Compute magic numbers for signed 32-bit division by constant d
 /// Requires: d != -1 && d != 0 && d != 1
-pub fn magic_s32(d : Int) -> MagicS32 {
+fn magic_s32(d : Int) -> MagicS32 {
   let two31 = 0x80000000U
   let mut p = 31
   let ad = if d < 0 {
@@ -162,7 +162,7 @@ pub fn magic_s32(d : Int) -> MagicS32 {
 ///|
 /// Compute magic numbers for signed 64-bit division by constant d
 /// Requires: d != -1 && d != 0 && d != 1
-pub fn magic_s64(d : Int64) -> MagicS64 {
+fn magic_s64(d : Int64) -> MagicS64 {
   let two63 = 0x8000000000000000UL
   let mut p = 63
   let ad = if d < 0L {

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -9,7 +9,7 @@
 
 ///|
 /// Lowering context - tracks state during IR to VCode conversion
-pub(all) struct LoweringContext {
+struct LoweringContext {
   ir_func : @ir.Function
   vcode_func : @regalloc.VCodeFunction
   // Map from IR Value id to @abi.VReg

--- a/vcode/lower/patterns.mbt
+++ b/vcode/lower/patterns.mbt
@@ -90,19 +90,17 @@ fn opcode_to_pattern(opcode : @ir.Opcode) -> PatternOpcode? {
 
 ///|
 /// Result of a pattern match - captured values and constants
-pub(all) struct MatchResult {
+struct MatchResult {
   // Captured IR values (in order of appearance in pattern)
   values : Array[@ir.Value]
   // Captured constants
   int_consts : Array[Int64]
   float_consts : Array[Double]
-  // The matched instruction
-  mut matched_inst : @ir.Inst?
 }
 
 ///|
 fn MatchResult::new() -> MatchResult {
-  { values: [], int_consts: [], float_consts: [], matched_inst: None }
+  { values: [], int_consts: [], float_consts: [] }
 }
 
 ///|
@@ -130,7 +128,6 @@ pub fn match_pattern(
   ctx : LoweringContext,
 ) -> MatchResult? {
   let result = MatchResult::new()
-  result.matched_inst = Some(inst)
   if match_pattern_impl(pattern, inst, ctx, result) {
     Some(result)
   } else {
@@ -346,7 +343,7 @@ fn is_power_of_2(val : Int64) -> Int? {
 
 ///|
 /// A rewrite rule - matches a pattern and produces optimized VCode
-pub(all) struct RewriteRule {
+struct RewriteRule {
   name : String
   pattern : Pattern
   // Priority - higher priority rules are tried first

--- a/vcode/lower/pkg.generated.mbti
+++ b/vcode/lower/pkg.generated.mbti
@@ -3,11 +3,9 @@ package "Milky2018/wasmoon/vcode/lower"
 
 import(
   "Milky2018/wasmoon/ir"
-  "Milky2018/wasmoon/vcode/abi"
   "Milky2018/wasmoon/vcode/block"
   "Milky2018/wasmoon/vcode/instr"
   "Milky2018/wasmoon/vcode/regalloc"
-  "moonbitlang/core/hashset"
 )
 
 // Values
@@ -31,14 +29,6 @@ pub fn lower_function_optimized(@ir.Function) -> @regalloc.VCodeFunction
 
 pub fn lower_inst_with_patterns(LoweringContext, @ir.Inst, @block.VCodeBlock, Array[RewriteRule]) -> Bool
 
-pub fn magic_s32(Int) -> MagicS32
-
-pub fn magic_s64(Int64) -> MagicS64
-
-pub fn magic_u32(UInt) -> MagicU32
-
-pub fn magic_u64(UInt64) -> MagicU64
-
 pub fn match_pattern(Pattern, @ir.Inst, LoweringContext) -> MatchResult?
 
 pub fn optimize_vcode(@regalloc.VCodeFunction) -> Unit
@@ -58,44 +48,10 @@ pub enum AArch64RewriteResult {
   NoMatch
 }
 
-pub(all) struct LoweringContext {
-  ir_func : @ir.Function
-  vcode_func : @regalloc.VCodeFunction
-  value_map : Map[Int, @abi.VReg]
-  block_map : Map[Int, Int]
-  stack_param_map : Map[Int, (Int, @abi.RegClass)]
-  fused_icmps : @hashset.HashSet[Int]
-}
+type LoweringContext
 pub fn LoweringContext::new(@ir.Function) -> Self
 
-pub(all) struct MagicS32 {
-  mul_by : Int
-  shift_by : Int
-}
-
-pub(all) struct MagicS64 {
-  mul_by : Int64
-  shift_by : Int
-}
-
-pub(all) struct MagicU32 {
-  mul_by : UInt
-  do_add : Bool
-  shift_by : Int
-}
-
-pub(all) struct MagicU64 {
-  mul_by : UInt64
-  do_add : Bool
-  shift_by : Int
-}
-
-pub(all) struct MatchResult {
-  values : Array[@ir.Value]
-  int_consts : Array[Int64]
-  float_consts : Array[Double]
-  mut matched_inst : @ir.Inst?
-}
+type MatchResult
 
 pub enum Pattern {
   Any
@@ -137,11 +93,7 @@ pub enum RewriteResult {
   NoMatch
 }
 
-pub(all) struct RewriteRule {
-  name : String
-  pattern : Pattern
-  priority : Int
-}
+type RewriteRule
 
 // Type aliases
 

--- a/vcode/pkg.generated.mbti
+++ b/vcode/pkg.generated.mbti
@@ -17,15 +17,11 @@ pub fn dump_vcode(@regalloc.VCodeFunction, String) -> Unit
 // Errors
 
 // Types and methods
-pub(all) struct AArch64 {
-  name : String
-}
+type AArch64
 pub fn AArch64::new() -> Self
 pub impl TargetISA for AArch64
 
-pub(all) struct AArch64Regs {
-  placeholder : Int
-}
+type AArch64Regs
 pub fn AArch64Regs::d0(Self) -> @abi.PReg
 pub fn AArch64Regs::d1(Self) -> @abi.PReg
 pub fn AArch64Regs::d2(Self) -> @abi.PReg
@@ -46,13 +42,7 @@ pub fn AArch64Regs::x5(Self) -> @abi.PReg
 pub fn AArch64Regs::x6(Self) -> @abi.PReg
 pub fn AArch64Regs::x7(Self) -> @abi.PReg
 
-pub(all) struct CodeCache {
-  functions : Map[Int, CompiledFunction]
-  mut total_size : Int
-  max_size : Int
-  mut hits : Int
-  mut misses : Int
-}
+type CodeCache
 pub fn CodeCache::clear(Self) -> Unit
 pub fn CodeCache::contains(Self, Int) -> Bool
 pub fn CodeCache::get(Self, Int) -> CompiledFunction?
@@ -63,7 +53,7 @@ pub fn CodeCache::remove(Self, Int) -> Unit
 pub fn CodeCache::stats(Self) -> (Int, Int, Int, Int)
 pub impl Show for CodeCache
 
-pub(all) struct CompiledFunction {
+pub struct CompiledFunction {
   name : String
   code : @emit.MachineCode
   entry_offset : Int
@@ -77,14 +67,7 @@ pub fn CompiledFunction::is_valid(Self) -> Bool
 pub fn CompiledFunction::new(String, @emit.MachineCode, Int) -> Self
 pub impl Show for CompiledFunction
 
-pub(all) struct ExecutableRegion {
-  id : Int
-  base_addr : Int
-  size : Int
-  mut write_pos : Int
-  code : Array[Int]
-  mut finalized : Bool
-}
+type ExecutableRegion
 pub fn ExecutableRegion::address_at(Self, Int) -> Int
 pub fn ExecutableRegion::finalize(Self) -> Unit
 pub fn ExecutableRegion::new(Int, Int) -> Self
@@ -93,7 +76,7 @@ pub fn ExecutableRegion::remaining(Self) -> Int
 pub fn ExecutableRegion::write(Self, Array[Int]) -> Result[Int, String]
 pub impl Show for ExecutableRegion
 
-pub(all) struct GcCompilerConfig {
+pub struct GcCompilerConfig {
   needs_write_barriers : Bool
   needs_read_barriers : Bool
   needs_safepoints : Bool
@@ -102,19 +85,14 @@ pub(all) struct GcCompilerConfig {
 }
 pub impl Show for GcCompilerConfig
 
-pub(all) struct GcSafepoint {
+pub struct GcSafepoint {
   code_offset : Int
   live_refs : Array[Int]
   metadata : Int64
 }
 pub impl Show for GcSafepoint
 
-pub(all) struct JITRuntime {
-  cache : CodeCache
-  memory : MemoryManager
-  mut compilations : Int
-  mut recompilations : Int
-}
+type JITRuntime
 pub fn JITRuntime::clear(Self) -> Unit
 pub fn JITRuntime::invalidate(Self, Int) -> Unit
 pub fn JITRuntime::lookup(Self, Int) -> CompiledFunction?
@@ -123,12 +101,7 @@ pub fn JITRuntime::register(Self, Int, CompiledFunction) -> Result[Int, String]
 pub fn JITRuntime::stats(Self) -> (Int, Int, Int, Int, Int, Int, Int)
 pub impl Show for JITRuntime
 
-pub(all) struct MemoryManager {
-  regions : Array[ExecutableRegion]
-  default_region_size : Int
-  mut next_id : Int
-  mut current_region : Int?
-}
+type MemoryManager
 pub fn MemoryManager::alloc_region(Self, Int) -> ExecutableRegion
 pub fn MemoryManager::finalize_all(Self) -> Unit
 pub fn MemoryManager::get_current_region(Self) -> ExecutableRegion
@@ -156,10 +129,7 @@ pub fn PlatformABI::int_arg_regs(Self) -> Int
 pub fn PlatformABI::requires_16_byte_stack_align(Self) -> Bool
 pub impl Show for PlatformABI
 
-pub(all) struct VCodeBuilder {
-  func : @regalloc.VCodeFunction
-  mut current_block : @block.VCodeBlock?
-}
+type VCodeBuilder
 pub fn VCodeBuilder::add(Self, @abi.VReg, @abi.VReg, is_64? : Bool) -> @abi.VReg
 pub fn VCodeBuilder::add_param(Self, @abi.RegClass) -> @abi.VReg
 pub fn VCodeBuilder::add_result(Self, @abi.RegClass) -> Unit

--- a/vcode/runtime.mbt
+++ b/vcode/runtime.mbt
@@ -10,7 +10,7 @@
 
 ///|
 /// A compiled function ready for execution
-pub(all) struct CompiledFunction {
+pub struct CompiledFunction {
   // Function name or identifier
   name : String
   // The compiled machine code bytes
@@ -74,7 +74,7 @@ pub impl Show for CompiledFunction with output(self, logger) {
 
 ///|
 /// Cache for storing compiled functions
-pub(all) struct CodeCache {
+struct CodeCache {
   // Function index -> compiled function
   functions : Map[Int, CompiledFunction]
   // Total size of all cached code
@@ -227,7 +227,7 @@ pub impl Show for CodeCache with output(self, logger) {
 ///|
 /// Represents a region of memory that can hold executable code
 /// (Abstraction - actual executable memory requires platform-specific implementation)
-pub(all) struct ExecutableRegion {
+struct ExecutableRegion {
   // Identifier for this region
   id : Int
   // Base address (simulated)
@@ -325,7 +325,7 @@ pub impl Show for ExecutableRegion with output(self, logger) {
 
 ///|
 /// Manages executable memory regions
-pub(all) struct MemoryManager {
+struct MemoryManager {
   // All allocated regions
   regions : Array[ExecutableRegion]
   // Default region size
@@ -447,7 +447,7 @@ pub impl Show for MemoryManager with output(self, logger) {
 
 ///|
 /// Complete JIT runtime combining code cache and memory management
-pub(all) struct JITRuntime {
+struct JITRuntime {
   // Code cache
   cache : CodeCache
   // Memory manager

--- a/vcode/target.mbt
+++ b/vcode/target.mbt
@@ -106,7 +106,7 @@ pub fn PlatformABI::float_arg_regs(self : PlatformABI) -> Int {
 
 ///|
 /// AArch64 target ISA
-pub(all) struct AArch64 {
+struct AArch64 {
   name : String
 }
 
@@ -161,14 +161,12 @@ pub impl TargetISA for AArch64 with pointer_size(_self) -> Int {
 // ============ AArch64 Register Definitions ============
 
 ///|
-/// AArch64 register names and roles
-pub(all) struct AArch64Regs {
-  placeholder : Int // Placeholder field
-}
+/// AArch64 register names and roles (namespace for register constants)
+struct AArch64Regs {}
 
 ///|
 pub fn AArch64Regs::new() -> AArch64Regs {
-  { placeholder: 0 }
+  AArch64Regs::{  }
 }
 
 // General-purpose registers


### PR DESCRIPTION
## Summary

- Refactor `pub(all)` types to appropriate visibility levels across the codebase
- Remove dead code discovered during the refactor
- Delete 640 lines of unused code

## Changes by Package

### ir/
- Builders (`IRBuilder`, `Translator`, `EGraphBuilder`, `FuncEnvironment`) → abstract
- Core types (`Value`, `Block`, `Inst`, `Function`, `CFG`, `Loop`, `OptResult`, `ValidationResult`) → `pub struct`
- Remove dead fields from `Translator`: `table_base_offsets`, `global_types`, `canonical_type_indices`
- Mark `BlockFrame` as `priv`

### ir/egraph/
- Remove unused `name` field from `RewriteRule` (251 rule definitions updated)
- Keep `EClassId`, `ENode`, `EOpcode` as `pub(all)` (external construction needed)

### vcode/
- `VCodeBuilder` → abstract
- `VCodeBlock`, `CompiledFunction`, `GcSafepoint`, `GcCompilerConfig` → `pub struct`
- `CodeCache`, `ExecutableRegion`, `MemoryManager`, `JITRuntime`, `AArch64`, `AArch64Regs` → abstract
- Delete unused `placeholder` field from `AArch64Regs`

### vcode/lower/
- Remove unused `matched_inst` field from `MatchResult`
- Magic number types (`MagicU32/U64/S32/S64`) → `priv`
- `LoweringContext`, `MatchResult`, `RewriteRule` → abstract

### vcode/instr/
- `VCodeInst` → `pub struct`
- All enums remain `pub(all)` (pattern matching needed)

### runtime/
- `Linker`, `Imports` → abstract
- `RuntimeErrorContext`, `GCStats`, `GcStats`, `ExnInstance` → `pub struct`
- Keep `CallStackEntry`, `ModuleInstance` as `pub(all)` (external construction)

## Test plan

- [x] `moon check` passes with no warnings
- [x] All 1429 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)