### PR TITLE
fix(cli): sync JIT globals/memory and align gating

### DIFF
--- a/cli/main/run.mbt
+++ b/cli/main/run.mbt
@@ -879,7 +879,8 @@ fn run_with_jit(
           // Initialize WASI context with args, env, and preopens
           jm.init_wasi(wasi_args, wasi_envs, wasi_preopens)
           // Initialize all memories (multi-memory support)
-          let jit_memories = match init_jit_memories(instance, store, jm) {
+          let _jit_memories = match
+            @wast.init_jit_memories_from_store(instance, store, jm) {
             Some(memories) => memories
             None => {
               @logger.error("Failed to initialize JIT memories")
@@ -925,7 +926,7 @@ fn run_with_jit(
                   @jit.gc_teardown()
                   // Sync state back to interpreter store even on trap.
                   @wast.sync_jit_globals_to_store(jit_ctx, store)
-                  sync_jit_memories_to_store(instance, store, jit_memories)
+                  @wast.sync_jit_memories_to_store(instance, store, jm)
                   // Capture and display backtrace if DWARF is enabled
                   match dwarf_builder {
                     Some(dwarf) => {
@@ -954,7 +955,7 @@ fn run_with_jit(
               @jit.gc_teardown()
               // Sync JIT state back to interpreter store for consistency.
               @wast.sync_jit_globals_to_store(jit_ctx, store)
-              sync_jit_memories_to_store(instance, store, jit_memories)
+              @wast.sync_jit_memories_to_store(instance, store, jm)
               // Convert Int64 results to Value using shared helper
               let values = convert_jit_results(results, f.result_types)
               // NOTE: Memory and globals are freed automatically by JITContext finalizer (GC-managed)
@@ -1087,143 +1088,6 @@ fn compile_module_to_jit(
     }
   }
   Some((precompiled, debug_db))
-}
-
-///|
-/// Copy interpreter memory to JIT memory (for a specific memory index)
-/// This preserves any modifications made by the start function
-fn copy_interp_memory_to_jit_indexed(
-  store : @runtime.Store,
-  mem_addr : Int,
-  jit_mem_ptr : Int64,
-) -> Unit {
-  let mem = store.get_memory(mem_addr)
-  // Copy only the pages that were actually touched/initialized.
-  // Untouched pages are implicitly zero.
-  for entry in mem.allocated_pages() {
-    let (page_idx, page_bytes) = entry
-    let off = page_idx.to_int64() * 65536L
-    @jit.memory_init(jit_mem_ptr, off, page_bytes) |> ignore
-  }
-}
-
-///|
-/// Initialize all JIT memories from interpreter memories (multi-memory support)
-/// Uses guarded memory allocation for memory 0 to enable bounds check elimination
-/// Returns the allocated MemoryInfo list on success
-fn init_jit_memories(
-  instance : @runtime.ModuleInstance,
-  store : @runtime.Store,
-  jm : @jit.JITModule,
-) -> Array[@jit.MemoryInfo]? {
-  if instance.mem_addrs.is_empty() {
-    return Some([]) // No memories to initialize
-  }
-  let memories : Array[@jit.MemoryInfo] = []
-  // Allocate and copy each memory
-  for i, mem_addr in instance.mem_addrs {
-    let mem = store.get_mem(mem_addr) catch { _ => return None }
-    let size = mem.byte_len()
-    let (_, max) = mem.get_limits()
-    fn bytes_to_64k_pages(bytes : Int64) -> Int {
-      ((bytes + 65535L) / 65536L).to_int()
-    }
-
-    let cur_pages_64k = bytes_to_64k_pages(size)
-    let max_pages_64k = max.map(fn(m) {
-      let max_bytes = m.to_int64() * mem.page_size_bytes()
-      bytes_to_64k_pages(max_bytes)
-    })
-
-    // Allocate JIT memory - use guarded memory for memory 0 (memory32 only)
-    let mem_ptr = if i == 0 && not(mem.is_memory64()) {
-      // Use guarded memory allocation with mmap + guard pages.
-      // This enables bounds check elimination in JIT code for memory32.
-      jm.alloc_guarded_memory(cur_pages_64k, max_pages_64k)
-    } else {
-      // Regular allocation for memory64 and non-zero memories.
-      @jit.alloc_memory(size)
-    }
-    if mem_ptr == 0L && size > 0L {
-      return None // Allocation failed
-    }
-    // Copy interpreter memory data to JIT memory
-    copy_interp_memory_to_jit_indexed(store, mem_addr, mem_ptr)
-    memories.push(@jit.MemoryInfo::new(mem_ptr, size, max_pages_64k))
-  }
-  // Set up multi-memory in JIT context
-  jm.set_memory_pointers(memories)
-  // Also set fast path for memory 0 (backward compatibility)
-  if memories.length() > 0 {
-    jm.set_memory(memories[0].ptr, memories[0].size)
-  }
-  Some(memories)
-}
-
-///|
-fn is_all_zero(data : Bytes) -> Bool {
-  for i in 0..<data.length() {
-    if data[i] != b'\x00' {
-      return false
-    }
-  }
-  true
-}
-
-///|
-fn sync_jit_memories_to_store(
-  instance : @runtime.ModuleInstance,
-  store : @runtime.Store,
-  jit_memories : Array[@jit.MemoryInfo],
-) -> Unit {
-  // Sync each memory by replacing the interpreter Memory with a freshly
-  // reconstructed sparse Memory from the JIT's linear memory snapshot.
-  for i, mem_addr in instance.mem_addrs {
-    if i >= jit_memories.length() {
-      break
-    }
-    let old_mem = store.get_mem(mem_addr) catch { _ => continue }
-    let (cur_pages, max_pages) = old_mem.get_limits()
-
-    // Recreate with identical configuration.
-    let page_size_bytes = old_mem.page_size_bytes()
-    let mut l2 = 0
-    let mut v = 1L
-    while v < page_size_bytes {
-      v = v << 1
-      l2 = l2 + 1
-    }
-    let new_mem = @runtime.Memory::new(
-      cur_pages,
-      max_pages,
-      is_memory64=old_mem.is_memory64(),
-      page_size_log2=l2,
-    )
-    let mem_ptr = jit_memories[i].ptr
-    let total_bytes = old_mem.byte_len()
-
-    // Copy in 64KiB physical chunks (same as interpreter sparse storage).
-    let mut off = 0L
-    while off < total_bytes {
-      let remaining = total_bytes - off
-      let chunk_len = if remaining >= 65536L {
-        65536
-      } else {
-        remaining.to_int()
-      }
-      let chunk = @jit.memory_read(mem_ptr, off, chunk_len)
-      if chunk.length() == chunk_len && !is_all_zero(chunk) {
-        // Best-effort: ignore errors for out-of-bounds.
-        try new_mem.init_data(off.to_int(), chunk) |> ignore catch {
-          _ => ()
-        }
-      }
-      off = off + chunk_len.to_int64()
-    }
-
-    // Replace memory in the store so subsequent interpreter operations see it.
-    store.mems[mem_addr] = new_mem
-  }
 }
 
 ///|

--- a/cli/main/wast.mbt
+++ b/cli/main/wast.mbt
@@ -118,7 +118,8 @@ fn try_compile_jit(
           // Use quiet mode to redirect stdout/stderr to /dev/null for testing
           jm.init_wasi_quiet([], [], [])
           // Initialize all memories (multi-memory support)
-          guard init_jit_memories(instance, store, jm) is Some(_) else {
+          guard @wast.init_jit_memories_from_store(instance, store, jm)
+            is Some(_) else {
             return None
           }
           // Initialize globals (pass jm for tagged funcref pointers)

--- a/jit/ffi_jit.mbt
+++ b/jit/ffi_jit.mbt
@@ -281,6 +281,16 @@ fn JITContext::set_memory_pointers(
 }
 
 ///|
+fn JITContext::get_memory_ptr(self : JITContext, memidx : Int) -> Int64 {
+  @jit_ffi.c_jit_ctx_get_memory_ptr(self.ptr(), memidx)
+}
+
+///|
+fn JITContext::get_memory_size(self : JITContext, memidx : Int) -> Int64 {
+  @jit_ffi.c_jit_ctx_get_memory_size(self.ptr(), memidx)
+}
+
+///|
 /// Allocate an independent WASM stack with guard page protection.
 /// This provides controlled stack overflow behavior - when WASM code
 /// overflows the stack, it hits the guard page and triggers a

--- a/jit/jit_ffi/ffi.mbt
+++ b/jit/jit_ffi/ffi.mbt
@@ -97,6 +97,20 @@ pub extern "c" fn c_jit_ctx_set_memory(
 ) -> Unit = "wasmoon_jit_ctx_set_memory"
 
 ///|
+/// Get memory base pointer for memidx
+pub extern "c" fn c_jit_ctx_get_memory_ptr(
+  ctx_ptr : Int64,
+  memidx : Int,
+) -> Int64 = "wasmoon_jit_ctx_get_memory_ptr"
+
+///|
+/// Get memory size in bytes for memidx
+pub extern "c" fn c_jit_ctx_get_memory_size(
+  ctx_ptr : Int64,
+  memidx : Int,
+) -> Int64 = "wasmoon_jit_ctx_get_memory_size"
+
+///|
 /// Allocate linear memory for WASM
 pub extern "c" fn c_jit_alloc_memory(size : Int64) -> Int64 = "wasmoon_jit_alloc_memory"
 

--- a/jit/jit_ffi/jit.c
+++ b/jit/jit_ffi/jit.c
@@ -747,6 +747,39 @@ MOONBIT_FFI_EXPORT int wasmoon_jit_memory_read(int64_t mem_ptr, int64_t offset, 
     return 0;
 }
 
+MOONBIT_FFI_EXPORT int64_t wasmoon_jit_ctx_get_memory_ptr(int64_t ctx_ptr, int memidx) {
+    if (!ctx_ptr || memidx < 0) return 0;
+    jit_context_t *ctx = (jit_context_t *)ctx_ptr;
+
+    // Memory 0 fast-path is authoritative.
+    if (memidx == 0) {
+        return (int64_t)ctx->memory_base;
+    }
+
+    // Multi-memory pointers.
+    if (ctx->memories && ctx->memory_count > 0 && memidx < ctx->memory_count) {
+        return (int64_t)ctx->memories[memidx];
+    }
+
+    return 0;
+}
+
+MOONBIT_FFI_EXPORT int64_t wasmoon_jit_ctx_get_memory_size(int64_t ctx_ptr, int memidx) {
+    if (!ctx_ptr || memidx < 0) return 0;
+    jit_context_t *ctx = (jit_context_t *)ctx_ptr;
+
+    // Memory 0 fast-path is authoritative and updated by memory.grow.
+    if (memidx == 0) {
+        return (int64_t)ctx->memory_size;
+    }
+
+    if (ctx->memory_sizes && ctx->memory_count > 0 && memidx < ctx->memory_count) {
+        return (int64_t)ctx->memory_sizes[memidx];
+    }
+
+    return 0;
+}
+
 // ============ Executable Memory FFI Exports ============
 
 static void finalize_exec_code(void *self) {

--- a/jit/jit_ffi/pkg.generated.mbti
+++ b/jit/jit_ffi/pkg.generated.mbti
@@ -118,6 +118,10 @@ pub fn c_jit_ctx_get_func_count(Int64) -> Int
 
 pub fn c_jit_ctx_get_func_table(Int64) -> Int64
 
+pub fn c_jit_ctx_get_memory_ptr(Int64, Int) -> Int64
+
+pub fn c_jit_ctx_get_memory_size(Int64, Int) -> Int64
+
 pub fn c_jit_ctx_set_func(Int64, Int, Int64) -> Unit
 
 pub fn c_jit_ctx_set_gc_heap(Int64, Int64) -> Unit

--- a/jit/jit_runtime.mbt
+++ b/jit/jit_runtime.mbt
@@ -709,6 +709,24 @@ pub fn JITModule::set_memory(
 }
 
 ///|
+/// Get current memory base pointer for memidx
+pub fn JITModule::get_memory_ptr(self : JITModule, memidx : Int) -> Int64 {
+  match self.context {
+    Some(ctx) => ctx.get_memory_ptr(memidx)
+    None => 0L
+  }
+}
+
+///|
+/// Get current memory size in bytes for memidx
+pub fn JITModule::get_memory_size(self : JITModule, memidx : Int) -> Int64 {
+  match self.context {
+    Some(ctx) => ctx.get_memory_size(memidx)
+    None => 0L
+  }
+}
+
+///|
 /// Set globals array for the JIT context
 pub fn JITModule::set_globals(self : JITModule, globals_ptr : Int64) -> Unit {
   if self.context is Some(ctx) {

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -454,6 +454,8 @@ pub fn JITModule::get_func_count(Self) -> Int
 pub fn JITModule::get_func_ptr(Self, Int) -> Int64
 pub fn JITModule::get_func_ptr_by_name(Self, String) -> Int64
 pub fn JITModule::get_func_table_ptr(Self) -> Int64
+pub fn JITModule::get_memory_ptr(Self, Int) -> Int64
+pub fn JITModule::get_memory_size(Self, Int) -> Int64
 pub fn JITModule::has_wasm_stack(Self) -> Bool
 pub fn JITModule::init_indirect_table(Self, Int, Array[(Int, Int, Int)]) -> Unit
 pub fn JITModule::init_shared_tables(Self, Array[JITTable?], Array[(Int, Int, Int?, Int)]) -> Unit

--- a/testsuite/cli_jit_sync_test.mbt
+++ b/testsuite/cli_jit_sync_test.mbt
@@ -1,0 +1,61 @@
+///|
+test "cli jit sync: memory.grow visible after jit" {
+  let source =
+    #|(module
+    #|  (memory (export "mem") 1 3)
+    #|  (func (export "grow_and_write")
+    #|    (drop (memory.grow (i32.const 1)))
+    #|    (i32.store (i32.const 65536) (i32.const 123))
+    #|  )
+    #|)
+
+  // Instantiate with interpreter store
+  let mod_ = @wat.parse(source) catch { _ => abort("parse failed") }
+  let linker = @runtime.Linker::new()
+  let store = linker.get_store()
+  store.enable_c_heap()
+  let instance = @executor.instantiate_with_linker(linker, "test", mod_)
+
+  // Compile module to JIT
+  let precompiled = @cwasm.PrecompiledModule::new(@cwasm.AArch64)
+  let func_signatures = @wast.build_func_signatures(mod_)
+
+  // Compile all funcs
+  let num_imports = @wast.count_func_imports(mod_.imports)
+  for i, _ in mod_.codes {
+    let func_idx = num_imports + i
+    let type_idx = mod_.funcs[i]
+    let func_type = mod_.get_func_type(type_idx)
+    let func_name = @wast.get_func_name(mod_, func_idx)
+    let ir_func = @ir.translate_function(mod_, i, name=func_name)
+    let vcode_func = @lower.lower_function(ir_func)
+    let allocated = @regalloc.allocate_registers_backtracking(vcode_func)
+    let mc = @emit.emit_function(allocated)
+    let compiled = @vcode.CompiledFunction::new(func_name, mc, 0)
+    precompiled.add_function(
+      func_idx,
+      func_name,
+      compiled,
+      func_type.params.length(),
+      func_type.results.length(),
+    )
+  }
+  guard @jit.JITModule::load(precompiled, func_signatures) is Some(jm) else {
+    abort("jit load failed")
+  }
+
+  // Init JIT memory from interpreter and execute
+  guard @wast.init_jit_memories_from_store(instance, store, jm) is Some(_) else {
+    abort("init jit memories failed")
+  }
+  let f = jm.get_func_by_name("grow_and_write").unwrap()
+  let _ = jm.call_with_context(f, [])
+
+  // Sync back and check interpreter sees the write in grown page
+  @wast.sync_jit_memories_to_store(instance, store, jm)
+  let mem = store.get_mem(instance.mem_addrs[0]) catch {
+    _ => abort("memory missing")
+  }
+  let v = mem.load_i32(65536) catch { _ => -1 }
+  inspect(v, content="123")
+}

--- a/wast/jit_state_sync.mbt
+++ b/wast/jit_state_sync.mbt
@@ -1,0 +1,138 @@
+/// JIT/interpreter state synchronization helpers.
+///
+/// CLI JIT currently executes with its own linear memory allocation.
+/// To keep behavior consistent when mixing interpreter instantiation/start and
+/// later JIT execution, we provide:
+/// - copying interpreter memory into JIT before execution
+/// - syncing JIT-mutated memory back into the interpreter store afterwards
+///
+/// This code lives under `wast/` because it depends on both `runtime` and `jit`.
+
+///|
+fn is_all_zero(data : Bytes) -> Bool {
+  for i in 0..<data.length() {
+    if data[i] != b'\x00' {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn copy_interp_memory_to_jit_indexed(
+  store : @runtime.Store,
+  mem_addr : Int,
+  jit_mem_ptr : Int64,
+) -> Unit {
+  let mem = store.get_memory(mem_addr)
+  // Copy only the 64KiB physical pages that were actually touched.
+  for entry in mem.allocated_pages() {
+    let (page_idx, page_bytes) = entry
+    let off = page_idx.to_int64() * 65536L
+    @jit.memory_init(jit_mem_ptr, off, page_bytes) |> ignore
+  }
+}
+
+///|
+/// Initialize JIT memory pointers by allocating fresh JIT memories and copying
+/// the interpreter's current content into them.
+///
+/// Returns the allocated MemoryInfo list on success.
+pub fn init_jit_memories_from_store(
+  instance : @runtime.ModuleInstance,
+  store : @runtime.Store,
+  jm : @jit.JITModule,
+) -> Array[@jit.MemoryInfo]? {
+  if instance.mem_addrs.is_empty() {
+    return Some([])
+  }
+  let memories : Array[@jit.MemoryInfo] = []
+  fn bytes_to_64k_pages(bytes : Int64) -> Int {
+    ((bytes + 65535L) / 65536L).to_int()
+  }
+
+  for i, mem_addr in instance.mem_addrs {
+    let mem = store.get_mem(mem_addr) catch { _ => return None }
+    let size = mem.byte_len()
+    let (_, max) = mem.get_limits()
+    let cur_pages_64k = bytes_to_64k_pages(size)
+    let max_pages_64k = max.map(fn(m) {
+      let max_bytes = m.to_int64() * mem.page_size_bytes()
+      bytes_to_64k_pages(max_bytes)
+    })
+    let mem_ptr = if i == 0 && not(mem.is_memory64()) {
+      jm.alloc_guarded_memory(cur_pages_64k, max_pages_64k)
+    } else {
+      @jit.alloc_memory(size)
+    }
+    if mem_ptr == 0L && size > 0L {
+      return None
+    }
+    copy_interp_memory_to_jit_indexed(store, mem_addr, mem_ptr)
+    memories.push(@jit.MemoryInfo::new(mem_ptr, size, max_pages_64k))
+  }
+  jm.set_memory_pointers(memories)
+  if memories.length() > 0 {
+    jm.set_memory(memories[0].ptr, memories[0].size)
+  }
+  Some(memories)
+}
+
+///|
+/// Sync JIT memory back to the interpreter store.
+///
+/// This uses the JIT context as the source of truth for both current memory
+/// pointer and memory size (handles memory.grow that may reallocate).
+pub fn sync_jit_memories_to_store(
+  instance : @runtime.ModuleInstance,
+  store : @runtime.Store,
+  jm : @jit.JITModule,
+) -> Unit {
+  for i, mem_addr in instance.mem_addrs {
+    let old_mem = store.get_mem(mem_addr) catch { _ => continue }
+    let mem_ptr = jm.get_memory_ptr(i)
+    let jit_size_bytes = jm.get_memory_size(i)
+
+    // If the JIT doesn't have this memory, skip.
+    if mem_ptr == 0L && jit_size_bytes > 0L {
+      continue
+    }
+    let page_size_bytes = old_mem.page_size_bytes()
+    if page_size_bytes <= 0L {
+      continue
+    }
+    let new_pages = ((jit_size_bytes + page_size_bytes - 1L) / page_size_bytes).to_int()
+    let (_, max_pages) = old_mem.get_limits()
+
+    // Derive log2(page_size_bytes) for Memory::new.
+    let mut l2 = 0
+    let mut v = 1L
+    while v < page_size_bytes {
+      v = v << 1
+      l2 = l2 + 1
+    }
+    let new_mem = @runtime.Memory::new(
+      new_pages,
+      max_pages,
+      is_memory64=old_mem.is_memory64(),
+      page_size_log2=l2,
+    )
+    let mut off = 0L
+    while off < jit_size_bytes {
+      let remaining = jit_size_bytes - off
+      let chunk_len = if remaining >= 65536L {
+        65536
+      } else {
+        remaining.to_int()
+      }
+      let chunk = @jit.memory_read(mem_ptr, off, chunk_len)
+      if chunk.length() == chunk_len && !is_all_zero(chunk) {
+        try new_mem.init_data(off.to_int(), chunk) |> ignore catch {
+          _ => ()
+        }
+      }
+      off = off + chunk_len.to_int64()
+    }
+    store.mems[mem_addr] = new_mem
+  }
+}

--- a/wast/pkg.generated.mbti
+++ b/wast/pkg.generated.mbti
@@ -37,6 +37,8 @@ pub fn has_unsupported_instructions(@types.Module) -> Bool
 
 pub fn init_elem_segments(@types.Module, @jit.JITModule, @runtime.ModuleInstance, @runtime.Store) -> Unit
 
+pub fn init_jit_memories_from_store(@runtime.ModuleInstance, @runtime.Store, @jit.JITModule) -> Array[@jit.MemoryInfo]?
+
 pub fn invoke_action(WastContext, @wat.WastAction) -> Array[@types.Value] raise WastRunnerError
 
 pub fn parse(String) -> @wat.WastScript raise @wat.WatError
@@ -46,6 +48,8 @@ pub fn run_wast_command(WastContext, @wat.WastCommand, Int, WastResult, String, 
 pub fn run_wast_commands(@wat.WastScript, String, Bool, Bool, jit_compiler? : JITCompiler?) -> WastResult
 
 pub fn sync_jit_globals_to_store(JITModuleContext, @runtime.Store) -> Unit
+
+pub fn sync_jit_memories_to_store(@runtime.ModuleInstance, @runtime.Store, @jit.JITModule) -> Unit
 
 pub fn sync_table_to_jit(@runtime.Table, @jit.JITTable, @jit.JITModule) -> Unit
 


### PR DESCRIPTION
## Summary
- Align CLI JIT gating with the WAST runner by reusing `wast/jit_support` checks (cross-module imports, shared exports, and unsupported instructions).
- Sync JIT-executed state back into the interpreter store after `run` (globals + memories), to avoid divergence when mixing interpreter instantiation/start with later JIT execution.
- Add a small JIT FFI helper `memory_read` to support copying JIT linear memory back.

## Notes
- Table sync remains TODO (same limitation already documented in the WAST runner).

## Testing
- `moon check`
- `moon build`
- `moon test -p testsuite -f gc_jit_test.mbt`
- `moon test -p testsuite -f wasi_jit_wbtest.mbt`

Fixes #295