### PR TITLE
jit: define _POSIX_C_SOURCE for sigsetjmp

### DIFF
--- a/jit/jit_ffi/exception.c
+++ b/jit/jit_ffi/exception.c
@@ -2,6 +2,12 @@
 // Exception handling for JIT runtime
 // Implements WebAssembly exception handling using setjmp/longjmp
 
+// Ensure POSIX setjmp APIs are declared on glibc.
+// This is required for `sigsetjmp` to be visible in some feature-macro configurations.
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <setjmp.h>
 
 #include "jit_internal.h"


### PR DESCRIPTION
## Summary
- Defines `_POSIX_C_SOURCE=200809L` before including `<setjmp.h>` so `sigsetjmp` is declared on Linux.

## Context
- The OCI release workflow builds on Ubuntu and currently fails with `sigsetjmp undeclared` in `jit/jit_ffi/exception.c`.