### PR TITLE
fix(wat): reject trailing tokens and fail CLI

### DIFF
--- a/cli/main/path.mbt
+++ b/cli/main/path.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Load a module from file path (supports both .wasm and .wat)
 fn load_module_from_path(path : String) -> @types.Module raise CliError {
-  let is_wat = path.has_suffix(".wat")
+  let is_wat = path.has_suffix(".wat") || path.has_suffix(".wast")
   if is_wat {
     let content = @fs.read_file_to_string(path) catch {
       IOError(_e) => raise FileNotFound(path)

--- a/cli/main/run.mbt
+++ b/cli/main/run.mbt
@@ -1,4 +1,12 @@
 ///|
+extern "c" fn native_exit(code : Int) = "exit"
+
+///|
+fn exit_failure() -> Unit {
+  native_exit(1)
+}
+
+///|
 /// Get the basename from a file path (last component after /)
 fn get_basename(path : String) -> String {
   // Find last '/' character
@@ -284,6 +292,7 @@ fn run_wasm(
         @logger.error(
           "invalid --dir format '\{dir}', expected HOST_DIR or HOST_DIR::GUEST_DIR",
         )
+        exit_failure()
         return
       }
     }
@@ -298,6 +307,7 @@ fn run_wasm(
       }
       None => {
         @logger.error("invalid --env format '\{env_var}', expected NAME=VALUE")
+        exit_failure()
         return
       }
     }
@@ -340,6 +350,7 @@ fn run_wasm(
         let preload_mod = load_module_from_path(path) catch {
           e => {
             @logger.error("loading preload module '\{name}': \{e}")
+            exit_failure()
             return
           }
         }
@@ -348,6 +359,7 @@ fn run_wasm(
         ) catch {
           e => {
             @logger.error("instantiating preload module '\{name}': \{e}")
+            exit_failure()
             return
           }
         }
@@ -355,6 +367,7 @@ fn run_wasm(
       }
       None => {
         @logger.error("invalid preload format '\{preload}', expected NAME=PATH")
+        exit_failure()
         return
       }
     }
@@ -363,6 +376,7 @@ fn run_wasm(
   let mod_ = load_module_from_path(wasm_path) catch {
     e => {
       @logger.error("loading main module: \{e}")
+      exit_failure()
       return
     }
   }
@@ -383,6 +397,7 @@ fn run_wasm(
   let instance = @executor.instantiate_module_with_imports(store, mod_, imports) catch {
     e => {
       @logger.error("instantiating module: \{e}")
+      exit_failure()
       return
     }
   }
@@ -400,6 +415,7 @@ fn run_wasm(
     let args = parse_func_args(ft.params, func_args) catch {
       e => {
         @logger.error("parsing arguments: \{e}")
+        exit_failure()
         return
       }
     }
@@ -430,6 +446,7 @@ fn run_wasm(
       ) catch {
         e => {
           @logger.error("\{e}")
+          exit_failure()
           return
         }
       }
@@ -442,6 +459,7 @@ fn run_wasm(
     // No exported function found, check if there's a start function
   } else if invoke is Some(name) {
     @logger.error("function '\{name}' not found")
+    exit_failure()
   }
 }
 

--- a/wat/parser.mbt
+++ b/wat/parser.mbt
@@ -685,7 +685,11 @@ fn count_tag_imports(imports : Array[@types.Import]) -> Int {
 /// Parse a WAT module from string
 pub fn parse(input : String) -> @types.Module raise WatError {
   let parser = Parser::new(input)
-  parser.parse_module()
+  let mod_ = parser.parse_module()
+  if parser.current.token != Eof {
+    raise WatError::UnexpectedToken("unexpected trailing tokens", parser.loc())
+  }
+  mod_
 }
 
 ///|

--- a/wat/wat_test.mbt
+++ b/wat/wat_test.mbt
@@ -246,6 +246,16 @@ test "parse data segment with offset keyword" {
   inspect(mod_.datas[0].init.length(), content="4")
 }
 
+///|
+test "reject trailing tokens after module" {
+  let wat = "(module))"
+  let result = try? parse(wat)
+  match result {
+    Err(_) => ()
+    Ok(_) => fail("expected parse error but parsing succeeded")
+  }
+}
+
 // ============================================================
 // Error Formatting Tests
 // ============================================================


### PR DESCRIPTION
## Summary
- Make `@wat.parse` reject trailing tokens after a `(module ...)` so malformed `.wat`/`.wast` is not silently accepted.
- Ensure `wasmoon run` exits with status 1 on load/parse/instantiate/arg errors instead of returning 0.
- Treat `.wast` extension as text modules in `load_module_from_path` (for module-only WAST files).

## Testing
- `moon test -p wat`
- `moon check`
- Manual: `./wasmoon-tools validate nwf.wat` and `./wasmoon run nwf.wat` now fail