### PR TITLE
jit: cache memory0 descriptor in x20

### DIFF
--- a/jit/execution_wbtest.mbt
+++ b/jit/execution_wbtest.mbt
@@ -470,75 +470,76 @@ test "end-to-end: f32_br_2locals.wast from source" {
   inspect(
     mc.dump_disasm(),
     content=(
+      #|  0000: fd7bbfa9  stp x29, x30, [sp, #-16]!
+      #|  0004: fd030091  add x29, sp, #0
+      #|  0008: f353bfa9  stp x19, x20, [sp, #-16]!
+      #|  000c: f30300aa  mov x19, x0
+      #|  0010: 740240f9  ldr x20, [x19, #0]
       #|block0:
-      #|  0000: 100080d2  movz x16, #0, lsl #0
-      #|  0004: 0202271e  fmov s2, w16
-      #|  0008: 100080d2  movz x16, #0, lsl #0
-      #|  000c: 1024a8f2  movk x16, #16672, lsl #16
-      #|  0010: 0302271e  fmov s3, w16
-      #|  0014: 080080d2  movz x8, #0, lsl #0
-      #|  0018: 5f00086b  cmp w2, w8
-      #|  001c: e8179f9a  cset x8, eq
-      #|  0020: 480300b5  cbnz x8, block5
-      #|  0024: 28000014  b block9
+      #|  0014: 100080d2  movz x16, #0, lsl #0
+      #|  0018: 0202271e  fmov s2, w16
+      #|  001c: 100080d2  movz x16, #0, lsl #0
+      #|  0020: 1024a8f2  movk x16, #16672, lsl #16
+      #|  0024: 0302271e  fmov s3, w16
+      #|  0028: 080080d2  movz x8, #0, lsl #0
+      #|  002c: 5f00086b  cmp w2, w8
+      #|  0030: e8179f9a  cset x8, eq
+      #|  0034: c80200b5  cbnz x8, block5
+      #|  0038: 24000014  b block9
       #|block1:
-      #|  0028: 1840201e  fmov s24, s0
-      #|  002c: 0043201e  fmov s0, s24
-      #|  0030: c0035fd6  ret
+      #|  003c: 1840201e  fmov s24, s0
+      #|  0040: 0043201e  fmov s0, s24
+      #|  0044: f353c1a8  ldp x19, x20, [sp], #16
+      #|  0048: fd7bc1a8  ldp x29, x30, [sp], #16
+      #|  004c: c0035fd6  ret
       #|block2:
-      #|  0034: 090040f9  ldr x9, [x0, #0]
-      #|  0038: 290140f9  ldr x9, [x9, #0]
-      #|  003c: 210100bd  str s1, [x9, #0]
-      #|  0040: 090040f9  ldr x9, [x0, #0]
-      #|  0044: 290140f9  ldr x9, [x9, #0]
-      #|  0048: 200140bd  ldr s0, [x9, #0]
-      #|  004c: f7ffff17  b block1
+      #|  0050: 890240f9  ldr x9, [x20, #0]
+      #|  0054: 210100bd  str s1, [x9, #0]
+      #|  0058: 890240f9  ldr x9, [x20, #0]
+      #|  005c: 200140bd  ldr s0, [x9, #0]
+      #|  0060: f7ffff17  b block1
       #|block3:
-      #|  0050: 090040f9  ldr x9, [x0, #0]
-      #|  0054: 290140f9  ldr x9, [x9, #0]
-      #|  0058: 210100bd  str s1, [x9, #0]
-      #|  005c: 090040f9  ldr x9, [x0, #0]
-      #|  0060: 290140f9  ldr x9, [x9, #0]
-      #|  0064: 200140bd  ldr s0, [x9, #0]
-      #|  0068: f0ffff17  b block1
+      #|  0064: 890240f9  ldr x9, [x20, #0]
+      #|  0068: 210100bd  str s1, [x9, #0]
+      #|  006c: 890240f9  ldr x9, [x20, #0]
+      #|  0070: 200140bd  ldr s0, [x9, #0]
+      #|  0074: f2ffff17  b block1
       #|block4:
-      #|  006c: 090040f9  ldr x9, [x0, #0]
-      #|  0070: 290140f9  ldr x9, [x9, #0]
-      #|  0074: 210100bd  str s1, [x9, #0]
-      #|  0078: 090040f9  ldr x9, [x0, #0]
-      #|  007c: 290140f9  ldr x9, [x9, #0]
-      #|  0080: 200140bd  ldr s0, [x9, #0]
-      #|  0084: e9ffff17  b block1
+      #|  0078: 890240f9  ldr x9, [x20, #0]
+      #|  007c: 210100bd  str s1, [x9, #0]
+      #|  0080: 890240f9  ldr x9, [x20, #0]
+      #|  0084: 200140bd  ldr s0, [x9, #0]
+      #|  0088: edffff17  b block1
       #|block5:
-      #|  0088: e80302aa  mov x8, x2
-      #|  008c: 6140201e  fmov s1, s3
-      #|  0090: f7ffff17  b block4
+      #|  008c: e80302aa  mov x8, x2
+      #|  0090: 6140201e  fmov s1, s3
+      #|  0094: f9ffff17  b block4
       #|block6:
-      #|  0094: e80302aa  mov x8, x2
-      #|  0098: 6140201e  fmov s1, s3
-      #|  009c: 4040201e  fmov s0, s2
-      #|  00a0: ecffff17  b block3
+      #|  0098: e80302aa  mov x8, x2
+      #|  009c: 6140201e  fmov s1, s3
+      #|  00a0: 4040201e  fmov s0, s2
+      #|  00a4: f0ffff17  b block3
       #|block7:
-      #|  00a4: e80302aa  mov x8, x2
-      #|  00a8: 6140201e  fmov s1, s3
-      #|  00ac: 4040201e  fmov s0, s2
-      #|  00b0: e1ffff17  b block2
+      #|  00a8: e80302aa  mov x8, x2
+      #|  00ac: 6140201e  fmov s1, s3
+      #|  00b0: 4040201e  fmov s0, s2
+      #|  00b4: e7ffff17  b block2
       #|block8:
-      #|  00b4: e80302aa  mov x8, x2
-      #|  00b8: 6140201e  fmov s1, s3
-      #|  00bc: 4040201e  fmov s0, s2
-      #|  00c0: daffff17  b block1
+      #|  00b8: e80302aa  mov x8, x2
+      #|  00bc: 6140201e  fmov s1, s3
+      #|  00c0: 4040201e  fmov s0, s2
+      #|  00c4: deffff17  b block1
       #|block9:
-      #|  00c4: 280080d2  movz x8, #1, lsl #0
-      #|  00c8: 5f00086b  cmp w2, w8
-      #|  00cc: e8179f9a  cset x8, eq
-      #|  00d0: 28feffb5  cbnz x8, block6
+      #|  00c8: 280080d2  movz x8, #1, lsl #0
+      #|  00cc: 5f00086b  cmp w2, w8
+      #|  00d0: e8179f9a  cset x8, eq
+      #|  00d4: 28feffb5  cbnz x8, block6
       #|block10:
-      #|  00d4: 480080d2  movz x8, #2, lsl #0
-      #|  00d8: 5f00086b  cmp w2, w8
-      #|  00dc: e8179f9a  cset x8, eq
-      #|  00e0: 28feffb5  cbnz x8, block7
-      #|  00e4: f4ffff17  b block8
+      #|  00d8: 480080d2  movz x8, #2, lsl #0
+      #|  00dc: 5f00086b  cmp w2, w8
+      #|  00e0: e8179f9a  cset x8, eq
+      #|  00e4: 28feffb5  cbnz x8, block7
+      #|  00e8: f4ffff17  b block8
       #|
     ),
   )

--- a/vcode/abi/abi.mbt
+++ b/vcode/abi/abi.mbt
@@ -97,6 +97,11 @@ pub const VMCTX_GC_HEAP_OFFSET : Int = 104
 pub const REG_VMCTX : Int = 19
 
 ///|
+/// Register holding cached memory0 descriptor pointer (X20, callee-saved).
+/// When enabled, prologue loads: x20 = [x19 + VMCTX_MEMORY0_OFFSET].
+pub const REG_MEM0_DESC : Int = 20
+
+///|
 /// Frame Pointer register (X29)
 pub const REG_FP : Int = 29
 

--- a/vcode/abi/pkg.generated.mbti
+++ b/vcode/abi/pkg.generated.mbti
@@ -24,6 +24,8 @@ pub const REG_FP : Int = 29
 
 pub const REG_LR : Int = 30
 
+pub const REG_MEM0_DESC : Int = 20
+
 pub const REG_SRET : Int = 8
 
 pub const REG_VMCTX : Int = 19

--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -352,6 +352,11 @@ fn MachineCode::emit_prologue(
   // loaded on-demand from vmctx, on-demand.
   if stack_frame.needs_vmctx {
     self.emit_mov_reg(19, 0)
+    // Optionally cache memory0 descriptor pointer in X20.
+    // This allows `LoadMemBase(mem=0)` to be a single load from [X20 + 0].
+    if stack_frame.cache_mem0_desc {
+      self.emit_ldr_imm(@abi.REG_MEM0_DESC, 19, @abi.VMCTX_MEMORY0_OFFSET)
+    }
   }
 
   // Step 6: Move arguments from ABI registers to allocated registers
@@ -440,19 +445,26 @@ pub fn emit_function(
   // Build stack frame layout using JITStackFrame
   // has_calls is true if function makes any calls
   let has_calls = func_has_calls(func)
+  let uses_mem0 = func.uses_mem0()
 
   // Check if function uses vmctx (x19)
   // A function needs vmctx if:
   // 1. It directly uses x19 in instructions/terminators
   // 2. It makes any calls (wasm ABI requires passing vmctx to callees)
-  let needs_vmctx = has_calls || func_uses_vmctx(func)
+  // 3. It uses memory0 base loads that may leverage cached memory0 descriptor
+  let needs_vmctx = has_calls || func_uses_vmctx(func) || uses_mem0
+  let clobbered_gprs = clobbered
+  if uses_mem0 && !clobbered_gprs.contains(@abi.REG_MEM0_DESC) {
+    clobbered_gprs.push(@abi.REG_MEM0_DESC)
+  }
   let stack_frame = JITStackFrame::build(
-    clobbered,
+    clobbered_gprs,
     clobbered_fprs,
     func.get_num_spill_slots(),
     has_calls~,
     outgoing_args_size=func.get_max_outgoing_args_size(),
     needs_vmctx~,
+    cache_mem0_desc=uses_mem0,
     force_frame_setup~,
   )
 
@@ -1549,7 +1561,10 @@ fn MachineCode::emit_instruction(
       // Uses: [vmctx], Defs: [result]
       let dst = wreg_num(inst.defs[0])
       let vmctx_reg = reg_num(inst.uses[0])
-      if memidx == 0 {
+      if memidx == 0 && stack_frame.cache_mem0_desc {
+        // Fast path: memory0 descriptor pointer is cached in X20.
+        self.emit_ldr_imm(dst, @abi.REG_MEM0_DESC, 0)
+      } else if memidx == 0 {
         self.emit_ldr_imm(dst, vmctx_reg, @abi.VMCTX_MEMORY0_OFFSET)
         self.emit_ldr_imm(dst, dst, 0)
       } else {

--- a/vcode/emit/pkg.generated.mbti
+++ b/vcode/emit/pkg.generated.mbti
@@ -69,8 +69,9 @@ pub struct JITStackFrame {
   saved_fprs : Array[Int]
   has_setup_area : Bool
   needs_vmctx : Bool
+  cache_mem0_desc : Bool
 }
-pub fn JITStackFrame::build(Array[Int], Array[Int], Int, has_calls? : Bool, outgoing_args_size? : Int, needs_vmctx? : Bool, force_frame_setup? : Bool) -> Self
+pub fn JITStackFrame::build(Array[Int], Array[Int], Int, has_calls? : Bool, outgoing_args_size? : Int, needs_vmctx? : Bool, cache_mem0_desc? : Bool, force_frame_setup? : Bool) -> Self
 pub fn JITStackFrame::get_fpr_save_offset(Self, Int) -> Int
 pub fn JITStackFrame::get_gpr_save_offset(Self, Int) -> Int
 pub fn JITStackFrame::get_outgoing_arg_offset(Self, Int) -> Int

--- a/vcode/emit/stackframe.mbt
+++ b/vcode/emit/stackframe.mbt
@@ -67,6 +67,7 @@ pub struct JITStackFrame {
   // Flags
   has_setup_area : Bool // Whether FP/LR are saved
   needs_vmctx : Bool // Whether function uses vmctx (X19)
+  cache_mem0_desc : Bool // Whether to cache memory0 descriptor in X20
 }
 
 ///|
@@ -86,6 +87,7 @@ pub fn JITStackFrame::build(
   has_calls? : Bool = false,
   outgoing_args_size? : Int = 0,
   needs_vmctx? : Bool = true,
+  cache_mem0_desc? : Bool = false,
   force_frame_setup? : Bool = false,
 ) -> JITStackFrame {
   // Build the list of GPRs to save
@@ -145,6 +147,7 @@ pub fn JITStackFrame::build(
     saved_fprs: clobbered_fprs.copy(),
     has_setup_area,
     needs_vmctx,
+    cache_mem0_desc,
   }
 }
 

--- a/vcode/regalloc/function.mbt
+++ b/vcode/regalloc/function.mbt
@@ -210,6 +210,20 @@ pub fn VCodeFunction::calls_multi_value_function(self : VCodeFunction) -> Bool {
 }
 
 ///|
+/// Returns true if the function uses `LoadMemBase(memidx=0)`.
+/// Used to enable caching of the memory0 descriptor pointer in a reserved register.
+pub fn VCodeFunction::uses_mem0(self : VCodeFunction) -> Bool {
+  for block in self.blocks {
+    for inst in block.insts {
+      if inst.opcode is LoadMemBase(0) {
+        return true
+      }
+    }
+  }
+  false
+}
+
+///|
 pub fn VCodeFunction::new_block(self : VCodeFunction) -> @block.VCodeBlock {
   let id = self.blocks.length()
   let block = @block.VCodeBlock::new(id)

--- a/vcode/regalloc/pkg.generated.mbti
+++ b/vcode/regalloc/pkg.generated.mbti
@@ -231,6 +231,7 @@ pub fn VCodeFunction::push_param(Self, @abi.VReg) -> Unit
 pub fn VCodeFunction::set_int_stack_params(Self, Int) -> Unit
 pub fn VCodeFunction::set_num_spill_slots(Self, Int) -> Unit
 pub fn VCodeFunction::update_max_outgoing_args_size(Self, Int) -> Unit
+pub fn VCodeFunction::uses_mem0(Self) -> Bool
 pub impl Show for VCodeFunction
 
 // Type aliases

--- a/vcode/regalloc/regalloc.mbt
+++ b/vcode/regalloc/regalloc.mbt
@@ -975,6 +975,10 @@ fn allocate_reload_registers(
   // used by the ABI / codegen.
   // - X19 is reserved for vmctx caching in the prologue when needed.
   used_int_regs.add(19) |> ignore
+  // - X20 is reserved for cached memory0 descriptor pointer when needed.
+  if func.uses_mem0() {
+    used_int_regs.add(@abi.REG_MEM0_DESC) |> ignore
+  }
   // - X23 is reserved for extra_results_buffer when needed.
   let calls_multi = func.calls_multi_value_function()
   let needs_extra = func.needs_extra_results_ptr()
@@ -1893,6 +1897,8 @@ fn build_aarch64_reg_pools(
   let calls_multi = func.calls_multi_value_function()
   let needs_extra = func.needs_extra_results_ptr()
   let needs_x23_reserved = needs_extra || calls_multi
+  // Cache memory0 descriptor pointer in X20 when needed.
+  let needs_x20_reserved = func.uses_mem0()
 
   // Build allocatable register pool:
   // 1. Scratch regs (caller-saved, no save needed) - use first
@@ -1905,6 +1911,10 @@ fn build_aarch64_reg_pools(
   for r in @abi.allocatable_callee_saved_regs() {
     // X23 (index 23) is reserved for extra_results_buffer when needed
     if needs_x23_reserved && r.index == 23 {
+      continue
+    }
+    // X20 is reserved for cached memory0 descriptor pointer when needed
+    if needs_x20_reserved && r.index == @abi.REG_MEM0_DESC {
       continue
     }
     int_regs.push(r)


### PR DESCRIPTION
Cache vmctx->memory0 descriptor pointer in X20 (callee-saved) when a function uses LoadMemBase(0), so each mem0 base load becomes a single LDR instead of vmctx->mem0 + mem0->base.

- Reserves X20 in regalloc only when needed
- Prologue loads X20 from vmctx once
- Keeps base loads correct across memory.grow (base is still loaded from descriptor)