### PR TITLE
chore: release v0.2.1

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "Milky2018/wasmoon",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "deps": {
     "moonbitlang/x": "0.4.38",
     "TheWaWaR/clap": "0.2.6"


### PR DESCRIPTION
Bump `moon.mod.json` version to 0.2.1.

Publishing steps after merge:
- `moon publish`
