### PR TITLE
ABI: proper overflow stack layout + v128 stack params

### DIFF
--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -51,6 +51,16 @@ fn decode_i31_ref(raw : Int64) -> @types.Value {
 }
 
 ///|
+fn bytes_to_int64_le(bytes : Bytes, offset : Int) -> Int64 {
+  let mut result = 0L
+  for i in 0..<8 {
+    let b = bytes[offset + i].to_int64() & 0xFFL
+    result = result | (b << (i * 8))
+  }
+  result
+}
+
+///|
 /// Compare JIT and interpreter execution results
 /// Returns (jit_result, interp_result, match)
 
@@ -449,7 +459,22 @@ pub fn run_jit(
       } else {
         @types.ValueType::I64
       }
-      jit_args.push(value_to_jit_arg_typed(arg, ty))
+      if ty is @types.ValueType::V128 {
+        match arg {
+          V128(bytes) => {
+            guard bytes.length() == 16 else {
+              return Err("Invalid V128 argument length: \{bytes.length()}")
+            }
+            let low = bytes_to_int64_le(bytes, 0)
+            let high = bytes_to_int64_le(bytes, 8)
+            jit_args.push(low)
+            jit_args.push(high)
+          }
+          _ => return Err("Expected V128 argument, got \{arg}")
+        }
+      } else {
+        jit_args.push(value_to_jit_arg_typed(arg, ty))
+      }
     }
     let raw_results = jm.call_with_context(f, jit_args)
 

--- a/testsuite/stack_params_v128_test.mbt
+++ b/testsuite/stack_params_v128_test.mbt
@@ -1,0 +1,42 @@
+///|
+test "v128 stack param (9th v128 arg)" {
+  let source =
+    #|(module
+    #|  (func (export "test")
+    #|    (param v128 v128 v128 v128 v128 v128 v128 v128 v128)
+    #|    (result v128)
+    #|    (local.get 8))
+    #|)
+  let v = @types.Value::V128(
+    b"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10",
+  )
+  let result = compare_jit_interp(source, "test", [v, v, v, v, v, v, v, v, v])
+  inspect(result, content="matched")
+}
+
+///|
+test "mixed overflow: f32 then v128 (16-byte alignment)" {
+  let source =
+    #|(module
+    #|  (func (export "test")
+    #|    (param f64 f64 f64 f64 f64 f64 f64 f64 f32 v128)
+    #|    (result v128)
+    #|    (local.get 9))
+    #|)
+  let v = @types.Value::V128(
+    b"\x10\x0f\x0e\x0d\x0c\x0b\x0a\x09\x08\x07\x06\x05\x04\x03\x02\x01",
+  )
+  let result = compare_jit_interp(source, "test", [
+    F64(1.0),
+    F64(2.0),
+    F64(3.0),
+    F64(4.0),
+    F64(5.0),
+    F64(6.0),
+    F64(7.0),
+    F64(8.0),
+    F32(3.5),
+    v,
+  ])
+  inspect(result, content="matched")
+}

--- a/vcode/abi/abi.mbt
+++ b/vcode/abi/abi.mbt
@@ -167,6 +167,62 @@ pub const SCRATCH_REG_1 : Int = 16
 /// Secondary scratch register (X17/IP1)
 pub const SCRATCH_REG_2 : Int = 17
 
+// ============ ABI Helpers ============
+
+///|
+/// Align value up to the next multiple of `align` (which must be a power of two).
+pub fn align_up(value : Int, align : Int) -> Int {
+  if align <= 1 {
+    value
+  } else {
+    (value + (align - 1)) / align * align
+  }
+}
+
+///|
+/// Stack slot size (bytes) for the Wasm v3 calling convention overflow area.
+/// We keep 8-byte slots for scalars for simplicity; V128 occupies 16 bytes.
+pub fn wasm_stack_slot_size(class : RegClass) -> Int {
+  match class {
+    Vector => 16
+    _ => 8
+  }
+}
+
+///|
+/// Stack slot alignment (bytes) for the Wasm v3 calling convention overflow area.
+pub fn wasm_stack_slot_align(class : RegClass) -> Int {
+  match class {
+    Vector => 16
+    _ => 8
+  }
+}
+
+///|
+/// Compute overflow argument stack layout for the Wasm v3 calling convention.
+/// Layout: [int_overflow...][float_overflow...] with V128 aligned to 16.
+///
+/// Returned offsets are relative to the start of the overflow area.
+/// The total size is 16-byte aligned for stack frame allocation.
+pub fn wasm_layout_overflow_stack(
+  int_overflow_count : Int,
+  float_overflow_classes : Array[RegClass],
+) -> (Array[Int], Array[Int], Int) {
+  let int_offsets : Array[Int] = []
+  for i in 0..<int_overflow_count {
+    int_offsets.push(i * 8)
+  }
+  let float_offsets : Array[Int] = []
+  let mut cur = int_overflow_count * 8
+  for class in float_overflow_classes {
+    cur = align_up(cur, wasm_stack_slot_align(class))
+    float_offsets.push(cur)
+    cur = cur + wasm_stack_slot_size(class)
+  }
+  let total = align_up(cur, 16)
+  (int_offsets, float_offsets, total)
+}
+
 // ============ Register Usage in AAPCS64 ============
 
 ///|

--- a/vcode/abi/pkg.generated.mbti
+++ b/vcode/abi/pkg.generated.mbti
@@ -76,6 +76,8 @@ pub fn aapcs64_ret_fprs() -> Array[PReg]
 
 pub fn aapcs64_ret_gprs() -> Array[PReg]
 
+pub fn align_up(Int, Int) -> Int
+
 pub fn allocatable_callee_saved_fprs() -> Array[PReg]
 
 pub fn allocatable_callee_saved_regs() -> Array[PReg]
@@ -93,6 +95,12 @@ pub fn call_clobbered_gprs() -> Array[PReg]
 pub fn callee_saved_fprs() -> Array[PReg]
 
 pub let spill_slot_base : Int
+
+pub fn wasm_layout_overflow_stack(Int, Array[RegClass]) -> (Array[Int], Array[Int], Int)
+
+pub fn wasm_stack_slot_align(RegClass) -> Int
+
+pub fn wasm_stack_slot_size(RegClass) -> Int
 
 // Errors
 

--- a/vcode/emit/codegen.mbt
+++ b/vcode/emit/codegen.mbt
@@ -1824,7 +1824,7 @@ fn MachineCode::emit_instruction(
         Vector => self.emit_str_q_imm(rt, 31, spill_base_offset + offset) // STR Qt, [SP, #offset]
       }
     }
-    LoadStackParam(param_idx, class, int_overflow_count) => {
+    LoadStackParam(offset, class) => {
       // Load stack parameter from stack (Standard layout)
       //
       // Stack layout from callee's perspective:
@@ -1838,21 +1838,9 @@ fn MachineCode::emit_instruction(
       // │  Outgoing args            │
       // └═══════════════════════════┘ ← current_SP
       //
-      // param_idx >= 0: int overflow at index param_idx
-      // param_idx < 0: float overflow at index (-param_idx - 1)
-      //
-      // The offset calculation:
-      // - frame_size (= total_size) gets us from current_SP to entry_SP
-      // - param_idx * 8 for the specific argument
-      // Note: total_size already includes setup_area_size, so we don't add it again
-      let stack_offset = if param_idx >= 0 {
-        // Int stack param: directly at param_idx * 8
-        frame_size + param_idx * 8
-      } else {
-        // Float stack param: after all int overflow params
-        let float_idx = -param_idx - 1
-        frame_size + int_overflow_count * 8 + float_idx * 8
-      }
+      // `offset` is the byte offset from entry_SP to the argument.
+      // entry_SP = current_SP + frame_size.
+      let stack_offset = frame_size + offset
       let rd = wreg_num(inst.defs[0])
       match class {
         Int => self.emit_ldr_imm(rd, 31, stack_offset) // LDR Xd, [SP, #offset]
@@ -1866,7 +1854,7 @@ fn MachineCode::emit_instruction(
           self.emit_ldr_imm(16, 31, stack_offset) // LDR X16, [SP, #offset]
           self.emit_fmov_x_to_d(rd, 16) // FMOV Dd, X16
         }
-        Vector => abort("SIMD JIT not implemented: vector stack param load")
+        Vector => self.emit_ldr_q_imm(rd, 31, stack_offset) // LDR Qd, [SP, #offset]
       }
     }
     LoadMemBase(memidx) => {

--- a/vcode/instr/instr.mbt
+++ b/vcode/instr/instr.mbt
@@ -331,11 +331,10 @@ pub(all) enum VCodeOpcode {
   StackLoad(Int)
   StackStore(Int)
   // Stack parameter load (for params that overflow registers)
-  // LoadStackParam(param_idx, class, int_overflow_count):
-  //   param_idx >= 0: int overflow param at index param_idx
-  //   param_idx < 0: float overflow param at index (-param_idx - 1), after int_overflow_count int params
-  // Stack layout: [int_overflow..., float_overflow...]
-  LoadStackParam(Int, @abi.RegClass, Int)
+  // LoadStackParam(offset, class):
+  //   offset: byte offset from entry SP (start of overflow area)
+  // Stack layout: [int_overflow..., float_overflow...] with V128 aligned to 16.
+  LoadStackParam(Int, @abi.RegClass)
   // NOTE: memory.grow/size/fill/copy and table.grow are lowered to CallPtr[ C ].
   // NOTE: TableGet, TableSet are desugared at IR level via FuncEnvironment to LoadPtr/StorePtr
   // NOTE: GlobalGet, GlobalSet are desugared at IR level via FuncEnvironment to LoadPtr/StorePtr
@@ -935,8 +934,7 @@ fn VCodeOpcode::to_string(self : VCodeOpcode) -> String {
     TypeCheckIndirect(expected_type) => "type_check_indirect \{expected_type}"
     StackLoad(offset) => "stack_load [sp+\{offset}]"
     StackStore(offset) => "stack_store [sp+\{offset}]"
-    LoadStackParam(param_idx, class, _) =>
-      "load_stack_param \{param_idx} (\{class})"
+    LoadStackParam(offset, class) => "load_stack_param +\{offset} (\{class})"
     // NOTE: memory.grow/size/fill/copy and table.grow are lowered to CallPtr[ C ].
     // NOTE: TableGet, TableSet, GlobalGet, GlobalSet removed - desugared at IR level
     LoadPtr(ty, offset) => "load_ptr.\{ty} +\{offset}"

--- a/vcode/instr/pkg.generated.mbti
+++ b/vcode/instr/pkg.generated.mbti
@@ -306,7 +306,7 @@ pub(all) enum VCodeOpcode {
   TypeCheckIndirect(Int)
   StackLoad(Int)
   StackStore(Int)
-  LoadStackParam(Int, @abi.RegClass, Int)
+  LoadStackParam(Int, @abi.RegClass)
   LoadMemBase(Int)
   LoadPtr(MemType, Int)
   StorePtr(MemType, Int)

--- a/vcode/lower/lower.mbt
+++ b/vcode/lower/lower.mbt
@@ -116,13 +116,10 @@ fn LoweringContext::get_vreg_for_use(
   block : @block.VCodeBlock,
 ) -> @abi.VReg {
   // First check if it's a stack parameter
-  if self.stack_param_map.get(value.id) is Some((param_idx, class)) {
+  if self.stack_param_map.get(value.id) is Some((offset, class)) {
     // Generate LoadStackParam instruction
-    // Pass int_stack_params so emit can calculate correct offset for float overflow params
     let result = self.vcode_func.new_vreg(class)
-    let inst = @instr.VCodeInst::new(
-      LoadStackParam(param_idx, class, self.vcode_func.int_stack_params),
-    )
+    let inst = @instr.VCodeInst::new(LoadStackParam(offset, class))
     inst.add_def({ reg: Virtual(result) })
     block.add_inst(inst)
     result
@@ -342,8 +339,9 @@ pub fn lower_function(ir_func : @ir.Function) -> @regalloc.VCodeFunction {
   let max_float_reg_params = @abi.MAX_FLOAT_REG_PARAMS // V0-V7
   let mut int_reg_count = 0
   let mut float_reg_count = 0
-  let mut int_stack_count = 0
-  let mut float_stack_count = 0
+  let int_stack_values : Array[@ir.Value] = []
+  let float_stack_values : Array[(@ir.Value, @abi.RegClass)] = []
+  let float_stack_classes : Array[@abi.RegClass] = []
   for param in ir_func.params {
     let (value, ty) = param
     let class = ir_type_to_reg_class(ty)
@@ -355,9 +353,8 @@ pub fn lower_function(ir_func : @ir.Function) -> @regalloc.VCodeFunction {
           ctx.value_map.set(value.id, vreg)
           int_reg_count = int_reg_count + 1
         } else {
-          // Stack parameter: int overflow comes first in stack layout
-          ctx.stack_param_map.set(value.id, (int_stack_count, class))
-          int_stack_count = int_stack_count + 1
+          // Stack parameter: laid out in overflow area (entry SP).
+          int_stack_values.push(value)
         }
       Float32 | Float64 | Vector =>
         // Vector uses same V0-V7 registers as floats on AArch64
@@ -367,17 +364,23 @@ pub fn lower_function(ir_func : @ir.Function) -> @regalloc.VCodeFunction {
           ctx.value_map.set(value.id, vreg)
           float_reg_count = float_reg_count + 1
         } else {
-          // Stack parameter: float overflow comes after int overflow
-          // We encode this as negative index to distinguish from int
-          // Actual offset = int_overflow_count * 8 + float_idx * 8
-          // We'll compute this in emit using special encoding
-          ctx.stack_param_map.set(value.id, (-(float_stack_count + 1), class)) // negative = float stack param
-          float_stack_count = float_stack_count + 1
+          float_stack_values.push((value, class))
+          float_stack_classes.push(class)
         }
     }
   }
-  // Store int overflow count for emit to calculate correct offsets
-  ctx.vcode_func.set_int_stack_params(int_stack_count)
+  let (int_offsets, float_offsets, _) = @abi.wasm_layout_overflow_stack(
+    int_stack_values.length(),
+    float_stack_classes,
+  )
+  for i in 0..<int_stack_values.length() {
+    ctx.stack_param_map.set(int_stack_values[i].id, (int_offsets[i], Int))
+  }
+  for i in 0..<float_stack_values.length() {
+    let (value, class) = float_stack_values[i]
+    ctx.stack_param_map.set(value.id, (float_offsets[i], class))
+  }
+  ctx.vcode_func.set_int_stack_params(int_stack_values.length())
 
   // Phase 3: Lower result types
   for ty in ir_func.results {

--- a/vcode/lower/lower_call.mbt
+++ b/vcode/lower/lower_call.mbt
@@ -1,6 +1,48 @@
 // ============ Wasm Call Lowering (Standard) ============
 
 ///|
+/// Emit StoreToStack for overflow arguments according to the Wasm v3 ABI.
+/// This also updates `max_outgoing_args_size` so the prologue reserves enough
+/// space and SP doesn't move at call sites.
+fn emit_wasm_overflow_arg_stores(
+  ctx : LoweringContext,
+  block : @block.VCodeBlock,
+  int_args : Array[(@abi.VReg, @abi.RegClass)],
+  float_args : Array[(@abi.VReg, @abi.RegClass)],
+) -> Unit {
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS // 6 (X2-X7)
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS // 8 (V0-V7)
+  let int_overflow = if int_args.length() > max_int_reg_args {
+    int_args.length() - max_int_reg_args
+  } else {
+    0
+  }
+  let float_overflow_classes : Array[@abi.RegClass] = []
+  for i in max_float_reg_args..<float_args.length() {
+    let (_, class) = float_args[i]
+    float_overflow_classes.push(class)
+  }
+  let (int_offsets, float_offsets, total_bytes) = @abi.wasm_layout_overflow_stack(
+    int_overflow, float_overflow_classes,
+  )
+  if total_bytes > 0 {
+    ctx.vcode_func.update_max_outgoing_args_size(total_bytes)
+  }
+  for i in 0..<int_overflow {
+    let (vreg, _) = int_args[max_int_reg_args + i]
+    let store = @instr.VCodeInst::new(StoreToStack(int_offsets[i]))
+    store.add_use(Virtual(vreg))
+    block.add_inst(store)
+  }
+  for i in 0..<float_offsets.length() {
+    let (vreg, _) = float_args[max_float_reg_args + i]
+    let store = @instr.VCodeInst::new(StoreToStack(float_offsets[i]))
+    store.add_use(Virtual(vreg))
+    block.add_inst(store)
+  }
+}
+
+///|
 /// Lower a Wasm function call using Standard approach.
 /// All argument placement is done in lowering via FixedReg constraints.
 /// The emit phase just emits BLR X17.
@@ -33,45 +75,8 @@ fn lower_wasm_call(
     }
   }
 
-  // Calculate overflow args
-  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS // 6 (X2-X7)
-  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS // 8 (V0-V7)
-  let int_overflow = if int_args.length() > max_int_reg_args {
-    int_args.length() - max_int_reg_args
-  } else {
-    0
-  }
-  let float_overflow = if float_args.length() > max_float_reg_args {
-    float_args.length() - max_float_reg_args
-  } else {
-    0
-  }
-  let total_overflow = int_overflow + float_overflow
-
-  // Generate StoreToStack for overflow arguments
-  // These use the pre-allocated outgoing args area (offset from SP)
-  for i in max_int_reg_args..<int_args.length() {
-    let (vreg, _) = int_args[i]
-    let stack_idx = i - max_int_reg_args
-    let offset = stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
-  for i in max_float_reg_args..<float_args.length() {
-    let (vreg, _) = float_args[i]
-    let stack_idx = i - max_float_reg_args
-    let offset = int_overflow * 8 + stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
-
-  // Track outgoing args size for frame layout
-  if total_overflow > 0 {
-    let overflow_bytes = total_overflow * 8
-    ctx.vcode_func.update_max_outgoing_args_size(overflow_bytes)
-  }
+  // Store overflow args to stack (pre-allocated outgoing args area at SP).
+  emit_wasm_overflow_arg_stores(ctx, block, int_args, float_args)
 
   // Create CallPtr instruction with Wasm calling convention
   let num_args = args.length()
@@ -107,6 +112,7 @@ fn lower_wasm_call(
   })
 
   // Register int args: X2-X7
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
   let int_reg_count = if int_args.length() < max_int_reg_args {
     int_args.length()
   } else {
@@ -122,6 +128,7 @@ fn lower_wasm_call(
   }
 
   // Register float args: V0-V7
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
   let float_reg_count = if float_args.length() < max_float_reg_args {
     float_args.length()
   } else {
@@ -221,31 +228,7 @@ fn lower_return_call(
   }
 
   // Calculate overflow args count (user args, not including vmctx)
-  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS // 6 (X2-X7)
-  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS // 8 (V0-V7)
-  let int_overflow = if int_args.length() > max_int_reg_args {
-    int_args.length() - max_int_reg_args
-  } else {
-    0
-  }
-
-  // Generate StoreToStack instructions for overflow arguments
-  for i in max_int_reg_args..<int_args.length() {
-    let (vreg, _) = int_args[i]
-    let stack_idx = i - max_int_reg_args
-    let offset = stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
-  for i in max_float_reg_args..<float_args.length() {
-    let (vreg, _) = float_args[i]
-    let stack_idx = i - max_float_reg_args
-    let offset = int_overflow * 8 + stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
+  emit_wasm_overflow_arg_stores(ctx, block, int_args, float_args)
 
   // Create ReturnCallIndirect instruction with fixed register constraints
   let call_inst = @instr.VCodeInst::new(ReturnCallIndirect(0, 0))
@@ -267,6 +250,7 @@ fn lower_return_call(
   })
 
   // Register int args: X2-X7
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
   let int_reg_count = if int_args.length() < max_int_reg_args {
     int_args.length()
   } else {
@@ -282,6 +266,7 @@ fn lower_return_call(
   }
 
   // Register float args: V0-V7
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
   let float_reg_count = if float_args.length() < max_float_reg_args {
     float_args.length()
   } else {
@@ -414,33 +399,7 @@ fn lower_return_call_indirect(
       @abi.Vector => float_args.push((vreg, @abi.Vector)) // SIMD uses Vn registers
     }
   }
-
-  // Calculate overflow
-  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
-  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
-  let int_overflow = if int_args.length() > max_int_reg_args {
-    int_args.length() - max_int_reg_args
-  } else {
-    0
-  }
-
-  // Generate StoreToStack for overflow arguments
-  for i in max_int_reg_args..<int_args.length() {
-    let (vreg, _) = int_args[i]
-    let stack_idx = i - max_int_reg_args
-    let offset = stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
-  for i in max_float_reg_args..<float_args.length() {
-    let (vreg, _) = float_args[i]
-    let stack_idx = i - max_float_reg_args
-    let offset = int_overflow * 8 + stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
+  emit_wasm_overflow_arg_stores(ctx, block, int_args, float_args)
 
   // Create ReturnCallIndirect with fixed constraints
   let call_inst = @instr.VCodeInst::new(ReturnCallIndirect(0, 0))
@@ -462,6 +421,7 @@ fn lower_return_call_indirect(
   })
 
   // Register int args: X2-X7
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
   let int_reg_count = if int_args.length() < max_int_reg_args {
     int_args.length()
   } else {
@@ -477,6 +437,7 @@ fn lower_return_call_indirect(
   }
 
   // Register float args: V0-V7
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
   let float_reg_count = if float_args.length() < max_float_reg_args {
     float_args.length()
   } else {
@@ -542,33 +503,7 @@ fn lower_return_call_ref(
       @abi.Vector => float_args.push((vreg, @abi.Vector)) // SIMD uses Vn registers
     }
   }
-
-  // Calculate overflow
-  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
-  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
-  let int_overflow = if int_args.length() > max_int_reg_args {
-    int_args.length() - max_int_reg_args
-  } else {
-    0
-  }
-
-  // Generate StoreToStack for overflow arguments
-  for i in max_int_reg_args..<int_args.length() {
-    let (vreg, _) = int_args[i]
-    let stack_idx = i - max_int_reg_args
-    let offset = stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
-  for i in max_float_reg_args..<float_args.length() {
-    let (vreg, _) = float_args[i]
-    let stack_idx = i - max_float_reg_args
-    let offset = int_overflow * 8 + stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
+  emit_wasm_overflow_arg_stores(ctx, block, int_args, float_args)
 
   // Create ReturnCallIndirect with fixed constraints
   let call_inst = @instr.VCodeInst::new(ReturnCallIndirect(0, 0))
@@ -590,6 +525,7 @@ fn lower_return_call_ref(
   })
 
   // Register int args: X2-X7
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
   let int_reg_count = if int_args.length() < max_int_reg_args {
     int_args.length()
   } else {
@@ -605,6 +541,7 @@ fn lower_return_call_ref(
   }
 
   // Register float args: V0-V7
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
   let float_reg_count = if float_args.length() < max_float_reg_args {
     float_args.length()
   } else {
@@ -856,47 +793,7 @@ fn lower_call_ptr(
       @abi.Vector => float_args.push((vreg, @abi.Vector)) // SIMD uses Vn registers
     }
   }
-
-  // Calculate overflow args count
-  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS // 6 (X2-X7)
-  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS // 8 (V0-V7)
-  let int_overflow = if int_args.length() > max_int_reg_args {
-    int_args.length() - max_int_reg_args
-  } else {
-    0
-  }
-  let float_overflow = if float_args.length() > max_float_reg_args {
-    float_args.length() - max_float_reg_args
-  } else {
-    0
-  }
-  let stack_arg_space = (int_overflow + float_overflow) * 8
-  // Align to 16 bytes
-  let aligned_stack_space = (stack_arg_space + 15) / 16 * 16
-
-  // Update max_outgoing_args_size (Standard: pre-allocate in prologue)
-  // This ensures SP doesn't move during call sequences, avoiding spill slot issues
-  ctx.vcode_func.update_max_outgoing_args_size(aligned_stack_space)
-
-  // Step 1: Store overflow int args to stack (space is pre-allocated in prologue)
-  for i in max_int_reg_args..<int_args.length() {
-    let (vreg, _) = int_args[i]
-    let stack_idx = i - max_int_reg_args
-    let offset = stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
-
-  // Step 2: Store overflow float args to stack (after int overflow args)
-  for i in max_float_reg_args..<float_args.length() {
-    let (vreg, _) = float_args[i]
-    let stack_idx = i - max_float_reg_args
-    let offset = int_overflow * 8 + stack_idx * 8
-    let store = @instr.VCodeInst::new(StoreToStack(offset))
-    store.add_use(Virtual(vreg))
-    block.add_inst(store)
-  }
+  emit_wasm_overflow_arg_stores(ctx, block, int_args, float_args)
 
   // Step 3: Create CallPtr instruction with FixedReg constraints (Wasm calling convention)
   let call_inst = @instr.VCodeInst::new(CallPtr(num_args, num_results, Wasm))
@@ -920,6 +817,7 @@ fn lower_call_ptr(
   })
 
   // Register int args: X2-X7
+  let max_int_reg_args = @abi.MAX_USER_REG_PARAMS
   let int_reg_count = if int_args.length() < max_int_reg_args {
     int_args.length()
   } else {
@@ -935,6 +833,7 @@ fn lower_call_ptr(
   }
 
   // Register float args: V0-V7
+  let max_float_reg_args = @abi.MAX_FLOAT_REG_PARAMS
   let float_reg_count = if float_args.length() < max_float_reg_args {
     float_args.length()
   } else {


### PR DESCRIPTION
- Add `@abi.wasm_layout_overflow_stack` to compute byte offsets with 16-byte alignment for V128
- Replace index-based `LoadStackParam` with byte-offset form; implement Vector stack param load
- Unify call lowering overflow stores via shared helper and update outgoing-args sizing
- Extend testsuite JIT runner to encode V128 args (2x i64 slots)
- Add regression tests for V128 stack args and alignment

Tests: `moon test -p testsuite`, `python3 scripts/run_all_wast.py --rec --only-jit`