### PR TITLE
Fix #349: const expr array.new_fixed and proper null reference surfacing

### DIFF
--- a/executor/executor.mbt
+++ b/executor/executor.mbt
@@ -1114,7 +1114,7 @@ pub fn instantiate_module(
 ///|
 /// Evaluate a constant initialization expression
 /// Supports extended constant expressions with arithmetic operations
-/// and GC instructions (array.new, array.new_default, struct.new, struct.new_default)
+/// and GC instructions (array.new, array.new_default, array.new_fixed, struct.new, struct.new_default)
 fn eval_const_expr(
   instrs : Array[@types.Instruction],
   func_addrs? : Array[Int] = [],
@@ -1181,6 +1181,30 @@ fn eval_const_expr(
           let init_val = stack.pop().unwrap()
           if len_val is I32(len) {
             let elements : Array[@types.Value] = Array::make(len, init_val)
+            let ref_idx = s.alloc_array(type_idx, elements)
+            stack.push(ArrayRef(ref_idx))
+          }
+        }
+      // GC: array.new_fixed - create array from fixed number of stack values
+      ArrayNewFixed(type_idx, len) =>
+        if store is Some(s) && type_idx < types.length() {
+          // Ensure this is actually an array type.
+          match types[type_idx].composite {
+            Array(_) => ()
+            _ => continue
+          }
+          if len == 0 {
+            let ref_idx = s.alloc_array(type_idx, [])
+            stack.push(ArrayRef(ref_idx))
+          } else if stack.length() >= len {
+            // Pop elements in reverse order (last element pushed first).
+            let elements : Array[@types.Value] = Array::make(
+              len,
+              @types.Value::Null,
+            )
+            for i = len - 1; i >= 0; i = i - 1 {
+              elements[i] = stack.pop().unwrap()
+            }
             let ref_idx = s.alloc_array(type_idx, elements)
             stack.push(ArrayRef(ref_idx))
           }
@@ -1470,6 +1494,7 @@ pub fn instantiate_module_with_init(
       @runtime.TypeMismatch => raise @runtime.TypeMismatch
       @runtime.OutOfBoundsMemoryAccess => raise @runtime.OutOfBoundsMemoryAccess
       @runtime.OutOfBoundsTableAccess => raise @runtime.OutOfBoundsTableAccess
+      @runtime.OutOfBoundsArrayAccess => raise @runtime.OutOfBoundsArrayAccess
       @runtime.UndefinedElement => raise @runtime.UndefinedElement
       @runtime.UninitializedElement => raise @runtime.UninitializedElement
       @runtime.IndirectCallTypeMismatch =>
@@ -1480,6 +1505,8 @@ pub fn instantiate_module_with_init(
       @runtime.Unreachable => raise @runtime.Unreachable
       @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
       @runtime.UnknownImport(_) as e => raise e
+      @runtime.NullReference => raise @runtime.NullReference
+      @runtime.UnalignedAtomic => raise @runtime.UnalignedAtomic
       _ => raise @runtime.Unreachable
     })
     |> ignore
@@ -1922,6 +1949,7 @@ pub fn instantiate_module_with_imports(
       @runtime.TypeMismatch => raise @runtime.TypeMismatch
       @runtime.OutOfBoundsMemoryAccess => raise @runtime.OutOfBoundsMemoryAccess
       @runtime.OutOfBoundsTableAccess => raise @runtime.OutOfBoundsTableAccess
+      @runtime.OutOfBoundsArrayAccess => raise @runtime.OutOfBoundsArrayAccess
       @runtime.UndefinedElement => raise @runtime.UndefinedElement
       @runtime.UninitializedElement => raise @runtime.UninitializedElement
       @runtime.IndirectCallTypeMismatch =>
@@ -1934,6 +1962,8 @@ pub fn instantiate_module_with_imports(
       @runtime.UnknownImport(_) as e => raise e
       @runtime.LinkError => raise @runtime.LinkError
       @runtime.LinkErrorDetail(_) as e => raise e
+      @runtime.NullReference => raise @runtime.NullReference
+      @runtime.UnalignedAtomic => raise @runtime.UnalignedAtomic
       _ => raise @runtime.Unreachable
     })
     |> ignore
@@ -1984,6 +2014,8 @@ pub fn call_exported_func(
               raise @runtime.OutOfBoundsMemoryAccess
             @runtime.OutOfBoundsTableAccess =>
               raise @runtime.OutOfBoundsTableAccess
+            @runtime.OutOfBoundsArrayAccess =>
+              raise @runtime.OutOfBoundsArrayAccess
             @runtime.UndefinedElement => raise @runtime.UndefinedElement
             @runtime.UninitializedElement => raise @runtime.UninitializedElement
             @runtime.IndirectCallTypeMismatch =>
@@ -1994,6 +2026,8 @@ pub fn call_exported_func(
             @runtime.Unreachable => raise @runtime.Unreachable
             @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
             @runtime.UnknownImport(_) as e => raise e
+            @runtime.NullReference => raise @runtime.NullReference
+            @runtime.UnalignedAtomic => raise @runtime.UnalignedAtomic
             _ => raise @runtime.Unreachable
           }
         } // Unknown error
@@ -2020,6 +2054,7 @@ pub fn call_func_by_index(
     @runtime.TypeMismatch => raise @runtime.TypeMismatch
     @runtime.OutOfBoundsMemoryAccess => raise @runtime.OutOfBoundsMemoryAccess
     @runtime.OutOfBoundsTableAccess => raise @runtime.OutOfBoundsTableAccess
+    @runtime.OutOfBoundsArrayAccess => raise @runtime.OutOfBoundsArrayAccess
     @runtime.UndefinedElement => raise @runtime.UndefinedElement
     @runtime.UninitializedElement => raise @runtime.UninitializedElement
     @runtime.IndirectCallTypeMismatch => raise @runtime.IndirectCallTypeMismatch
@@ -2029,6 +2064,8 @@ pub fn call_func_by_index(
     @runtime.Unreachable => raise @runtime.Unreachable
     @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
     @runtime.UnknownImport(_) as e => raise e
+    @runtime.NullReference => raise @runtime.NullReference
+    @runtime.UnalignedAtomic => raise @runtime.UnalignedAtomic
     _ => raise @runtime.Unreachable
   }
 }
@@ -2145,6 +2182,7 @@ pub fn instantiate_with_linker(
       @runtime.TypeMismatch => raise @runtime.TypeMismatch
       @runtime.OutOfBoundsMemoryAccess => raise @runtime.OutOfBoundsMemoryAccess
       @runtime.OutOfBoundsTableAccess => raise @runtime.OutOfBoundsTableAccess
+      @runtime.OutOfBoundsArrayAccess => raise @runtime.OutOfBoundsArrayAccess
       @runtime.UndefinedElement => raise @runtime.UndefinedElement
       @runtime.UninitializedElement => raise @runtime.UninitializedElement
       @runtime.IndirectCallTypeMismatch =>
@@ -2155,6 +2193,8 @@ pub fn instantiate_with_linker(
       @runtime.Unreachable => raise @runtime.Unreachable
       @runtime.CallStackExhausted => raise @runtime.CallStackExhausted
       @runtime.UnknownImport(_) as e => raise e
+      @runtime.NullReference => raise @runtime.NullReference
+      @runtime.UnalignedAtomic => raise @runtime.UnalignedAtomic
       _ => raise @runtime.Unreachable
     })
     |> ignore

--- a/testsuite/gc_wbtest.mbt
+++ b/testsuite/gc_wbtest.mbt
@@ -158,6 +158,46 @@ test "gc: array.new_fixed" {
 }
 
 ///|
+test "gc: const expr array.new_fixed (empty)" {
+  let results = run_wat(
+    (
+      #|
+      #|(module
+      #|  (type $moonbit.string (array (mut i16)))
+      #|  (global $g (ref $moonbit.string) (array.new_fixed $moonbit.string 0))
+      #|  (func (export "test") (result i32)
+      #|    (array.len (global.get $g))
+      #|  )
+      #|)
+    ),
+  )
+  inspect(results, content="[I32(0)]")
+}
+
+///|
+test "gc: null reference trap is surfaced as null reference" {
+  let wat =
+    #|
+    #|(module
+    #|  (type $arr (array i32))
+    #|  (global $g (ref null $arr) (ref.null $arr))
+    #|  (func (export "test") (result i32)
+    #|    (array.len (global.get $g))
+    #|  )
+    #|)
+  let mod = @wat.parse(wat)
+  let (store, instance) = @executor.instantiate_module_with_init(mod)
+  try @executor.call_exported_func(store, instance, "test", []) catch {
+    e => {
+      inspect(e.to_string(), content="null reference")
+      return
+    }
+  } noraise {
+    _ => fail("expected trap")
+  }
+}
+
+///|
 test "gc: array.set" {
   let results = run_wat(
     (


### PR DESCRIPTION
Fixes #349.

Root cause: the extended const-expr evaluator did not handle `array.new_fixed`, so the empty-string global initializer evaluated to `Null`. Later `array.len` on that global trapped, and the wrapper catch-lists re-mapped `NullReference` to `Unreachable`.

Changes:
- Implement `ArrayNewFixed(type_idx, len)` in `executor/executor.mbt::eval_const_expr` (including len=0).
- Explicitly surface `NullReference` (and also `OutOfBoundsArrayAccess`/`UnalignedAtomic`) in the relevant executor catch lists so traps aren’t misreported as `unreachable`.
- Add regression tests in `testsuite/gc_wbtest.mbt`.

Repro (interpreter):
`(global (ref 0) (array.new_fixed 0 0))` + `(array.len (global.get 0))` now returns 0 instead of trapping.