### PR TITLE
jit: use reg-offset addressing for pointer ops

### DIFF
--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -495,11 +495,300 @@ pub fn emit_function(
   } else {
     None
   }
+
+  // Compute a conservative liveness mask for physical integer registers at block boundaries.
+  // Used by codegen peepholes that remove instructions, to ensure the removed value is not live-out.
+  let nblocks = blocks.length()
+  let live_out_int : Array[Int64] = Array::make(nblocks, 0L)
+  let live_in_int : Array[Int64] = Array::make(nblocks, 0L)
+  let use_int : Array[Int64] = Array::make(nblocks, 0L)
+  let def_int : Array[Int64] = Array::make(nblocks, 0L)
+  let id_to_idx : Map[Int, Int] = {}
+  for bi, b in blocks {
+    id_to_idx.set(b.id, bi)
+  }
+  // Per-block use/def.
+  for bi, b in blocks {
+    let mut defined : Int64 = 0L
+    let mut use_mask : Int64 = 0L
+    let mut def_mask : Int64 = 0L
+    for inst in b.insts {
+      for u in inst.uses {
+        match u {
+          Physical(p) =>
+            if p.class is Int {
+              let bit = 1L << p.index
+              if (defined & bit) == 0L {
+                use_mask = use_mask | bit
+              }
+            }
+          Virtual(_) => ()
+        }
+      }
+      for d in inst.defs {
+        match d.reg {
+          Physical(p) =>
+            if p.class is Int {
+              let bit = 1L << p.index
+              def_mask = def_mask | bit
+              defined = defined | bit
+            }
+          Virtual(_) => ()
+        }
+      }
+    }
+    if b.terminator is Some(term) {
+      match term {
+        Jump(_, args) =>
+          for a in args {
+            match a {
+              Physical(p) =>
+                if p.class is Int {
+                  let bit = 1L << p.index
+                  if (defined & bit) == 0L {
+                    use_mask = use_mask | bit
+                  }
+                }
+              Virtual(_) => ()
+            }
+          }
+        Branch(cond, _, _) =>
+          match cond {
+            Physical(p) =>
+              if p.class is Int {
+                let bit = 1L << p.index
+                if (defined & bit) == 0L {
+                  use_mask = use_mask | bit
+                }
+              }
+            Virtual(_) => ()
+          }
+        BranchCmp(lhs, rhs, _, _, _, _) =>
+          for r in [lhs, rhs] {
+            match r {
+              Physical(p) =>
+                if p.class is Int {
+                  let bit = 1L << p.index
+                  if (defined & bit) == 0L {
+                    use_mask = use_mask | bit
+                  }
+                }
+              Virtual(_) => ()
+            }
+          }
+        BranchZero(r, _, _, _, _) =>
+          match r {
+            Physical(p) =>
+              if p.class is Int {
+                let bit = 1L << p.index
+                if (defined & bit) == 0L {
+                  use_mask = use_mask | bit
+                }
+              }
+            Virtual(_) => ()
+          }
+        BranchCmpImm(lhs, _, _, _, _, _) =>
+          match lhs {
+            Physical(p) =>
+              if p.class is Int {
+                let bit = 1L << p.index
+                if (defined & bit) == 0L {
+                  use_mask = use_mask | bit
+                }
+              }
+            Virtual(_) => ()
+          }
+        Return(values) =>
+          for v in values {
+            match v {
+              Physical(p) =>
+                if p.class is Int {
+                  let bit = 1L << p.index
+                  if (defined & bit) == 0L {
+                    use_mask = use_mask | bit
+                  }
+                }
+              Virtual(_) => ()
+            }
+          }
+        BrTable(index, _, _) =>
+          match index {
+            Physical(p) =>
+              if p.class is Int {
+                let bit = 1L << p.index
+                if (defined & bit) == 0L {
+                  use_mask = use_mask | bit
+                }
+              }
+            Virtual(_) => ()
+          }
+        Trap(_) => ()
+      }
+    }
+    use_int[bi] = use_mask
+    def_int[bi] = def_mask
+  }
+  // Fixed-point.
+  if nblocks > 0 {
+    let mut changed = true
+    while changed {
+      changed = false
+      let mut bi = nblocks - 1
+      while bi >= 0 {
+        let b = blocks[bi]
+        let succs : Array[Int] = match b.terminator {
+          Some(Jump(target, _)) => [target]
+          Some(Branch(_, then_b, else_b)) => [then_b, else_b]
+          Some(BranchCmp(_, _, _, _, then_b, else_b)) => [then_b, else_b]
+          Some(BranchZero(_, _, _, then_b, else_b)) => [then_b, else_b]
+          Some(BranchCmpImm(_, _, _, _, then_b, else_b)) => [then_b, else_b]
+          Some(BrTable(_, targets, default)) => {
+            let out : Array[Int] = []
+            for t in targets {
+              out.push(t)
+            }
+            out.push(default)
+            out
+          }
+          _ => []
+        }
+        let mut out_mask : Int64 = 0L
+        for sid in succs {
+          if id_to_idx.get(sid) is Some(si) {
+            out_mask = out_mask | live_in_int[si]
+          }
+        }
+        let in_mask = use_int[bi] | (out_mask & (def_int[bi] ^ -1L))
+        if out_mask != live_out_int[bi] || in_mask != live_in_int[bi] {
+          live_out_int[bi] = out_mask
+          live_in_int[bi] = in_mask
+          changed = true
+        }
+        bi = bi - 1
+      }
+    }
+  }
   for i, block in blocks {
     mc.define_label(block.id)
     let mut inst_idx = 0
     while inst_idx < block.insts.length() {
       let inst = block.insts[inst_idx]
+      // Peephole: fuse an address add into the following load/store.
+      // Pattern:
+      //   add addr = base + off
+      //   load/store [addr + 0]
+      //
+      // Emit as a single reg-offset load/store: [base + off].
+      if inst.opcode is Add(true) &&
+        inst.defs.length() == 1 &&
+        inst.uses.length() == 2 &&
+        inst_idx + 1 < block.insts.length() {
+        let next = block.insts[inst_idx + 1]
+        let add_dst = wreg_num(inst.defs[0])
+        let add_rn = reg_num(inst.uses[0])
+        let add_rm = reg_num(inst.uses[1])
+
+        // Only safe to skip the add if its result is not used elsewhere.
+        let mut add_used_later = false
+        let mut killed_in_block = false
+        for j in (inst_idx + 2)..<block.insts.length() {
+          let later = block.insts[j]
+          for use_ in later.uses {
+            if reg_num(use_) == add_dst {
+              add_used_later = true
+              break
+            }
+          }
+          if add_used_later {
+            break
+          }
+          for def in later.defs {
+            if wreg_num(def) == add_dst {
+              killed_in_block = true
+              break
+            }
+          }
+          if killed_in_block {
+            break
+          }
+        }
+        if !add_used_later && !killed_in_block {
+          let bit = 1L << add_dst
+          if (live_out_int[i] & bit) != 0L {
+            add_used_later = true
+          }
+        }
+        if !add_used_later {
+          let mut fused = false
+          match next.opcode {
+            LoadPtr(ty, 0) => {
+              let base_reg = reg_num(next.uses[0])
+              if base_reg == add_dst {
+                let dst = wreg_num(next.defs[0])
+                match ty {
+                  I32 => {
+                    mc.emit_ldr_w_reg_scaled(dst, add_rn, add_rm, 0)
+                    fused = true
+                  }
+                  I64 => {
+                    mc.emit_ldr_reg_scaled(dst, add_rn, add_rm, 0)
+                    fused = true
+                  }
+                  _ => ()
+                }
+              }
+            }
+            StorePtr(ty, 0) => {
+              let base_reg = reg_num(next.uses[0])
+              if base_reg == add_dst {
+                let value = reg_num(next.uses[1])
+                match ty {
+                  I32 => {
+                    mc.emit_str_w_reg_scaled(value, add_rn, add_rm, 0)
+                    fused = true
+                  }
+                  I64 => {
+                    mc.emit_str_reg_scaled(value, add_rn, add_rm, 0)
+                    fused = true
+                  }
+                  _ => ()
+                }
+              }
+            }
+            LoadPtrNarrow(bits, signed, 0) => {
+              let base_reg = reg_num(next.uses[0])
+              if base_reg == add_dst && !signed {
+                let dst = wreg_num(next.defs[0])
+                match bits {
+                  8 => mc.emit_ldrb_reg(dst, add_rn, add_rm)
+                  16 => mc.emit_ldrh_reg(dst, add_rn, add_rm)
+                  32 => mc.emit_ldr_w_reg_scaled(dst, add_rn, add_rm, 0)
+                  _ => ()
+                }
+                fused = bits == 8 || bits == 16 || bits == 32
+              }
+            }
+            StorePtrNarrow(bits, 0) => {
+              let base_reg = reg_num(next.uses[0])
+              if base_reg == add_dst {
+                let value = reg_num(next.uses[1])
+                match bits {
+                  8 => mc.emit_strb_reg(value, add_rn, add_rm)
+                  16 => mc.emit_strh_reg(value, add_rn, add_rm)
+                  32 => mc.emit_str_w_reg_scaled(value, add_rn, add_rm, 0)
+                  _ => ()
+                }
+                fused = bits == 8 || bits == 16 || bits == 32
+              }
+            }
+            _ => ()
+          }
+          if fused {
+            inst_idx = inst_idx + 2
+            continue
+          }
+        }
+      }
       // Peephole: fold u32->u64 zero-extend into following 64-bit add.
       //   extend.u32_64 r = x  ; (mov wR, wX)
       //   add r = add base, r ; => add r, base, wX, uxtw

--- a/vcode/emit/instructions.mbt
+++ b/vcode/emit/instructions.mbt
@@ -90,6 +90,14 @@ enum Instruction {
   LdrImm(Int, Int, Int)
   LdrImmSigned(Int, Int, Int)
   LdrRegScaled(Int, Int, Int, Int)
+  // Register-offset load/store using X register offset (UXTX), optional scaling.
+  // shift is either 0 (no scale) or the natural scale for the access size.
+  LdrWRegScaled(Int, Int, Int, Int)
+  StrWRegScaled(Int, Int, Int, Int)
+  LdrbReg(Int, Int, Int)
+  StrbReg(Int, Int, Int)
+  LdrhReg(Int, Int, Int)
+  StrhReg(Int, Int, Int)
   StrImm(Int, Int, Int)
   StrRegScaled(Int, Int, Int, Int)
   LdrbImm(Int, Int, Int)
@@ -602,6 +610,14 @@ fn Instruction::annotate(self : Instruction) -> String {
     LdrImmSigned(rt, rn, simm9) => "ldur x\{rt}, [x\{rn}, #\{simm9}]"
     LdrRegScaled(rt, rn, rm, shift) =>
       "ldr x\{rt}, [x\{rn}, x\{rm}, lsl #\{shift}]"
+    LdrWRegScaled(rt, rn, rm, shift) =>
+      "ldr w\{rt}, [x\{rn}, x\{rm}, lsl #\{shift}]"
+    StrWRegScaled(rt, rn, rm, shift) =>
+      "str w\{rt}, [x\{rn}, x\{rm}, lsl #\{shift}]"
+    LdrbReg(rt, rn, rm) => "ldrb w\{rt}, [x\{rn}, x\{rm}]"
+    StrbReg(rt, rn, rm) => "strb w\{rt}, [x\{rn}, x\{rm}]"
+    LdrhReg(rt, rn, rm) => "ldrh w\{rt}, [x\{rn}, x\{rm}]"
+    StrhReg(rt, rn, rm) => "strh w\{rt}, [x\{rn}, x\{rm}]"
     StrImm(rt, rn, imm12) => "str x\{rt}, [x\{rn}, #\{imm12}]"
     StrRegScaled(rt, rn, rm, shift) =>
       "str x\{rt}, [x\{rn}, x\{rm}, lsl #\{shift}]"
@@ -1538,6 +1554,98 @@ fn Instruction::instr_bytes(self : Instruction) -> (Int, Int, Int, Int) {
         ((rm & 31) << 16) |
         (0b011 << 13) |
         (s_bit << 12) |
+        (0b10 << 10) |
+        ((rn & 31) << 5) |
+        (rt & 31)
+      (inst & 255, (inst >> 8) & 255, (inst >> 16) & 255, (inst >> 24) & 255)
+    }
+    LdrWRegScaled(rt, rn, rm, shift) => {
+      let s_bit = if shift == 2 { 1 } else { 0 }
+      let inst = (0b10 << 30) |
+        (0b111 << 27) |
+        (0 << 26) |
+        (0b00 << 24) |
+        (0b01 << 22) |
+        (1 << 21) |
+        ((rm & 31) << 16) |
+        (0b011 << 13) |
+        (s_bit << 12) |
+        (0b10 << 10) |
+        ((rn & 31) << 5) |
+        (rt & 31)
+      (inst & 255, (inst >> 8) & 255, (inst >> 16) & 255, (inst >> 24) & 255)
+    }
+    StrWRegScaled(rt, rn, rm, shift) => {
+      let s_bit = if shift == 2 { 1 } else { 0 }
+      let inst = (0b10 << 30) |
+        (0b111 << 27) |
+        (0 << 26) |
+        (0b00 << 24) |
+        (0b00 << 22) |
+        (1 << 21) |
+        ((rm & 31) << 16) |
+        (0b011 << 13) |
+        (s_bit << 12) |
+        (0b10 << 10) |
+        ((rn & 31) << 5) |
+        (rt & 31)
+      (inst & 255, (inst >> 8) & 255, (inst >> 16) & 255, (inst >> 24) & 255)
+    }
+    LdrbReg(rt, rn, rm) => {
+      let inst = (0b00 << 30) |
+        (0b111 << 27) |
+        (0 << 26) |
+        (0b00 << 24) |
+        (0b01 << 22) |
+        (1 << 21) |
+        ((rm & 31) << 16) |
+        (0b011 << 13) |
+        (0 << 12) |
+        (0b10 << 10) |
+        ((rn & 31) << 5) |
+        (rt & 31)
+      (inst & 255, (inst >> 8) & 255, (inst >> 16) & 255, (inst >> 24) & 255)
+    }
+    StrbReg(rt, rn, rm) => {
+      let inst = (0b00 << 30) |
+        (0b111 << 27) |
+        (0 << 26) |
+        (0b00 << 24) |
+        (0b00 << 22) |
+        (1 << 21) |
+        ((rm & 31) << 16) |
+        (0b011 << 13) |
+        (0 << 12) |
+        (0b10 << 10) |
+        ((rn & 31) << 5) |
+        (rt & 31)
+      (inst & 255, (inst >> 8) & 255, (inst >> 16) & 255, (inst >> 24) & 255)
+    }
+    LdrhReg(rt, rn, rm) => {
+      let inst = (0b01 << 30) |
+        (0b111 << 27) |
+        (0 << 26) |
+        (0b00 << 24) |
+        (0b01 << 22) |
+        (1 << 21) |
+        ((rm & 31) << 16) |
+        (0b011 << 13) |
+        (0 << 12) |
+        (0b10 << 10) |
+        ((rn & 31) << 5) |
+        (rt & 31)
+      (inst & 255, (inst >> 8) & 255, (inst >> 16) & 255, (inst >> 24) & 255)
+    }
+    StrhReg(rt, rn, rm) => {
+      let inst = (0b01 << 30) |
+        (0b111 << 27) |
+        (0 << 26) |
+        (0b00 << 24) |
+        (0b00 << 22) |
+        (1 << 21) |
+        ((rm & 31) << 16) |
+        (0b011 << 13) |
+        (0 << 12) |
         (0b10 << 10) |
         ((rn & 31) << 5) |
         (rt & 31)
@@ -4281,6 +4389,68 @@ pub fn MachineCode::emit_str_reg_scaled(
   shift : Int,
 ) -> Unit {
   StrRegScaled(rt, rn, rm, shift).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_ldr_w_reg_scaled(
+  self : MachineCode,
+  rt : Int,
+  rn : Int,
+  rm : Int,
+  shift : Int,
+) -> Unit {
+  LdrWRegScaled(rt, rn, rm, shift).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_str_w_reg_scaled(
+  self : MachineCode,
+  rt : Int,
+  rn : Int,
+  rm : Int,
+  shift : Int,
+) -> Unit {
+  StrWRegScaled(rt, rn, rm, shift).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_ldrb_reg(
+  self : MachineCode,
+  rt : Int,
+  rn : Int,
+  rm : Int,
+) -> Unit {
+  LdrbReg(rt, rn, rm).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_strb_reg(
+  self : MachineCode,
+  rt : Int,
+  rn : Int,
+  rm : Int,
+) -> Unit {
+  StrbReg(rt, rn, rm).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_ldrh_reg(
+  self : MachineCode,
+  rt : Int,
+  rn : Int,
+  rm : Int,
+) -> Unit {
+  LdrhReg(rt, rn, rm).emit(self)
+}
+
+///|
+pub fn MachineCode::emit_strh_reg(
+  self : MachineCode,
+  rt : Int,
+  rn : Int,
+  rm : Int,
+) -> Unit {
+  StrhReg(rt, rn, rm).emit(self)
 }
 
 ///|

--- a/vcode/emit/pkg.generated.mbti
+++ b/vcode/emit/pkg.generated.mbti
@@ -186,8 +186,11 @@ pub fn MachineCode::emit_ldr_q_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_ldr_reg_scaled(Self, Int, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_ldr_s_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_ldr_w_imm(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_ldr_w_reg_scaled(Self, Int, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_ldrb_imm(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_ldrb_reg(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_ldrh_imm(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_ldrh_reg(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_ldrsb_w_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_ldrsb_x_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_ldrsh_w_imm(Self, Int, Int, Int) -> Unit
@@ -237,8 +240,11 @@ pub fn MachineCode::emit_str_q_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_str_reg_scaled(Self, Int, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_str_s_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_str_w_imm(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_str_w_reg_scaled(Self, Int, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_strb_imm(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_strb_reg(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_strh_imm(Self, Int, Int, Int) -> Unit
+pub fn MachineCode::emit_strh_reg(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_sub_imm(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_sub_imm32(Self, Int, Int, Int) -> Unit
 pub fn MachineCode::emit_sub_reg(Self, Int, Int, Int) -> Unit


### PR DESCRIPTION
Close some of the codegen gap vs wasmtime by using AArch64 register-offset addressing modes instead of materializing full addresses with `add` + `ldr/str [addr, #0]`.

- Add instruction encodings for reg-offset byte/half/word loads/stores
- Codegen peephole uses these forms when safe (guarded by block-level physical-reg liveness)
- Updates generated interface

`moon test` passes.