### PR TITLE
refactor(jit): centralize reference encoding

### DIFF
--- a/cli/main/run.mbt
+++ b/cli/main/run.mbt
@@ -68,7 +68,7 @@ fn convert_args_to_jit(args : Array[@types.Value]) -> Array[Int64] {
       F32(f) => f.reinterpret_as_int().to_int64()
       F64(d) => d.reinterpret_as_int64()
       FuncRef(idx) => idx.to_int64()
-      ExternRef(idx) => idx.to_int64()
+      ExternRef(idx) => @jit.encode_externref(idx)
       Null => @types.NULL_REF
       V128(_) => abort("V128 args not yet supported")
       StructRef(idx) => idx.to_int64() << 1
@@ -126,7 +126,10 @@ fn convert_jit_results(
         if raw == @types.NULL_REF {
           Null
         } else {
-          ExternRef(raw.to_int())
+          match @jit.decode_externref(raw) {
+            Some(idx) => ExternRef(idx)
+            None => ExternRef(raw.to_int())
+          }
         }
       }
       AnyRef | NullRef | RefAny | RefEq | RefNullEq => {
@@ -662,20 +665,18 @@ fn get_import_func_type_idx(imports : Array[@types.Import], idx : Int) -> Int? {
 
 ///|
 /// Convert a store function address to module function index
-/// Returns -1 if not found (for null reference sentinel)
 fn store_addr_to_module_func_idx(
   store_addr : Int,
   instance : @runtime.ModuleInstance,
-) -> Int {
+) -> Int? {
   // Search for the store address in the instance's func_addrs
   for i, addr in instance.func_addrs {
     if addr == store_addr {
-      return i
+      return Some(i)
     }
   }
-  // Not found - this shouldn't happen for valid function references
-  // Return -1 to trigger a null reference trap
-  -1
+  // Not found - treat as null
+  None
 }
 
 ///|
@@ -698,8 +699,6 @@ fn init_jit_globals(
   if globals_ptr == 0L {
     return 0L
   }
-  // FUNCREF_TAG: bit 61 set for tagged function pointers (same as lower_get_func_ref)
-  let funcref_tag = 0x2000000000000000L
   // Write each global value to the array
   for i in 0..<num_globals {
     let global_addr = instance.global_addrs[i]
@@ -713,17 +712,18 @@ fn init_jit_globals(
       I64(n) => @types.ToInt64::to_int64_bits(n)
       F32(f) => @types.ToInt64::to_int64_bits(f)
       F64(d) => @types.ToInt64::to_int64_bits(d)
-      FuncRef(store_addr) => {
-        // Convert store address to module function index
-        let func_idx = store_addr_to_module_func_idx(store_addr, instance)
-        // Get function pointer from JIT module and tag it
-        let func_ptr = jit_module.get_func_ptr(func_idx)
-        if func_ptr == 0L {
-          @types.NULL_REF
-        } else { // null funcref
-          func_ptr | funcref_tag // Tagged function pointer
+      FuncRef(store_addr) =>
+        match store_addr_to_module_func_idx(store_addr, instance) {
+          Some(func_idx) => {
+            let func_ptr = jit_module.get_func_ptr(func_idx)
+            if func_ptr == 0L {
+              @types.NULL_REF
+            } else {
+              @jit.tag_funcref_ptr(func_ptr)
+            }
+          }
+          None => @types.NULL_REF
         }
-      }
       ExternRef(idx) => idx.to_int64()
       ExnRef(idx) => idx.to_int64()
       ArrayRef(gc_ref) => @jit.encode_heap_ref(gc_ref)
@@ -769,8 +769,8 @@ fn init_jit_tables(
   for i, addr in instance.func_addrs {
     func_addr_to_idx.set(addr, i)
   }
-  // Copy table contents into JIT tables as (func_ptr, type_idx) pairs
-  let elem_init : Array[(Int, Int, Int, Int)] = []
+  // Copy table contents into JIT tables as (funcref?, type_idx) pairs
+  let elem_init : Array[(Int, Int, Int?, Int)] = []
   for table_idx, table_addr in instance.table_addrs {
     let runtime_table = store.get_table(table_addr) catch { _ => continue }
     // Avoid writing past the allocated JIT table size (JIT tables are sized at instantiation).
@@ -783,20 +783,20 @@ fn init_jit_tables(
       let value = runtime_table.get(elem_idx) catch { _ => continue }
       match value {
         FuncRef(store_addr) => {
-          let func_idx = match func_addr_to_idx.get(store_addr) {
-            Some(idx) => idx
+          let func_idx = func_addr_to_idx.get(store_addr)
+          let type_idx = match func_idx {
+            Some(idx) =>
+              if idx >= 0 && idx < instance.func_type_indices.length() {
+                instance.func_type_indices[idx]
+              } else {
+                -1
+              }
             None => -1
-          }
-          let type_idx = if func_idx >= 0 &&
-            func_idx < instance.func_type_indices.length() {
-            instance.func_type_indices[func_idx]
-          } else {
-            -1
           }
           elem_init.push((table_idx, elem_idx, func_idx, type_idx))
         }
         // Null and non-funcref entries are written as null to keep shared tables consistent.
-        _ => elem_init.push((table_idx, elem_idx, -1, -1))
+        _ => elem_init.push((table_idx, elem_idx, None, -1))
       }
     }
   }

--- a/jit/jit_runtime.mbt
+++ b/jit/jit_runtime.mbt
@@ -871,7 +871,7 @@ pub fn setup_data_segments(datas : Array[@types.Data]) -> Unit {
 /// This must be called before running code that uses table.init or elem.drop.
 /// The segments are stored globally and accessed by libcalls.
 /// elem_values: Array of Int64 arrays, one per element segment
-///   Each Int64 represents a function reference (func_idx) or null (-1)
+///   Each Int64 represents an encoded funcref table entry (tagged func ptr) or null (0)
 pub fn setup_elem_segments(elem_values : Array[Array[Int64]]) -> Unit {
   if elem_values.is_empty() {
     return
@@ -905,11 +905,11 @@ pub fn clear_segments() -> Unit {
 ///|
 /// Initialize shared tables from Store (for multi-table support with table imports/exports).
 /// jit_tables: Array of JITTable from Store (one per runtime table)
-/// elem_init: Array of (table_idx, elem_idx, func_idx, type_hash) tuples
+/// elem_init: Array of (table_idx, elem_idx, func_idx?, type_hash) tuples
 pub fn JITModule::init_shared_tables(
   self : JITModule,
   jit_tables : Array[JITTable?],
-  elem_init : Array[(Int, Int, Int, Int)],
+  elem_init : Array[(Int, Int, Int?, Int)],
 ) -> Unit {
   if self.context is None {
     return
@@ -931,15 +931,11 @@ pub fn JITModule::init_shared_tables(
       Some(tbl) => tbl
       None => continue
     }
-    // Get function pointer and encode as funcref
-    // func_idx = -1 represents ref.null (null reference sentinel)
-    let funcref_value = if func_idx == -1 {
-      @types.NULL_REF
-    } else { // Use NULL_REF for null reference
-      // Tag function pointer with FUNCREF_TAG (bit 61) for ref.test detection
-      // FUNCREF_TAG = 0x2000000000000000
-      self.get_func_ptr(func_idx) | 0x2000000000000000L
+    let funcref_value = match func_idx {
+      Some(idx) => tag_funcref_ptr(self.get_func_ptr(idx))
+      None => @types.NULL_REF
     }
+
     // Set the table entry (including null references)
     jit_table.set(elem_idx, funcref_value, type_hash)
   }

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -20,13 +20,27 @@ pub fn check_trap() -> Unit raise JITTrap
 
 pub fn clear_segments() -> Unit
 
+pub fn decode_externref(Int64) -> Int?
+
+pub fn decode_funcref_idx(Int64) -> Int?
+
+pub fn decode_gc_heap_ref(Int64) -> Int?
+
 pub fn decode_heap_ref(Int64) -> Int
 
 pub fn decode_i31(Int64) -> Int
 
+pub fn encode_externref(Int) -> Int64
+
+pub fn encode_funcref_idx(Int) -> Int64
+
+pub fn encode_gc_heap_ref(Int) -> Int64
+
 pub fn encode_heap_ref(Int) -> Int64
 
 pub fn encode_i31(Int) -> Int64
+
+pub fn encode_null_ref() -> Int64
 
 pub fn free_memory(Int64) -> Unit
 
@@ -178,11 +192,15 @@ pub fn get_temperature(Int, HotThreshold) -> FunctionTemperature
 
 pub fn i64_to_value(Int64, @types.ValueType) -> @types.Value
 
+pub fn is_funcref_ptr(Int64) -> Bool
+
 pub fn is_i31(Int64) -> Bool
 
 pub fn is_jit_supported_module(String) -> Bool
 
 pub fn is_null(Int64) -> Bool
+
+pub fn is_null_ref(Int64) -> Bool
 
 pub fn memory_init(Int64, Int64, Bytes) -> Bool
 
@@ -191,6 +209,10 @@ pub fn setup_data_segments(Array[@types.Data]) -> Unit
 pub fn setup_elem_segments(Array[Array[Int64]]) -> Unit
 
 pub fn setup_type_cache_from_types(Array[@types.SubType], Array[Int]) -> Unit
+
+pub fn tag_funcref_ptr(Int64) -> Int64
+
+pub fn untag_funcref_ptr(Int64) -> Int64
 
 pub fn value_to_i64(@types.Value) -> Int64
 
@@ -432,7 +454,7 @@ pub fn JITModule::get_func_ptr_by_name(Self, String) -> Int64
 pub fn JITModule::get_func_table_ptr(Self) -> Int64
 pub fn JITModule::has_wasm_stack(Self) -> Bool
 pub fn JITModule::init_indirect_table(Self, Int, Array[(Int, Int, Int)]) -> Unit
-pub fn JITModule::init_shared_tables(Self, Array[JITTable?], Array[(Int, Int, Int, Int)]) -> Unit
+pub fn JITModule::init_shared_tables(Self, Array[JITTable?], Array[(Int, Int, Int?, Int)]) -> Unit
 pub fn JITModule::init_wasi(Self, Array[String], Array[String], Array[(String, String)]) -> Unit
 pub fn JITModule::init_wasi_quiet(Self, Array[String], Array[String], Array[(String, String)]) -> Unit
 pub fn JITModule::load(@cwasm.PrecompiledModule, Array[(Array[@types.ValueType], Array[@types.ValueType])], debug_db? : JITDebugDB?) -> Self?

--- a/jit/ref_encoding.mbt
+++ b/jit/ref_encoding.mbt
@@ -1,0 +1,82 @@
+/// Reference encoding helpers for JIT/runtime interop.
+///
+/// There are multiple representations used for references:
+/// - Raw (JIT ABI for values): null = 0
+/// - Funcref (index form): raw = -(func_idx + 1)  (so -1 is func_idx 0, not null)
+/// - Funcref (pointer form): raw = func_ptr | FUNCREF_TAG
+/// - Externref: raw = EXTERNREF_TAG | (host_idx << 1)
+/// - GC refs: raw = (heap_idx0 + 1) << 1
+/// - i31: raw = (value << 1) | 1
+
+///|
+pub fn is_null_ref(raw : Int64) -> Bool {
+  raw == @types.NULL_REF
+}
+
+///|
+pub fn encode_null_ref() -> Int64 {
+  @types.NULL_REF
+}
+
+///|
+pub fn encode_funcref_idx(func_idx : Int) -> Int64 {
+  -(func_idx.to_int64() + 1L)
+}
+
+///|
+pub fn decode_funcref_idx(raw : Int64) -> Int? {
+  if raw < 0L {
+    Some((-(raw + 1L)).to_int())
+  } else {
+    None
+  }
+}
+
+///|
+pub fn is_funcref_ptr(raw : Int64) -> Bool {
+  (raw & @types.FUNCREF_TAG) != 0L
+}
+
+///|
+pub fn tag_funcref_ptr(func_ptr : Int64) -> Int64 {
+  func_ptr | @types.FUNCREF_TAG
+}
+
+///|
+pub fn untag_funcref_ptr(tagged_ptr : Int64) -> Int64 {
+  // Clear bit 61
+  tagged_ptr & 0xDFFFFFFFFFFFFFFFL
+}
+
+///|
+pub fn encode_externref(host_idx : Int) -> Int64 {
+  @types.EXTERNREF_TAG | (host_idx.to_int64() << 1)
+}
+
+///|
+pub fn decode_externref(raw : Int64) -> Int? {
+  if (raw & @types.EXTERNREF_TAG) != 0L {
+    // Clear the tag bit and shift back.
+    Some(((raw ^ @types.EXTERNREF_TAG) >> 1).to_int())
+  } else {
+    None
+  }
+}
+
+///|
+pub fn encode_gc_heap_ref(heap_idx0 : Int) -> Int64 {
+  (heap_idx0 + 1).to_int64() << 1
+}
+
+///|
+pub fn decode_gc_heap_ref(raw : Int64) -> Int? {
+  if raw == @types.NULL_REF {
+    None
+  } else if (raw & (@types.FUNCREF_TAG | @types.EXTERNREF_TAG)) != 0L {
+    None
+  } else if (raw & 1L) == 1L {
+    None
+  } else {
+    Some(((raw >> 1) - 1L).to_int())
+  }
+}

--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -120,7 +120,10 @@ pub fn jit_results_to_values(
         if raw == 0L {
           Null
         } else {
-          ExternRef(raw.to_int())
+          match @jit.decode_externref(raw) {
+            Some(idx) => ExternRef(idx)
+            None => ExternRef(raw.to_int())
+          }
         }
       }
       // GC reference types - decode using JIT encoding:
@@ -202,19 +205,18 @@ pub fn value_to_jit_arg_typed(
         | RefFunc
         | RefFuncTyped(_)
         | RefNullFuncTyped(_)
-        | NullFuncRef => -(idx.to_int64() + 1L)
+        | NullFuncRef => @jit.encode_funcref_idx(idx)
         _ => idx.to_int64()
       }
     ExternRef(idx) =>
       match ty {
-        ExternRef | RefExtern | NullExternRef =>
-          @types.EXTERNREF_TAG | (idx.to_int64() << 1)
+        ExternRef | RefExtern | NullExternRef => @jit.encode_externref(idx)
         _ => idx.to_int64()
       }
     ExnRef(idx) => idx.to_int64()
     // GC references: encoding uses 0 for null
-    ArrayRef(gc_ref) => (gc_ref.to_int64() + 1L) << 1
-    StructRef(gc_ref) => (gc_ref.to_int64() + 1L) << 1
+    ArrayRef(gc_ref) => @jit.encode_gc_heap_ref(gc_ref)
+    StructRef(gc_ref) => @jit.encode_gc_heap_ref(gc_ref)
     I31(n) => (n.to_int64() << 1) | 1L
     Null => 0L
     V128(_) => abort("V128 not yet supported in testsuite")
@@ -619,8 +621,8 @@ pub fn init_elem_segments(
     }
   }
 
-  // Process elem segments: build (table_idx, elem_idx, func_idx, type_hash) tuples
-  let elem_init : Array[(Int, Int, Int, Int)] = []
+  // Process elem segments: build (table_idx, elem_idx, func_idx?, type_hash) tuples
+  let elem_init : Array[(Int, Int, Int?, Int)] = []
   for table_idx, _table in mod_.tables {
     // Process elem segments for this table
     for elem in mod_.elems {
@@ -629,16 +631,19 @@ pub fn init_elem_segments(
         let offset = eval_elem_offset_expr(offset_expr, globals)
         for i, init_expr in elem.init {
           let func_idx = match init_expr {
-            [RefFunc(idx)] => idx
-            [I32Const(idx)] => idx
-            [RefNull(_)] => -1 // Use -1 to represent null reference
+            [RefFunc(idx)] => Some(idx)
+            [I32Const(idx)] => Some(idx)
+            [RefNull(_)] => None
             _ => continue
           }
-          let canonical_type_idx = if func_idx >= 0 &&
-            func_idx < func_canonical_types.length() {
-            func_canonical_types[func_idx]
-          } else {
-            0
+          let canonical_type_idx = match func_idx {
+            Some(idx) =>
+              if idx >= 0 && idx < func_canonical_types.length() {
+                func_canonical_types[idx]
+              } else {
+                0
+              }
+            None => 0
           }
           // Element index within this specific table
           let elem_idx = offset + i

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -8,11 +8,17 @@
 // They must match the encoding in jit/jit_ffi/jit.c
 
 ///|
-/// Null reference value for GC types and externref (used in JIT)
+/// Null reference value in JIT/reference encodings.
+///
+/// This is also used by GC encodings to avoid collisions with non-null refs.
 pub const NULL_REF : Int64 = 0L
 
 ///|
-/// Null reference sentinel for funcref in interpreter mode
+/// Legacy constant kept for compatibility.
+///
+/// Do not use this as a "null reference" value.
+/// JIT/reference encodings use `NULL_REF` (=0) for null, and `-1` is commonly
+/// used by the JIT ABI to encode funcref index 0 as `-(idx+1)`.
 pub const FUNCREF_NULL_SENTINEL : Int64 = -1L
 
 ///|

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -171,7 +171,7 @@ fn ir_type_to_mem_type(ty : @ir.Type) -> @instr.MemType {
     @ir.Type::F32 => F32
     @ir.Type::F64 => F64
     @ir.Type::V128 => V128
-    // Reference types use 64-bit storage (-1L as null sentinel)
+    // Reference types use 64-bit storage (0 as null)
     @ir.Type::FuncRef | @ir.Type::ExternRef => I64
   }
 }

--- a/wast/jit_support.mbt
+++ b/wast/jit_support.mbt
@@ -187,7 +187,10 @@ pub fn sync_jit_globals_to_store(
           if raw_value == 0L {
             @types.Value::Null
           } else if (raw_value & EXTERNREF_TAG) != 0L {
-            @types.Value::ExternRef((raw_value >> 1).to_int())
+            match @jit.decode_externref(raw_value) {
+              Some(idx) => @types.Value::ExternRef(idx)
+              None => @types.Value::ExternRef(raw_value.to_int())
+            }
           } else {
             // Fallback: treat as raw host index
             @types.Value::ExternRef(raw_value.to_int())
@@ -379,23 +382,26 @@ pub fn init_elem_segments(
     jit_tables.push(jit_table)
   }
 
-  // Initialize elements: (table_idx, elem_idx, func_idx, canonical_type_idx)
-  let elem_init : Array[(Int, Int, Int, Int)] = []
+  // Initialize elements: (table_idx, elem_idx, func_idx?, canonical_type_idx)
+  let elem_init : Array[(Int, Int, Int?, Int)] = []
   for elem in mod_.elems {
     if elem.mode is @types.ElemMode::Active(table_idx, offset_expr) {
       let offset = eval_elem_offset_expr(offset_expr, globals)
       for i, init_expr in elem.init {
         let func_idx = match init_expr {
-          [RefFunc(idx)] => idx
-          [I32Const(idx)] => idx
-          [RefNull(_)] => -1 // Use -1 to represent null reference
+          [RefFunc(idx)] => Some(idx)
+          [I32Const(idx)] => Some(idx)
+          [RefNull(_)] => None
           _ => continue
         }
-        let canonical_type_idx = if func_idx >= 0 &&
-          func_idx < func_canonical_types.length() {
-          func_canonical_types[func_idx]
-        } else {
-          0
+        let canonical_type_idx = match func_idx {
+          Some(idx) =>
+            if idx >= 0 && idx < func_canonical_types.length() {
+              func_canonical_types[idx]
+            } else {
+              0
+            }
+          None => 0
         }
         // No flattening: use actual table_idx and elem_idx
         let elem_idx = offset + i

--- a/wast/runner.mbt
+++ b/wast/runner.mbt
@@ -680,10 +680,8 @@ pub fn invoke_action(
                     )
                   RefNull(_) => i64_args.push(NULL_REF)
                   // Externref uses special encoding: EXTERNREF_TAG | (host_idx << 1)
-                  RefExtern(n) =>
-                    i64_args.push(EXTERNREF_TAG | (n.to_int64() << 1))
-                  RefHost(n) =>
-                    i64_args.push(EXTERNREF_TAG | (n.to_int64() << 1))
+                  RefExtern(n) => i64_args.push(@jit.encode_externref(n))
+                  RefHost(n) => i64_args.push(@jit.encode_externref(n))
                   RefFunc => i64_args.push(NULL_REF) // placeholder
                   RefExternAny => i64_args.push(NULL_REF) // placeholder
                   // GC reference types - these shouldn't appear as args but handle them
@@ -872,7 +870,10 @@ fn convert_jit_result(
       if v == NULL_REF {
         @types.Value::Null
       } else {
-        @types.Value::ExternRef((v >> 1).to_int())
+        match @jit.decode_externref(v) {
+          Some(idx) => @types.Value::ExternRef(idx)
+          None => @types.Value::ExternRef(v.to_int())
+        }
       }
     // GC reference types - decode using c_heap encoding
     // Encoding: StructRef/ArrayRef = (gc_ref - 1) << 1 (even), i31 = (value << 1) | 1 (odd), null = NULL_REF
@@ -882,8 +883,10 @@ fn convert_jit_result(
         @types.Value::Null
       } else if (v & EXTERNREF_TAG) != 0L {
         // Host externref that was converted to anyref via any.convert_extern
-        // Decode by shifting right to get the original host_idx
-        @types.Value::ExternRef((v >> 1).to_int())
+        match @jit.decode_externref(v) {
+          Some(idx) => @types.Value::ExternRef(idx)
+          None => @types.Value::ExternRef(v.to_int())
+        }
       } else if (v & 1L) == 1L {
         // i31 (odd)
         @types.Value::I31((v >> 1).to_int())


### PR DESCRIPTION
## Summary
- Add `jit/ref_encoding.mbt` as the single source of truth for JIT raw reference encodings (null=0; funcref index encoding; externref tag encoding).
- Replace scattered `-1` null sentinels with `Int?` where appropriate (table element initialization) to avoid ambiguity.
- Fix externref decoding to clear `EXTERNREF_TAG` before shifting.
- Clarify `types/types.mbt` docs: `FUNCREF_NULL_SENTINEL` is legacy and should not be used as null.

## Testing
- `moon check`
- `moon test -p testsuite`
- `moon test -p jit`
- `./install.sh && python3 scripts/run_all_wast.py --dir spec --rec` (interp + JIT: 258/258)