### PR TITLE
regalloc: multi-span live ranges (holes)

### DIFF
--- a/jit/execution_wbtest.mbt
+++ b/jit/execution_wbtest.mbt
@@ -410,49 +410,38 @@ test "end-to-end: f32_br_2locals.wast from source" {
     content=(
       #|vcode test(v0:int, v1:int, v2:int) -> float {
       #|block0:
-      #|    d2 = ldf 0
-      #|    d3 = ldf 10
+      #|    d0 = ldf 0
+      #|    d1 = ldf 10
       #|    x8 = ldi 0
       #|    x8 = cmp32.eq x2, x8
       #|    branch x8, block5, block9
       #|block1(v3:int, f4:float, f5:float):
       #|    ret d0
       #|block2(v6:int, f7:float, f8:float):
-      #|    x9 = load_mem_base mem=0 x0
-      #|    store_ptr.f32 +0 x9, d1
-      #|    x9 = load_mem_base mem=0 x0
-      #|    d0 = load_ptr.f32 +0 x9
+      #|    x8 = load_mem_base mem=0 x0
+      #|    store_ptr.f32 +0 x8, d1
+      #|    x8 = load_mem_base mem=0 x0
+      #|    d0 = load_ptr.f32 +0 x8
       #|    jump block1
       #|block3(v9:int, f10:float, f11:float):
-      #|    x9 = load_mem_base mem=0 x0
-      #|    store_ptr.f32 +0 x9, d1
-      #|    x9 = load_mem_base mem=0 x0
-      #|    d0 = load_ptr.f32 +0 x9
+      #|    x8 = load_mem_base mem=0 x0
+      #|    store_ptr.f32 +0 x8, d1
+      #|    x8 = load_mem_base mem=0 x0
+      #|    d0 = load_ptr.f32 +0 x8
       #|    jump block1
       #|block4(v12:int, f13:float, f14:float):
-      #|    x9 = load_mem_base mem=0 x0
-      #|    store_ptr.f32 +0 x9, d1
-      #|    x9 = load_mem_base mem=0 x0
-      #|    d0 = load_ptr.f32 +0 x9
+      #|    x8 = load_mem_base mem=0 x0
+      #|    store_ptr.f32 +0 x8, d1
+      #|    x8 = load_mem_base mem=0 x0
+      #|    d0 = load_ptr.f32 +0 x8
       #|    jump block1
       #|block5:
-      #|    x8 = mov x2
-      #|    d1 = mov d3
       #|    jump block4
       #|block6:
-      #|    x8 = mov x2
-      #|    d1 = mov d3
-      #|    d0 = mov d2
       #|    jump block3
       #|block7:
-      #|    x8 = mov x2
-      #|    d1 = mov d3
-      #|    d0 = mov d2
       #|    jump block2
       #|block8:
-      #|    x8 = mov x2
-      #|    d1 = mov d3
-      #|    d0 = mov d2
       #|    jump block1
       #|block9:
       #|    x8 = ldi 1
@@ -477,15 +466,15 @@ test "end-to-end: f32_br_2locals.wast from source" {
       #|  0010: 740240f9  ldr x20, [x19, #0]
       #|block0:
       #|  0014: 100080d2  movz x16, #0, lsl #0
-      #|  0018: 0202271e  fmov s2, w16
+      #|  0018: 0002271e  fmov s0, w16
       #|  001c: 100080d2  movz x16, #0, lsl #0
       #|  0020: 1024a8f2  movk x16, #16672, lsl #16
-      #|  0024: 0302271e  fmov s3, w16
+      #|  0024: 0102271e  fmov s1, w16
       #|  0028: 080080d2  movz x8, #0, lsl #0
       #|  002c: 5f00086b  cmp w2, w8
       #|  0030: e8179f9a  cset x8, eq
       #|  0034: c80200b5  cbnz x8, block5
-      #|  0038: 24000014  b block9
+      #|  0038: 19000014  b block9
       #|block1:
       #|  003c: 1840201e  fmov s24, s0
       #|  0040: 0043201e  fmov s0, s24
@@ -493,53 +482,42 @@ test "end-to-end: f32_br_2locals.wast from source" {
       #|  0048: fd7bc1a8  ldp x29, x30, [sp], #16
       #|  004c: c0035fd6  ret
       #|block2:
-      #|  0050: 890240f9  ldr x9, [x20, #0]
-      #|  0054: 210100bd  str s1, [x9, #0]
-      #|  0058: 890240f9  ldr x9, [x20, #0]
-      #|  005c: 200140bd  ldr s0, [x9, #0]
+      #|  0050: 880240f9  ldr x8, [x20, #0]
+      #|  0054: 010100bd  str s1, [x8, #0]
+      #|  0058: 880240f9  ldr x8, [x20, #0]
+      #|  005c: 000140bd  ldr s0, [x8, #0]
       #|  0060: f7ffff17  b block1
       #|block3:
-      #|  0064: 890240f9  ldr x9, [x20, #0]
-      #|  0068: 210100bd  str s1, [x9, #0]
-      #|  006c: 890240f9  ldr x9, [x20, #0]
-      #|  0070: 200140bd  ldr s0, [x9, #0]
+      #|  0064: 880240f9  ldr x8, [x20, #0]
+      #|  0068: 010100bd  str s1, [x8, #0]
+      #|  006c: 880240f9  ldr x8, [x20, #0]
+      #|  0070: 000140bd  ldr s0, [x8, #0]
       #|  0074: f2ffff17  b block1
       #|block4:
-      #|  0078: 890240f9  ldr x9, [x20, #0]
-      #|  007c: 210100bd  str s1, [x9, #0]
-      #|  0080: 890240f9  ldr x9, [x20, #0]
-      #|  0084: 200140bd  ldr s0, [x9, #0]
+      #|  0078: 880240f9  ldr x8, [x20, #0]
+      #|  007c: 010100bd  str s1, [x8, #0]
+      #|  0080: 880240f9  ldr x8, [x20, #0]
+      #|  0084: 000140bd  ldr s0, [x8, #0]
       #|  0088: edffff17  b block1
       #|block5:
-      #|  008c: e80302aa  mov x8, x2
-      #|  0090: 6140201e  fmov s1, s3
-      #|  0094: f9ffff17  b block4
+      #|  008c: fbffff17  b block4
       #|block6:
-      #|  0098: e80302aa  mov x8, x2
-      #|  009c: 6140201e  fmov s1, s3
-      #|  00a0: 4040201e  fmov s0, s2
-      #|  00a4: f0ffff17  b block3
+      #|  0090: f5ffff17  b block3
       #|block7:
-      #|  00a8: e80302aa  mov x8, x2
-      #|  00ac: 6140201e  fmov s1, s3
-      #|  00b0: 4040201e  fmov s0, s2
-      #|  00b4: e7ffff17  b block2
+      #|  0094: efffff17  b block2
       #|block8:
-      #|  00b8: e80302aa  mov x8, x2
-      #|  00bc: 6140201e  fmov s1, s3
-      #|  00c0: 4040201e  fmov s0, s2
-      #|  00c4: deffff17  b block1
+      #|  0098: e9ffff17  b block1
       #|block9:
-      #|  00c8: 280080d2  movz x8, #1, lsl #0
-      #|  00cc: 5f00086b  cmp w2, w8
-      #|  00d0: e8179f9a  cset x8, eq
-      #|  00d4: 28feffb5  cbnz x8, block6
+      #|  009c: 280080d2  movz x8, #1, lsl #0
+      #|  00a0: 5f00086b  cmp w2, w8
+      #|  00a4: e8179f9a  cset x8, eq
+      #|  00a8: 48ffffb5  cbnz x8, block6
       #|block10:
-      #|  00d8: 480080d2  movz x8, #2, lsl #0
-      #|  00dc: 5f00086b  cmp w2, w8
-      #|  00e0: e8179f9a  cset x8, eq
-      #|  00e4: 28feffb5  cbnz x8, block7
-      #|  00e8: f4ffff17  b block8
+      #|  00ac: 480080d2  movz x8, #2, lsl #0
+      #|  00b0: 5f00086b  cmp w2, w8
+      #|  00b4: e8179f9a  cset x8, eq
+      #|  00b8: e8feffb5  cbnz x8, block7
+      #|  00bc: f7ffff17  b block8
       #|
     ),
   )

--- a/testsuite/f32_br_table_test.mbt
+++ b/testsuite/f32_br_table_test.mbt
@@ -109,8 +109,8 @@ test "A critical bug (fixed) as in data/f32_br_2locals_simp" {
     content=(
       #|vcode test(v0:int, v1:int, v2:int) -> float {
       #|block0:
-      #|    d2 = ldf 0
-      #|    d3 = ldf 0
+      #|    d0 = ldf 0
+      #|    d1 = ldf 0
       #|    x8 = ldi 0
       #|    x8 = cmp32.eq x2, x8
       #|    branch x8, block4, block7
@@ -123,18 +123,10 @@ test "A critical bug (fixed) as in data/f32_br_2locals_simp" {
       #|    d0 = ldf 2
       #|    jump block1
       #|block4:
-      #|    x8 = mov x2
-      #|    d1 = mov d3
       #|    jump block3
       #|block5:
-      #|    x8 = mov x2
-      #|    d0 = mov d2
-      #|    d1 = mov d3
       #|    jump block2
       #|block6:
-      #|    x8 = mov x2
-      #|    d0 = mov d2
-      #|    d1 = mov d3
       #|    jump block1
       #|block7:
       #|    x8 = ldi 1

--- a/vcode/lower/lower_wbtest.mbt
+++ b/vcode/lower/lower_wbtest.mbt
@@ -965,21 +965,21 @@ test "lower br_table with f32 locals (f32_br_2locals pattern)" {
     content=(
       #|vcode test(v0:int) -> float {
       #|block0:
-      #|    d1 = ldf 10
+      #|    d0 = ldf 10
       #|    x8 = ldi 0
       #|    x9 = ldi 0
       #|    x9 = cmp32.eq x0, x9
       #|    branch x9, block1, block5
       #|block1:
-      #|    store_ptr.f32 +0 x8, d1
+      #|    store_ptr.f32 +0 x8, d0
       #|    d0 = load_ptr.f32 +0 x8
       #|    jump block4
       #|block2:
-      #|    store_ptr.f32 +0 x8, d1
+      #|    store_ptr.f32 +0 x8, d0
       #|    d0 = load_ptr.f32 +0 x8
       #|    jump block4
       #|block3:
-      #|    store_ptr.f32 +0 x8, d1
+      #|    store_ptr.f32 +0 x8, d0
       #|    d0 = load_ptr.f32 +0 x8
       #|    jump block4
       #|block4(f1:float):

--- a/vcode/regalloc/backtrack.mbt
+++ b/vcode/regalloc/backtrack.mbt
@@ -48,6 +48,7 @@ struct BacktrackingAllocator {
   // Configuration
   int_regs : Array[@abi.PReg]
   float_regs : Array[@abi.PReg]
+  vector_regs : Array[@abi.PReg]
   callee_saved_int : Array[@abi.PReg]
   callee_saved_float : Array[@abi.PReg]
 
@@ -65,6 +66,7 @@ pub fn BacktrackingAllocator::new(
   bundles : BundleSet,
   int_regs : Array[@abi.PReg],
   float_regs : Array[@abi.PReg],
+  vector_regs : Array[@abi.PReg],
   callee_saved_int : Array[@abi.PReg],
   callee_saved_float : Array[@abi.PReg],
 ) -> BacktrackingAllocator {
@@ -78,6 +80,7 @@ pub fn BacktrackingAllocator::new(
     queue: [],
     int_regs,
     float_regs,
+    vector_regs,
     callee_saved_int,
     callee_saved_float,
     block_order: ranges.block_order,
@@ -141,12 +144,16 @@ fn BacktrackingAllocator::get_available_regs(
   if bundle.crosses_call(self.ranges) {
     match bundle.reg_class {
       @abi.Int => self.callee_saved_int
-      @abi.Float32 | @abi.Float64 | @abi.Vector => self.callee_saved_float
+      @abi.Float32 | @abi.Float64 => self.callee_saved_float
+      // V8-V15 preservation is only guaranteed for the low 64 bits by AAPCS64.
+      // Vector values that cross calls are handled by forced spilling earlier.
+      @abi.Vector => []
     }
   } else {
     match bundle.reg_class {
       @abi.Int => self.int_regs
-      @abi.Float32 | @abi.Float64 | @abi.Vector => self.float_regs
+      @abi.Float32 | @abi.Float64 => self.float_regs
+      @abi.Vector => self.vector_regs
     }
   }
 }
@@ -272,12 +279,15 @@ fn BacktrackingAllocator::is_callee_saved(
           return true
         }
       }
-    @abi.Float32 | @abi.Float64 | @abi.Vector =>
+    @abi.Float32 | @abi.Float64 =>
       for cs in self.callee_saved_float {
         if cs.index == preg.index {
           return true
         }
       }
+    // AAPCS64 only guarantees preserving the low 64 bits of V8-V15.
+    // Treat vectors as never callee-saved.
+    @abi.Vector => ()
   }
   false
 }
@@ -1000,6 +1010,7 @@ pub fn allocate_backtracking(
   liveness : LivenessResult,
   int_regs : Array[@abi.PReg],
   float_regs : Array[@abi.PReg],
+  vector_regs : Array[@abi.PReg],
   callee_saved_int : Array[@abi.PReg],
   callee_saved_float : Array[@abi.PReg],
 ) -> RegAllocResult {
@@ -1011,7 +1022,7 @@ pub fn allocate_backtracking(
 
   // Phase 4: Allocate
   let allocator = BacktrackingAllocator::new(
-    func, ranges, bundles, int_regs, float_regs, callee_saved_int, callee_saved_float,
+    func, ranges, bundles, int_regs, float_regs, vector_regs, callee_saved_int, callee_saved_float,
   )
 
   // Pre-assign function parameters to ABI registers (before main allocation)

--- a/vcode/regalloc/liverange.mbt
+++ b/vcode/regalloc/liverange.mbt
@@ -362,6 +362,82 @@ pub fn build_live_ranges(
 ) -> LiveRangeSet {
   let result = LiveRangeSet::new(liveness.block_order)
   let mut next_id = 0
+  let block_order = liveness.block_order
+  fn point_after(point : ProgPoint, block_len : Int) -> ProgPoint {
+    match point.pos {
+      Before => { block: point.block, inst: point.inst, pos: After }
+      After =>
+        if point.inst < block_len {
+          { block: point.block, inst: point.inst + 1, pos: Before }
+        } else {
+          { block: point.block, inst: block_len, pos: After }
+        }
+    }
+  }
+
+  fn pp_lt(
+    a : ProgPoint,
+    b : ProgPoint,
+    block_order : FixedArray[Int],
+  ) -> Bool {
+    a.compare_with_order(b, block_order) < 0
+  }
+
+  fn pp_le(
+    a : ProgPoint,
+    b : ProgPoint,
+    block_order : FixedArray[Int],
+  ) -> Bool {
+    a.compare_with_order(b, block_order) <= 0
+  }
+
+  fn pp_min(
+    a : ProgPoint,
+    b : ProgPoint,
+    block_order : FixedArray[Int],
+  ) -> ProgPoint {
+    if pp_le(a, b, block_order) {
+      a
+    } else {
+      b
+    }
+  }
+
+  fn pp_max(
+    a : ProgPoint,
+    b : ProgPoint,
+    block_order : FixedArray[Int],
+  ) -> ProgPoint {
+    if pp_lt(a, b, block_order) {
+      b
+    } else {
+      a
+    }
+  }
+
+  fn normalize_ranges(
+    ranges : Array[ProgPointRange],
+    block_order : FixedArray[Int],
+  ) -> Array[ProgPointRange] {
+    if ranges.length() <= 1 {
+      return ranges
+    }
+    ranges.sort_by(fn(a, b) { a.start.compare_with_order(b.start, block_order) })
+    let out : Array[ProgPointRange] = []
+    out.push(ranges[0])
+    for i in 1..<ranges.length() {
+      let r = ranges[i]
+      let last_idx = out.length() - 1
+      let last = out[last_idx]
+      if r.start.compare_with_order(last.end, block_order) < 0 {
+        let end = pp_max(last.end, r.end, block_order)
+        out[last_idx] = ProgPointRange::new(last.start, end)
+      } else {
+        out.push(r)
+      }
+    }
+    out
+  }
 
   // Process each vreg from use-def info
   for entry in liveness.use_def {
@@ -369,29 +445,96 @@ pub fn build_live_ranges(
     let range = LiveRange::new(next_id, info.vreg)
     next_id += 1
 
-    // Build ranges from def point to uses.
-    // Currently uses a single conservative range from earliest to latest point.
-    // This is correct but may cause unnecessary register pressure.
-    // Multi-span ranges would require: (1) CFG-based liveness analysis to find holes,
-    // (2) block order respecting loop nesting for accurate range splitting.
-    // The current approach works correctly for all cases.
-    let interval = liveness.intervals.get(vreg_id)
-    match interval {
-      Some(iv) => {
-        range.add_range(ProgPointRange::new(iv.start, iv.end))
-        range.crosses_call = iv.crosses_call
+    // Add use positions (for constraints / heuristics)
+    if info.def_point is Some(def) {
+      let constraint = find_constraint_at_for_vreg(func, def, vreg_id)
+      range.add_use(UsePosition::new(def, Def, constraint))
+    }
+    for use_point in info.use_points {
+      let constraint = find_constraint_at_for_vreg(func, use_point, vreg_id)
+      range.add_use(UsePosition::new(use_point, Use, constraint))
+    }
 
-        // Add use positions
-        if info.def_point is Some(def) {
-          let constraint = find_constraint_at_for_vreg(func, def, vreg_id)
-          range.add_use(UsePosition::new(def, Def, constraint))
-        }
-        for use_point in info.use_points {
-          let constraint = find_constraint_at_for_vreg(func, use_point, vreg_id)
-          range.add_use(UsePosition::new(use_point, Use, constraint))
+    // Build multi-span ranges (with holes) from per-block liveness plus use/def.
+    // This is a conservative refinement over the previous single [start, end] span:
+    // it never drops blocks where the value is live-in/out, but it avoids spanning
+    // across blocks where the value is not live, reducing register pressure.
+    let uses_in_block : Map[Int, (ProgPoint, ProgPoint)] = {}
+    for p in info.use_points {
+      match uses_in_block.get(p.block) {
+        Some((first, last)) =>
+          uses_in_block.set(
+            p.block,
+            (pp_min(first, p, block_order), pp_max(last, p, block_order)),
+          )
+        None => uses_in_block.set(p.block, (p, p))
+      }
+    }
+    let mut spans : Array[ProgPointRange] = []
+    for block_idx, block in func.blocks {
+      let live_in = liveness.live_in[block_idx].contains(vreg_id)
+      let live_out = liveness.live_out[block_idx].contains(vreg_id)
+      let has_def_in_block = info.def_point is Some(def) &&
+        def.block == block_idx
+      let use_bounds = uses_in_block.get(block_idx)
+      if !live_in && !live_out && !has_def_in_block && use_bounds is None {
+        continue
+      }
+      let block_len = block.insts.length()
+      let entry_point : ProgPoint = { block: block_idx, inst: -1, pos: Before }
+      let exit_point : ProgPoint = {
+        block: block_idx,
+        inst: block_len,
+        pos: After,
+      }
+      let start = if has_def_in_block {
+        info.def_point.unwrap()
+      } else if live_in {
+        entry_point
+      } else if use_bounds is Some((first_use, _)) {
+        // Should not normally happen (use implies live_in or local def),
+        // but be conservative.
+        pp_min(entry_point, first_use, block_order)
+      } else {
+        entry_point
+      }
+      let end = if live_out {
+        exit_point
+      } else if use_bounds is Some((_, last_use)) {
+        point_after(last_use, block_len)
+      } else if has_def_in_block {
+        // Defined in this block and dead here: keep a minimal span to avoid
+        // surprising empty ranges in allocator internals.
+        point_after(info.def_point.unwrap(), block_len)
+      } else {
+        point_after(start, block_len)
+      }
+      let (start, end) = if end.compare_with_order(start, block_order) <= 0 {
+        (start, point_after(start, block_len))
+      } else {
+        (start, end)
+      }
+      spans.push(ProgPointRange::new(start, end))
+    }
+    spans = normalize_ranges(spans, block_order)
+    for span in spans {
+      range.add_range(span)
+    }
+
+    // Recompute crosses_call precisely from the refined spans.
+    // A value crosses a call if it is live *across* the call point:
+    // span.start < call_point < span.end
+    for call_point in liveness.call_points {
+      for span in range.ranges {
+        if pp_lt(span.start, call_point, block_order) &&
+          pp_lt(call_point, span.end, block_order) {
+          range.crosses_call = true
+          break
         }
       }
-      None => ()
+      if range.crosses_call {
+        break
+      }
     }
     result.add_range(range)
   }

--- a/vcode/regalloc/pkg.generated.mbti
+++ b/vcode/regalloc/pkg.generated.mbti
@@ -10,7 +10,7 @@ import(
 )
 
 // Values
-pub fn allocate_backtracking(VCodeFunction, LivenessResult, Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg]) -> RegAllocResult
+pub fn allocate_backtracking(VCodeFunction, LivenessResult, Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg]) -> RegAllocResult
 
 pub fn allocate_registers_backtracking(VCodeFunction) -> VCodeFunction
 
@@ -65,7 +65,7 @@ pub impl Show for Allocation
 type BacktrackingAllocator
 pub fn BacktrackingAllocator::allocate(Self) -> Unit
 pub fn BacktrackingAllocator::generate_result(Self) -> RegAllocResult
-pub fn BacktrackingAllocator::new(VCodeFunction, LiveRangeSet, BundleSet, Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg]) -> Self
+pub fn BacktrackingAllocator::new(VCodeFunction, LiveRangeSet, BundleSet, Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg]) -> Self
 
 type Bundle
 pub fn Bundle::contains_range(Self, Int) -> Bool

--- a/vcode/regalloc/regalloc.mbt
+++ b/vcode/regalloc/regalloc.mbt
@@ -929,6 +929,12 @@ fn compute_reload_intervals(
       for use_reg in inst.uses {
         if use_reg is @abi.Virtual(vreg) {
           if alloc.spill_slots.get(vreg.id) is Some(slot) {
+            // Do not reload-coalesce vector values: there is no safe
+            // non-allocatable vector scratch register bank, and AAPCS64 only
+            // guarantees preserving the low 64 bits of V8-V15.
+            if vreg.class is @abi.Vector {
+              continue
+            }
             match slot_uses.get(slot) {
               Some((first, _, cls)) =>
                 slot_uses.set(slot, (first, inst_idx, cls))
@@ -1014,6 +1020,7 @@ fn allocate_reload_registers(
             block_int_used.add(idx) |> ignore
             break
           }
+        @abi.Vector => ()
         _ =>
           for idx in reload_float_regs {
             if used_float_regs.contains(idx) || block_float_used.contains(idx) {
@@ -1892,7 +1899,13 @@ pub fn eliminate_dead_code(func : VCodeFunction) -> VCodeFunction {
 /// Build the register pools for AArch64 allocation
 fn build_aarch64_reg_pools(
   func : VCodeFunction,
-) -> (Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg], Array[@abi.PReg]) {
+) -> (
+  Array[@abi.PReg],
+  Array[@abi.PReg],
+  Array[@abi.PReg],
+  Array[@abi.PReg],
+  Array[@abi.PReg],
+) {
   // Check if function needs extra results buffer (uses X23)
   let calls_multi = func.calls_multi_value_function()
   let needs_extra = func.needs_extra_results_ptr()
@@ -1921,16 +1934,42 @@ fn build_aarch64_reg_pools(
     callee_saved_int_regs.push(r)
   }
 
-  // Float regs pool: D0-D7 (caller-saved) + D8-D15 (callee-saved)
+  // Float regs pool:
+  // - Prefer argument regs V0-V7 (good locality; matches existing expectations).
+  // - Then use caller-saved V18-V31 (avoid V16/V17 reserved for scratch/temp).
+  // - Finally use callee-saved V8-V15.
   let float_regs : Array[@abi.PReg] = []
   for r in @abi.aapcs64_arg_fprs() {
+    float_regs.push(r)
+  }
+  for r in @abi.allocatable_scratch_fprs() {
+    if r.index == 16 || r.index == 17 {
+      continue
+    }
     float_regs.push(r)
   }
   for r in @abi.callee_saved_fprs() {
     float_regs.push(r)
   }
   let callee_saved_float_regs = @abi.callee_saved_fprs()
-  (int_regs, float_regs, callee_saved_int_regs, callee_saved_float_regs)
+
+  // Vector regs pool:
+  // - Only caller-saved V0-V7 and V18-V31.
+  // - Do NOT use V8-V15: AAPCS64 only guarantees preserving the low 64 bits.
+  // - Avoid V16/V17 reserved for scratch/temp.
+  let vector_regs : Array[@abi.PReg] = []
+  for r in @abi.aapcs64_arg_fprs() {
+    vector_regs.push({ index: r.index, class: @abi.Vector })
+  }
+  for r in @abi.allocatable_scratch_fprs() {
+    if r.index == 16 || r.index == 17 {
+      continue
+    }
+    vector_regs.push({ index: r.index, class: @abi.Vector })
+  }
+  (
+    int_regs, float_regs, vector_regs, callee_saved_int_regs, callee_saved_float_regs,
+  )
 }
 
 ///|
@@ -1944,16 +1983,20 @@ pub fn allocate_registers_backtracking(func : VCodeFunction) -> VCodeFunction {
   let func = eliminate_dead_code(func)
 
   // Build register pools
-  let (int_regs, float_regs, callee_saved_int_regs, callee_saved_float_regs) = build_aarch64_reg_pools(
-    func,
-  )
+  let (
+    int_regs,
+    float_regs,
+    vector_regs,
+    callee_saved_int_regs,
+    callee_saved_float_regs,
+  ) = build_aarch64_reg_pools(func)
 
   // Compute liveness (Phase 1)
   let liveness = compute_liveness(func)
 
   // Use backtracking allocator (Phases 2-4)
   let alloc_result = allocate_backtracking(
-    func, liveness, int_regs, float_regs, callee_saved_int_regs, callee_saved_float_regs,
+    func, liveness, int_regs, float_regs, vector_regs, callee_saved_int_regs, callee_saved_float_regs,
   )
 
   // Process constraints and generate RegMove edits
@@ -2016,15 +2059,19 @@ fn count_instructions(func : VCodeFunction) -> AllocStats {
 /// Get allocation statistics
 pub fn get_alloc_stats(func : VCodeFunction) -> AllocStats {
   let func = eliminate_dead_code(func)
-  let (int_regs, float_regs, callee_saved_int_regs, callee_saved_float_regs) = build_aarch64_reg_pools(
-    func,
-  )
+  let (
+    int_regs,
+    float_regs,
+    vector_regs,
+    callee_saved_int_regs,
+    callee_saved_float_regs,
+  ) = build_aarch64_reg_pools(func)
   let liveness = compute_liveness(func)
 
   // Count vregs
   let num_vregs = liveness.intervals.length()
   let alloc_result = allocate_backtracking(
-    func, liveness, int_regs, float_regs, callee_saved_int_regs, callee_saved_float_regs,
+    func, liveness, int_regs, float_regs, vector_regs, callee_saved_int_regs, callee_saved_float_regs,
   )
   process_constraints(func, alloc_result)
   let allocated = apply_allocation(func, alloc_result)


### PR DESCRIPTION
Implements multi-span live ranges (holes) based on per-block liveness, reducing register pressure and improving codegen stability.

Also hardens vector allocation by using a dedicated vector register pool and disabling vector reload-coalescing.

Tests: moon test