### PR TITLE
ci: lowercase GHCR repository for ORAS push

### DIFF
--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -15,7 +15,8 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  OCI_REPO: ${{ github.repository }}
+  # GHCR requires lowercase repository names.
+  OCI_REPO: ${{ toLower(github.repository) }}
   ARTIFACT_TYPE: application/vnd.wasmoon.binary.v1
 
 jobs:


### PR DESCRIPTION
## Summary
- Fixes ORAS push failing with: invalid repository "Milky2018/wasmoon".
- GHCR requires lowercase repo names; uses `toLower(github.repository)`.