### PR TITLE
ci: fix ORAS push script newline

### DIFF
--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -85,7 +85,8 @@ jobs:
         run: |
           set -euxo pipefail
           repo="$(echo "${{ env.OCI_REPO }}" | tr '[:upper:]' '[:lower:]')"
-          ref="${{ env.REGISTRY }}/${repo}:${{ steps.tag.outputs.tag }}-${{ matrix.tag_suffix }}"          oras push \
+          ref="${{ env.REGISTRY }}/${repo}:${{ steps.tag.outputs.tag }}-${{ matrix.tag_suffix }}"
+          oras push \
             --artifact-type "${{ env.ARTIFACT_TYPE }}" \
             --artifact-platform "${{ matrix.platform }}" \
             "$ref" \


### PR DESCRIPTION
## Summary
- Fixes the release workflow failing in `oras push` step because the `ref=...` assignment and `oras push` ended up on the same line.
- With `set -u`, this caused `ref: unbound variable`.