### PR TITLE
ci: fix MoonBit PATH in OCI release workflow

### DIFF
--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
+          export PATH="$HOME/.moon/bin:$PATH"
           moon version --all
           moon update
 


### PR DESCRIPTION
## Summary
- Fixes the release workflow failing with `moon: command not found` by exporting `PATH=$HOME/.moon/bin:$PATH` within the install step.

## Context
- `echo $HOME/.moon/bin >> $GITHUB_PATH` only affects later steps, not later commands in the same step.