### PR TITLE
jit: include <setjmp.h> for sigsetjmp on Linux

### DIFF
--- a/jit/jit_ffi/exception.c
+++ b/jit/jit_ffi/exception.c
@@ -2,6 +2,8 @@
 // Exception handling for JIT runtime
 // Implements WebAssembly exception handling using setjmp/longjmp
 
+#include <setjmp.h>
+
 #include "jit_internal.h"
 
 // ============ Exception Handler Management ============


### PR DESCRIPTION
## Summary
- Fixes Linux CI build failure where `sigsetjmp` is undeclared in `jit/jit_ffi/exception.c`.

## Context
- The OCI release workflow compiles JIT C sources on Ubuntu runners.