### PR TITLE
jit: omit fallthrough jumps

### DIFF
--- a/testsuite/cross_block_cse_test.mbt
+++ b/testsuite/cross_block_cse_test.mbt
@@ -151,12 +151,11 @@ test "cross_block_cse" {
       #|  0004: 62000034  cbz w2, block2
       #|block1:
       #|  0008: 08050011  add w8, w8, #1
-      #|  000c: 02000014  b block3
+      #|  000c: 01000014  b block3
       #|block2:
-      #|  0010: 01000014  b block3
       #|block3:
-      #|  0014: e00308aa  mov x0, x8
-      #|  0018: c0035fd6  ret
+      #|  0010: e00308aa  mov x0, x8
+      #|  0014: c0035fd6  ret
       #|
     ),
   )

--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -3241,8 +3241,11 @@ fn MachineCode::emit_terminator_with_epilogue(
 ) -> Unit {
   match term {
     Jump(target, _args) =>
-      // Unconditional branch
-      self.emit_b(target)
+      // Unconditional branch.
+      // If the target is the next block in linear order, omit the branch and fall through.
+      if next_block != Some(target) {
+        self.emit_b(target)
+      }
     Branch(cond, then_b, else_b) => {
       let rt = reg_num(cond)
       // Branch inversion: if then_b is next block, use CBZ to else_b


### PR DESCRIPTION
Omit emitting an unconditional `b` for `Jump` terminators when the target is the next block in linear order (fall-through). This removes jump-only branches like `block2: b block3` / `block8: b block9` and reduces code size.

Updates the affected disasm snapshot test.