### PR TITLE
fix linux-amd64 wasi parity and expose moon check ICE logs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,8 +21,21 @@ jobs:
           moon update
 
       - name: moon check
+        id: moon_check
+        continue-on-error: true
         run: |
-          moon check --target native
+          set -euxo pipefail
+          moon check --target native 2>&1 | tee /tmp/moon_check_native.log
+
+      - name: dump moon check log (if any)
+        if: steps.moon_check.outcome != 'success'
+        run: |
+          set -euxo pipefail
+          cat /tmp/moon_check_native.log || true
+
+      - name: fail fast if moon check failed
+        if: steps.moon_check.outcome != 'success'
+        run: exit 1
 
       - name: moon test
         run: |
@@ -69,8 +82,21 @@ jobs:
           moon update
 
       - name: moon check
+        id: moon_check
+        continue-on-error: true
         run: |
-          moon check --target native
+          set -euxo pipefail
+          moon check --target native 2>&1 | tee /tmp/moon_check_native.log
+
+      - name: dump moon check log (if any)
+        if: steps.moon_check.outcome != 'success'
+        run: |
+          set -euxo pipefail
+          cat /tmp/moon_check_native.log || true
+
+      - name: fail fast if moon check failed
+        if: steps.moon_check.outcome != 'success'
+        run: exit 1
 
       - name: moon test
         id: moon_test

--- a/jit/jit_ffi/wasi.c
+++ b/jit/jit_ffi/wasi.c
@@ -2876,6 +2876,7 @@ static int32_t wasi_path_filestat_get_impl(
 
     const char *stat_path = full_path;
     char *stat_path_alloc = NULL;
+
     if (has_trailing_slash) {
         size_t full_len = strlen(full_path);
         stat_path_alloc = malloc(full_len + 2);
@@ -3214,6 +3215,22 @@ static int32_t wasi_path_filestat_set_times_impl(
 
     const char *stat_path = full_path;
     char *stat_path_alloc = NULL;
+    int at_flags = (flags & 1) ? 0 : AT_SYMLINK_NOFOLLOW;
+
+    if (has_trailing_slash) {
+        // Keep parity with the interpreter path: trailing slash targets must be directories.
+        struct stat st_check;
+        if (fstatat(AT_FDCWD, full_path, &st_check, at_flags) != 0) {
+            int err = errno_to_wasi(errno);
+            free(full_path);
+            if (err == WASI_ENOTDIR) return WASI_ENOENT;
+            return err;
+        }
+        if (!S_ISDIR(st_check.st_mode)) {
+            free(full_path);
+            return WASI_ENOENT;
+        }
+    }
     if (has_trailing_slash) {
         size_t full_len = strlen(full_path);
         stat_path_alloc = malloc(full_len + 2);
@@ -3227,7 +3244,6 @@ static int32_t wasi_path_filestat_set_times_impl(
         stat_path = stat_path_alloc;
     }
 
-    int at_flags = (flags & 1) ? 0 : AT_SYMLINK_NOFOLLOW;
     int result = utimensat(AT_FDCWD, stat_path, times, at_flags);
     if (stat_path_alloc) free(stat_path_alloc);
     free(full_path);

--- a/testsuite/wasi_jit_wbtest.mbt
+++ b/testsuite/wasi_jit_wbtest.mbt
@@ -49,24 +49,6 @@ fn compare_wasi_with_options(
   stdin_data? : Bytes,
   stdin_callback? : (() -> Bytes)? = None,
 ) -> WasiCompareResult {
-  // AMD64 JIT is still being brought up. Keep the unit tests stable on
-  // Ubuntu/amd64 by skipping WASI JIT-vs-interpreter comparisons there; the
-  // amd64 backend is validated by WAST runners.
-  if @isa.ISA::current() is @isa.AMD64 {
-    ignore(source)
-    ignore(func_name)
-    ignore(preopens)
-    ignore(stdin_data)
-    ignore(stdin_callback)
-    return {
-      jit_result: Ok([]),
-      interp_result: Ok([]),
-      jit_stdout: b"",
-      interp_stdout: b"",
-      match_: true,
-    }
-  }
-
   // Parse the WAT source
   let mod_ = @wat.parse(source) catch {
     e => {

--- a/vcode/isa/amd64/call_conv.mbt
+++ b/vcode/isa/amd64/call_conv.mbt
@@ -47,8 +47,9 @@ pub fn wasm_vmctx_arg_preg() -> @abi.PReg {
 ///|
 /// Internal Wasm ABI (initial amd64 design): user integer argument registers.
 ///
-/// We start with a SysV-like prefix (excluding vmctx in rdi), and add `rax` as an
-/// extra user argument register to reduce stack traffic in internal calls.
+/// Keep this aligned with SysV argument placement after vmctx in `rdi`.
+/// This is required so imported C ABI functions (for example WASI hostcalls)
+/// observe correct stack/register argument ordering.
 pub fn wasm_user_arg_gprs() -> Array[@abi.PReg] {
   [
     { index: 6, class: @abi.Int }, // rsi
@@ -56,8 +57,7 @@ pub fn wasm_user_arg_gprs() -> Array[@abi.PReg] {
     { index: 1, class: @abi.Int }, // rcx
     { index: 8, class: @abi.Int }, // r8
     { index: 9, class: @abi.Int }, // r9
-    { index: 0, class: @abi.Int },
-  ] // rax
+  ] // r9
 }
 
 ///|

--- a/vcode/isa/isa_wbtest.mbt
+++ b/vcode/isa/isa_wbtest.mbt
@@ -29,7 +29,7 @@ test "Wasm ABI arg/ret reg counts (shape)" {
   inspect(a.wasm_ret_fprs().length(), content="8")
   let x = ISA::AMD64
   inspect(x.wasm_vmctx_arg_preg().index, content="7")
-  inspect(x.wasm_user_arg_gprs().length(), content="6")
+  inspect(x.wasm_user_arg_gprs().length(), content="5")
   inspect(x.wasm_arg_fprs().length(), content="8")
   inspect(x.wasm_ret_gprs().length(), content="8")
   inspect(x.wasm_ret_fprs().length(), content="8")

--- a/wasi/functions.mbt
+++ b/wasi/functions.mbt
@@ -2128,6 +2128,18 @@ pub fn path_filestat_set_times_impl(
     resolved_path
   }
   let lookup_flags = if follow_symlink { 0 } else { AT_SYMLINK_NOFOLLOW }
+  if has_trailing_slash {
+    match native_fstatat(0, resolved_path, lookup_flags) {
+      Some(stat) => if stat.filetype != 3 { return Errno::NoEnt.to_i32() }
+      None => {
+        let errno = native_last_errno_to_wasi()
+        if errno == Errno::NotDir.to_i32() {
+          return Errno::NoEnt.to_i32()
+        }
+        return errno
+      }
+    }
+  }
   if native_utimensat(0, stat_path, atim, mtim, fst_flags, lookup_flags) {
     Errno::Success.to_i32()
   } else {


### PR DESCRIPTION
## Summary
- fix linux-amd64 WASI JIT/interpreter parity by removing amd64 skip in wasi_jit_wbtest
- fix amd64 wasm user arg GPR mapping for C ABI hostcalls (drop extra rax arg register)
- align trailing-slash behavior in path_filestat_set_times between interpreter and JIT
- improve CI observability: when moon check fails in macOS/ubuntu jobs, dump full moon check log before fail-fast

## Why
MoonBit compiler ICEs can fail the check step without enough structured context.
This PR ensures the full moon check log is printed in CI so MoonBit developers can inspect exact compiler args from job logs.

## Validation
- docker linux-amd64: WASMOON_REGALLOC_VALIDATION=1 moon test --target native --no-parallelize -v (1927/1927)
- docker linux-amd64: python3 scripts/run_component_wast.py --dir component-spec --rec (70/70)
- docker linux-amd64: python3 scripts/run_all_wast.py --dir spec --rec (interp+jit 258/258)
