### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "Milky2018/wasmoon",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "deps": {
     "moonbitlang/x": "0.4.38",
     "TheWaWaR/clap": "0.2.6"


### PR DESCRIPTION
Release bump for strict const-expr evaluation hardening.

moon test: OK
