### PR TITLE
Fix issue #379 by making JIT gc_setup context explicit and validated

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -107,6 +107,16 @@ WIT support is still evolving. `wasmoon-tools wit` implements directory + `deps/
 
 ## Library Usage
 
+### JIT GC Setup Migration
+
+`@jit.gc_setup(...)` now requires full function-table context for typed funcref/ref.func safety:
+
+- `func_type_indices`
+- `func_table_ptr`
+- `num_funcs`
+
+The API now fails fast with `GCSetupError` when these values are inconsistent, instead of continuing with incomplete context.
+
 ### Basic Example
 
 ```moonbit check

--- a/cli/main/run.mbt
+++ b/cli/main/run.mbt
@@ -970,7 +970,12 @@ fn run_with_jit(
                     func_type_indices=instance.func_type_indices,
                     func_table_ptr=jm.get_func_table_ptr(),
                     num_funcs=jm.get_func_count(),
-                  )
+                  ) catch {
+                    err => {
+                      @logger.error("JIT GC setup failed: \{err}")
+                      return exit_failure()
+                    }
+                  }
                   // Set GC heap in VMContext for inline allocation
                   jm.set_gc_heap(heap.get_ptr())
                 }

--- a/jit/gc_helpers.mbt
+++ b/jit/gc_helpers.mbt
@@ -268,27 +268,46 @@ pub fn gc_clear_heap() -> Unit {
 }
 
 ///|
+/// Error for invalid JIT GC setup context
+pub suberror GCSetupError {
+  InvalidFuncCount(num_funcs~ : Int)
+  FuncTypeIndicesLengthMismatch(func_type_indices_len~ : Int, num_funcs~ : Int)
+  MissingFunctionTableContext(num_funcs~ : Int)
+} derive(Show)
+
+///|
 /// Full GC setup for JIT: set heap and type cache
+/// `func_type_indices`, `func_table_ptr`, and `num_funcs` are required to keep
+/// typed funcref/ref.func operations safe and deterministic.
 pub fn gc_setup(
   heap : CHeap,
   types : Array[@types.SubType],
   canonical_indices : Array[Int],
-  func_type_indices? : Array[Int] = [],
-  func_table_ptr? : Int64 = 0L,
-  num_funcs? : Int = 0,
-) -> Unit {
+  func_type_indices~ : Array[Int],
+  func_table_ptr~ : Int64,
+  num_funcs~ : Int,
+) -> Unit raise GCSetupError {
+  if num_funcs < 0 {
+    raise InvalidFuncCount(num_funcs~)
+  }
+  if func_type_indices.length() != num_funcs {
+    raise FuncTypeIndicesLengthMismatch(
+      func_type_indices_len=func_type_indices.length(),
+      num_funcs~,
+    )
+  }
+  if num_funcs > 0 && func_table_ptr == 0L {
+    raise MissingFunctionTableContext(num_funcs~)
+  }
   gc_set_heap(heap)
   setup_type_cache_from_types(types, canonical_indices)
-  // Also set function type indices for funcref subtyping
-  if func_type_indices.length() > 0 {
-    let indices = FixedArray::make(func_type_indices.length(), 0)
-    for i, idx in func_type_indices {
-      indices[i] = idx
-    }
-    @jit_ffi.c_jit_gc_set_func_type_indices(indices, func_type_indices.length())
+  // Set function type indices for funcref subtyping
+  let indices = FixedArray::make(func_type_indices.length(), 0)
+  for i, idx in func_type_indices {
+    indices[i] = idx
   }
-  // Set function table pointer for tagged pointer funcref lookups
-  if func_table_ptr != 0L && num_funcs > 0 {
-    @jit_ffi.c_jit_gc_set_func_table(func_table_ptr, num_funcs)
-  }
+  @jit_ffi.c_jit_gc_set_func_type_indices(indices, func_type_indices.length())
+
+  // Set function table pointer for tagged pointer funcref lookups.
+  @jit_ffi.c_jit_gc_set_func_table(func_table_ptr, num_funcs)
 }

--- a/jit/gc_wbtest.mbt
+++ b/jit/gc_wbtest.mbt
@@ -289,3 +289,43 @@ test "gc: field access after collection" {
   let leaf_value = heap.struct_get(leaf, 0, @types.ValueType::I32)
   inspect(leaf_value, content="I32(42)")
 }
+
+///|
+test "gc_setup: fail fast on inconsistent function table context" {
+  let heap = CHeap::new()
+  let missing_types : Result[Unit, GCSetupError] = try? gc_setup(
+    heap,
+    [],
+    [],
+    func_type_indices=[],
+    func_table_ptr=0L,
+    num_funcs=1,
+  )
+  guard missing_types
+    is Err(FuncTypeIndicesLengthMismatch(func_type_indices_len=0, num_funcs=1)) else {
+    fail("expected func_type_indices length mismatch")
+  }
+  let missing_table_ptr : Result[Unit, GCSetupError] = try? gc_setup(
+    heap,
+    [],
+    [],
+    func_type_indices=[0],
+    func_table_ptr=0L,
+    num_funcs=1,
+  )
+  guard missing_table_ptr is Err(MissingFunctionTableContext(num_funcs=1)) else {
+    fail("expected missing function table context")
+  }
+  let zero_funcs_ok : Result[Unit, GCSetupError] = try? gc_setup(
+    heap,
+    [],
+    [],
+    func_type_indices=[],
+    func_table_ptr=0L,
+    num_funcs=0,
+  )
+  guard zero_funcs_ok is Ok(_) else {
+    fail("expected gc_setup success for zero-func module")
+  }
+  gc_teardown()
+}

--- a/jit/pkg.generated.mbti
+++ b/jit/pkg.generated.mbti
@@ -54,7 +54,7 @@ pub fn gc_clear_heap() -> Unit
 
 pub fn gc_set_heap(CHeap) -> Unit
 
-pub fn gc_setup(CHeap, Array[@types.SubType], Array[Int], func_type_indices? : Array[Int], func_table_ptr? : Int64, num_funcs? : Int) -> Unit
+pub fn gc_setup(CHeap, Array[@types.SubType], Array[Int], func_type_indices~ : Array[Int], func_table_ptr~ : Int64, num_funcs~ : Int) -> Unit raise GCSetupError
 
 pub fn gc_teardown() -> Unit
 
@@ -233,6 +233,13 @@ pub(all) suberror CHeapError {
   OutOfBoundsArrayAccess
   NullReference
 }
+
+pub suberror GCSetupError {
+  InvalidFuncCount(num_funcs~ : Int)
+  FuncTypeIndicesLengthMismatch(func_type_indices_len~ : Int, num_funcs~ : Int)
+  MissingFunctionTableContext(num_funcs~ : Int)
+}
+pub impl Show for GCSetupError
 
 pub suberror JITModuleLoadError {
   ContextAllocationFailed(total_funcs~ : Int)

--- a/testsuite/compare.mbt
+++ b/testsuite/compare.mbt
@@ -453,7 +453,15 @@ pub fn run_jit(
       mod_.types,
       type_rec_groups=mod_.type_rec_groups,
     )
-    @jit.gc_setup(c_heap, mod_.types, canonical_indices)
+    let module_func_type_indices = build_module_func_type_indices(mod_)
+    @jit.gc_setup(
+      c_heap,
+      mod_.types,
+      canonical_indices,
+      func_type_indices=module_func_type_indices,
+      func_table_ptr=jm.get_func_table_ptr(),
+      num_funcs=jm.get_func_count(),
+    )
     // Set GC heap in VMContext for inline allocation
     jm.set_gc_heap(c_heap.get_ptr())
 
@@ -511,14 +519,8 @@ pub fn run_jit(
 }
 
 ///|
-/// Extract element segment values for JIT segment setup
-/// Returns an array of Int64 arrays, one per element segment
-/// Each Int64 is a function index or 0 for null
-fn extract_elem_segment_pairs(
-  mod_ : @types.Module,
-  jm : @jit.JITModule,
-) -> Array[Array[Int64]] {
-  // Build func_idx -> type_idx mapping in the module's index space.
+/// Build func_idx -> type_idx mapping in module index space.
+fn build_module_func_type_indices(mod_ : @types.Module) -> Array[Int] {
   let func_type_indices : Array[Int] = []
   for imp in mod_.imports {
     if imp.desc is Func(type_idx) {
@@ -528,6 +530,18 @@ fn extract_elem_segment_pairs(
   for type_idx in mod_.funcs {
     func_type_indices.push(type_idx)
   }
+  func_type_indices
+}
+
+///|
+/// Extract element segment values for JIT segment setup
+/// Returns an array of Int64 arrays, one per element segment
+/// Each Int64 is a function index or 0 for null
+fn extract_elem_segment_pairs(
+  mod_ : @types.Module,
+  jm : @jit.JITModule,
+) -> Array[Array[Int64]] {
+  let func_type_indices = build_module_func_type_indices(mod_)
   let result : Array[Array[Int64]] = []
   for elem in mod_.elems {
     let pairs : Array[Int64] = []

--- a/wast/runner.mbt
+++ b/wast/runner.mbt
@@ -731,7 +731,9 @@ pub fn invoke_action(
                     func_type_indices=jit_func_type_indices,
                     func_table_ptr=jit.jit_module.get_func_table_ptr(),
                     num_funcs=jit.jit_module.get_func_count(),
-                  )
+                  ) catch {
+                    err => raise RuntimeError("JIT GC setup failed: \{err}")
+                  }
                   // Set GC heap in VMContext for inline allocation
                   jit.jit_module.set_gc_heap(heap.get_ptr())
                 }


### PR DESCRIPTION
Fixes #379

## Summary
- make `@jit.gc_setup(...)` require full function-table context (`func_type_indices`, `func_table_ptr`, `num_funcs`) instead of optional defaults
- add `GCSetupError` and fail fast on inconsistent setup inputs, preventing late JIT SIGSEGV paths
- update JIT call paths to surface setup errors with explicit runtime diagnostics
- update compare test harness to pass module func-type mapping and function table context
- document the migration requirement in README

## Details
`gc_setup` now validates:
- `num_funcs >= 0`
- `func_type_indices.length() == num_funcs`
- when `num_funcs > 0`, `func_table_ptr != 0`

It raises:
- `InvalidFuncCount`
- `FuncTypeIndicesLengthMismatch`
- `MissingFunctionTableContext`

## Validation
- `moon check`
- `moon test -p Milky2018/wasmoon/jit -f gc_wbtest.mbt`
- `moon test testsuite/compare.mbt`
- `moon test testsuite/wast_hang_regression_test.mbt`
- `moon test testsuite/wasi_jit_wbtest.mbt`
