### PR TITLE
regalloc: fix BranchCmp clobber when both operands spilled

### DIFF
--- a/vcode/regalloc/regalloc_apply.mbt
+++ b/vcode/regalloc/regalloc_apply.mbt
@@ -791,29 +791,30 @@ pub fn apply_allocation(
           @instr.Jump(target, [])
         }
         Branch(cond, then_b, else_b) => {
-          // Handle spilled condition register
-          let new_cond = rewrite_reg_with_spill(cond, alloc, new_block)
+          // Handle spilled condition register (single input).
+          let new_cond = rewrite_reg_with_spill(cond, alloc, new_block, 16)
           Branch(new_cond, then_b, else_b)
         }
         BranchCmp(lhs, rhs, cond, is_64, then_b, else_b) => {
-          // Handle spilled registers
-          let new_lhs = rewrite_reg_with_spill(lhs, alloc, new_block)
-          let new_rhs = rewrite_reg_with_spill(rhs, alloc, new_block)
+          // Handle spilled registers. IMPORTANT: if both sides are spilled, we must
+          // reload into distinct scratch registers, otherwise we clobber one side.
+          let new_lhs = rewrite_reg_with_spill(lhs, alloc, new_block, 16)
+          let new_rhs = rewrite_reg_with_spill(rhs, alloc, new_block, 17)
           BranchCmp(new_lhs, new_rhs, cond, is_64, then_b, else_b)
         }
         BranchCmpImm(lhs, imm, cond, is_64, then_b, else_b) => {
-          // Handle spilled register
-          let new_lhs = rewrite_reg_with_spill(lhs, alloc, new_block)
+          // Handle spilled register (single input).
+          let new_lhs = rewrite_reg_with_spill(lhs, alloc, new_block, 16)
           BranchCmpImm(new_lhs, imm, cond, is_64, then_b, else_b)
         }
         BranchZero(reg, is_nonzero, is_64, then_b, else_b) => {
-          // Handle spilled register
-          let new_reg = rewrite_reg_with_spill(reg, alloc, new_block)
+          // Handle spilled register (single input).
+          let new_reg = rewrite_reg_with_spill(reg, alloc, new_block, 16)
           BranchZero(new_reg, is_nonzero, is_64, then_b, else_b)
         }
         BrTable(index, targets, default) => {
-          // Handle spilled index register
-          let new_index = rewrite_reg_with_spill(index, alloc, new_block)
+          // Handle spilled index register (single input).
+          let new_index = rewrite_reg_with_spill(index, alloc, new_block, 16)
           BrTable(new_index, targets, default)
         }
         Return(values) => {
@@ -925,6 +926,7 @@ fn rewrite_reg_with_spill(
   reg : @abi.Reg,
   alloc : RegAllocResult,
   block : @block.VCodeBlock,
+  scratch_idx : Int,
 ) -> @abi.Reg {
   match reg {
     @abi.Virtual(vreg) =>
@@ -934,7 +936,14 @@ fn rewrite_reg_with_spill(
           // Spilled: insert reload and use scratch register
           match alloc.spill_slots.get(vreg.id) {
             Some(slot) => {
-              let scratch_preg : @abi.PReg = { index: 16, class: vreg.class }
+              let scratch_class = match vreg.class {
+                @abi.Float32 | @abi.Float64 => @abi.Float64
+                _ => vreg.class
+              }
+              let scratch_preg : @abi.PReg = {
+                index: scratch_idx,
+                class: scratch_class,
+              }
               let reload_inst = @instr.VCodeInst::new(StackLoad(slot * 8))
               reload_inst.add_def({ reg: @abi.Physical(scratch_preg) })
               block.add_inst(reload_inst)

--- a/vcode/regalloc/regalloc_wbtest.mbt
+++ b/vcode/regalloc/regalloc_wbtest.mbt
@@ -122,6 +122,68 @@ test "liveness: multi-block function" {
 }
 
 ///|
+
+///|
+test "apply_allocation: BranchCmp reloads both spilled operands without clobber" {
+  // Regression test: terminator BranchCmp has two operands. If both are spilled,
+  // apply_allocation must reload them into distinct scratch registers, otherwise
+  // one reload clobbers the other and the compare becomes nonsense.
+  let func = VCodeFunction::new("test_branchcmp_spill")
+
+  // No return values needed.
+  let entry = func.new_block()
+  let then_b = func.new_block()
+  let else_b = func.new_block()
+  then_b.set_terminator(@instr.Return([]))
+  else_b.set_terminator(@instr.Return([]))
+
+  // Define two virtual regs.
+  let lhs = func.new_vreg(@abi.Int)
+  let rhs = func.new_vreg(@abi.Int)
+  let lhs_inst = @instr.VCodeInst::new(@instr.LoadConst(1L))
+  lhs_inst.add_def({ reg: @abi.Virtual(lhs) })
+  entry.add_inst(lhs_inst)
+  let rhs_inst = @instr.VCodeInst::new(@instr.LoadConst(2L))
+  rhs_inst.add_def({ reg: @abi.Virtual(rhs) })
+  entry.add_inst(rhs_inst)
+
+  // Compare lhs < rhs (unsigned), then branch.
+  entry.set_terminator(
+    @instr.BranchCmp(
+      @abi.Virtual(lhs),
+      @abi.Virtual(rhs),
+      @instr.Cond::Lo,
+      true,
+      then_b.id,
+      else_b.id,
+    ),
+  )
+
+  // Force both regs to be spilled so apply_allocation must reload them.
+  let spill_slots : Map[Int, Int] = {}
+  spill_slots.set(lhs.id, 0)
+  spill_slots.set(rhs.id, 1)
+  let alloc : RegAllocResult = {
+    assignments: {},
+    spill_slots,
+    num_spill_slots: 2,
+    inst_edits: {},
+  }
+  let allocated = apply_allocation(func, alloc)
+  match allocated.blocks[0].terminator {
+    Some(@instr.VCodeTerminator::BranchCmp(lhs_reg, rhs_reg, _, _, _, _)) =>
+      match (lhs_reg, rhs_reg) {
+        (@abi.Physical(l), @abi.Physical(r)) => {
+          inspect(l.index == 16, content="true")
+          inspect(r.index == 17, content="true")
+        }
+        _ => abort("expected BranchCmp to use physical regs after allocation")
+      }
+    _ => abort("expected BranchCmp terminator")
+  }
+}
+
+///|
 test "regalloc: aarch64 convenience function" {
   // Test the convenience function
   let func = VCodeFunction::new("test_aarch64")


### PR DESCRIPTION
Fixes a JIT miscompile where a terminator BranchCmp reloads two spilled operands into the same scratch reg (X16), clobbering one side.

Repro (before): 4618245000 reliably traps  via abort path.
After: runs successfully.

Also adds a whitebox test that forces both BranchCmp operands to be spilled and asserts they are reloaded into X16/X17.