### PR TITLE
Align WASIp1 parity with wasmtime for invalid-arg and fd_fdstat_set_rights

### DIFF
--- a/jit/jit_ffi/wasi.c
+++ b/jit/jit_ffi/wasi.c
@@ -3284,7 +3284,7 @@ static int32_t wasi_fd_fdstat_set_rights_impl(
     (void)rights_base;
     (void)rights_inheriting;
     if (!ctx) return WASI_EBADF;
-    if (is_stdio_fd(ctx, fd)) return WASI_ENOTSUP;
+    if (is_stdio_fd(ctx, fd)) return WASI_EBADF;
     int native_fd = get_native_fd(ctx, fd);
     if (native_fd < 0) return WASI_EBADF;
     return WASI_ENOTSUP;

--- a/jit/jit_ffi/wasi.c
+++ b/jit/jit_ffi/wasi.c
@@ -1376,6 +1376,7 @@ static int64_t wasi_fd_seek_impl(
     int64_t fd, int64_t offset, int64_t whence, int64_t newoffset_ptr
 ) {
     if (!ctx || !ctx->memory0 || !ctx->memory0->base) return WASI_EBADF;
+    if (whence < 0 || whence > 2) return trap_invalid_wasi_abi_arg();
 
     int wasi_fd = (int)fd;
     if (wasi_fd < 0) return WASI_EBADF;
@@ -1390,7 +1391,6 @@ static int64_t wasi_fd_seek_impl(
     uint32_t newoffset_ptr_u = (uint32_t)newoffset_ptr;
     if (!check_mem_range(ctx, newoffset_ptr_u, 8)) return WASI_EFAULT;
     uint32_t whence_u = (uint32_t)whence;
-    if (whence_u > 2) return WASI_EINVAL;
 
 #ifdef _WIN32
     int64_t pos = _lseeki64(native_fd, offset, (int)whence_u);
@@ -1596,7 +1596,6 @@ static int64_t wasi_path_open_impl(
     if (((int64_t)fdflags & 0x1A) != 0) { // DSYNC/RSYNC/SYNC
         return WASI_ENOTSUP;
     }
-
     // Read path from memory
     char *path = malloc((size_t)path_len_u + 1);
     if (!path) return WASI_ENOMEM;
@@ -2068,6 +2067,7 @@ static int64_t wasi_clock_time_get_impl(
 ) {
     (void)precision;
     if (!ctx || !ctx->memory0 || !ctx->memory0->base) return WASI_EBADF;
+    if (clock_id < 0 || clock_id > 3) return trap_invalid_wasi_abi_arg();
     uint32_t time_ptr_u = (uint32_t)time_ptr;
     if (!check_mem_range(ctx, time_ptr_u, 8)) return WASI_EFAULT;
 
@@ -2088,8 +2088,6 @@ static int64_t wasi_clock_time_get_impl(
 #endif
     } else if (clock_id == 2 || clock_id == 3) {
         return WASI_EBADF;
-    } else {
-        return WASI_EINVAL;
     }
 
     *(int64_t *)(ctx->memory0->base + time_ptr_u) = time_ns;
@@ -2102,13 +2100,13 @@ static int64_t wasi_clock_res_get_impl(
     int64_t clock_id, int64_t resolution_ptr
 ) {
     if (!ctx || !ctx->memory0 || !ctx->memory0->base) return WASI_EBADF;
+    if (clock_id < 0 || clock_id > 3) return trap_invalid_wasi_abi_arg();
     uint32_t resolution_ptr_u = (uint32_t)resolution_ptr;
     if (!check_mem_range(ctx, resolution_ptr_u, 8)) return WASI_EFAULT;
 
     // WASI clock IDs: 0=REALTIME, 1=MONOTONIC, 2=PROCESS_CPUTIME_ID, 3=THREAD_CPUTIME_ID.
     // Match wasmtime p1: CPU-time clocks return EBADF.
     if (clock_id == 2 || clock_id == 3) return WASI_EBADF;
-    if (clock_id < 0 || clock_id > 3) return WASI_EINVAL;
 #ifdef _WIN32
     if (clock_id == 0) {
         *(int64_t *)(ctx->memory0->base + resolution_ptr_u) = 1000000; // 1ms fallback
@@ -2846,7 +2844,7 @@ static int32_t wasi_path_filestat_get_impl(
     int32_t dir_fd, int32_t flags, int32_t path_ptr, int32_t path_len, int32_t buf_ptr
 ) {
     if (!ctx || !ctx->memory0 || !ctx->memory0->base) return WASI_EBADF;
-    if (invalid_lookupflags(flags)) return WASI_EINVAL;
+    if (invalid_lookupflags(flags)) return trap_invalid_wasi_abi_arg();
     uint8_t *mem = ctx->memory0->base;
     uint32_t path_ptr_u = (uint32_t)path_ptr;
     uint32_t path_len_u = (uint32_t)path_len;
@@ -3035,7 +3033,7 @@ static int32_t wasi_path_link_impl(
     int32_t new_fd, int32_t new_path_ptr, int32_t new_path_len
 ) {
     if (!ctx || !ctx->memory0 || !ctx->memory0->base) return WASI_EBADF;
-    if (invalid_lookupflags(old_flags)) return WASI_EINVAL;
+    if (invalid_lookupflags(old_flags)) return trap_invalid_wasi_abi_arg();
     uint8_t *mem = ctx->memory0->base;
     uint32_t old_path_ptr_u = (uint32_t)old_path_ptr;
     uint32_t old_path_len_u = (uint32_t)old_path_len;
@@ -3101,8 +3099,11 @@ static int32_t wasi_path_link_impl(
 }
 
 // fd_filestat_set_times: Set file timestamps
-static int invalid_fst_flags_for_set_times(int32_t fst_flags) {
-    if ((fst_flags & ~0x0f) != 0) return 1;
+static int unknown_fst_flags_for_set_times(int32_t fst_flags) {
+    return (fst_flags & ~0x0f) != 0;
+}
+
+static int conflicting_fst_flags_for_set_times(int32_t fst_flags) {
     if ((fst_flags & 0x03) == 0x03) return 1;
     if ((fst_flags & 0x0c) == 0x0c) return 1;
     return 0;
@@ -3112,7 +3113,8 @@ static int32_t wasi_fd_filestat_set_times_impl(
     jit_context_t *ctx,
     int32_t fd, int64_t atim, int64_t mtim, int32_t fst_flags
 ) {
-    if (invalid_fst_flags_for_set_times(fst_flags)) return WASI_EINVAL;
+    if (unknown_fst_flags_for_set_times(fst_flags)) return trap_invalid_wasi_abi_arg();
+    if (conflicting_fst_flags_for_set_times(fst_flags)) return WASI_EINVAL;
     int native_fd = -1;
     int err = get_non_stdio_native_fd(ctx, fd, &native_fd);
     if (err != WASI_ESUCCESS) return err;
@@ -3159,8 +3161,9 @@ static int32_t wasi_path_filestat_set_times_impl(
     int32_t dir_fd, int32_t flags, int32_t path_ptr, int32_t path_len,
     int64_t atim, int64_t mtim, int32_t fst_flags
 ) {
-    if (invalid_lookupflags(flags)) return WASI_EINVAL;
-    if (invalid_fst_flags_for_set_times(fst_flags)) return WASI_EINVAL;
+    if (invalid_lookupflags(flags)) return trap_invalid_wasi_abi_arg();
+    if (unknown_fst_flags_for_set_times(fst_flags)) return trap_invalid_wasi_abi_arg();
+    if (conflicting_fst_flags_for_set_times(fst_flags)) return WASI_EINVAL;
     if (!ctx || !ctx->memory0 || !ctx->memory0->base) return WASI_EBADF;
     uint8_t *mem = ctx->memory0->base;
     uint32_t path_ptr_u = (uint32_t)path_ptr;
@@ -3390,7 +3393,7 @@ static int32_t wasi_fd_fdstat_set_flags_impl(
     int32_t fd, int32_t flags
 ) {
     if ((flags & ~0x1f) != 0) {
-        return WASI_EINVAL;
+        return trap_invalid_wasi_abi_arg();
     }
     if (is_stdio_fd(ctx, fd)) return WASI_EBADF;
     if (is_preopen_fd(ctx, fd) || get_open_dir_path(ctx, fd)) return WASI_EBADF;
@@ -3508,7 +3511,7 @@ static int32_t wasi_sock_recv_impl(
     if (!check_mem_range(ctx, ri_data_u, (size_t)ri_data_len_u * 8)) return WASI_EFAULT;
     if (!check_mem_range(ctx, ro_datalen_ptr_u, 4)) return WASI_EFAULT;
     if (!check_mem_range(ctx, ro_flags_ptr_u, 2)) return WASI_EFAULT;
-    if (invalid_sock_recv_riflags(ri_flags)) return WASI_EINVAL;
+    if (invalid_sock_recv_riflags(ri_flags)) return trap_invalid_wasi_abi_arg();
 
     (void)ri_data_u;
     (void)ri_data_len_u;
@@ -3554,7 +3557,7 @@ static int32_t wasi_sock_shutdown_impl(
     int32_t fd, int32_t how
 ) {
     if (!ctx) return WASI_EBADF;
-    if (invalid_sock_shutdown_sdflags(how)) return WASI_EINVAL;
+    if (invalid_sock_shutdown_sdflags(how)) return trap_invalid_wasi_abi_arg();
     if (!is_valid_wasi_descriptor(ctx, fd)) return WASI_EBADF;
     return WASI_ENOTSOCK;
 }

--- a/testsuite/wasi_jit_wbtest.mbt
+++ b/testsuite/wasi_jit_wbtest.mbt
@@ -1258,7 +1258,7 @@ test "wasi jit: path_filestat_get trailing slash on regular file returns ENOENT"
 }
 
 ///|
-test "wasi jit: path_filestat_get rejects unknown lookupflags bits with EINVAL" {
+test "wasi jit: path_filestat_get traps on unknown lookupflags bits" {
   let source =
     #|(module
     #|  (import "wasi_snapshot_preview1" "path_open"
@@ -1292,8 +1292,8 @@ test "wasi jit: path_filestat_get rejects unknown lookupflags bits with EINVAL" 
     ("/tmp", "/"),
   ])
   inspect(result.match_, content="true")
-  inspect(wasi_errno_from_result(result.interp_result), content="28")
-  inspect(wasi_errno_from_result(result.jit_result), content="28")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
 }
 
 ///|
@@ -1399,7 +1399,7 @@ test "wasi jit: path_filestat_set_times rejects conflicting fst_flags with EINVA
 }
 
 ///|
-test "wasi jit: path_filestat_set_times rejects unknown lookupflags bits with EINVAL" {
+test "wasi jit: path_filestat_set_times traps on unknown lookupflags bits" {
   let source =
     #|(module
     #|  (import "wasi_snapshot_preview1" "path_open"
@@ -1433,8 +1433,8 @@ test "wasi jit: path_filestat_set_times rejects unknown lookupflags bits with EI
     ("/tmp", "/"),
   ])
   inspect(result.match_, content="true")
-  inspect(wasi_errno_from_result(result.interp_result), content="28")
-  inspect(wasi_errno_from_result(result.jit_result), content="28")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
 }
 
 ///|
@@ -1725,7 +1725,7 @@ test "wasi jit: path_link rejects LOOKUPFLAGS_SYMLINK_FOLLOW" {
 }
 
 ///|
-test "wasi jit: path_link rejects unknown lookupflags bits with EINVAL" {
+test "wasi jit: path_link traps on unknown lookupflags bits" {
   let source =
     #|(module
     #|  (import "wasi_snapshot_preview1" "path_unlink_file"
@@ -1758,8 +1758,8 @@ test "wasi jit: path_link rejects unknown lookupflags bits with EINVAL" {
     ("/tmp", "/"),
   ])
   inspect(result.match_, content="true")
-  inspect(wasi_errno_from_result(result.interp_result), content="28")
-  inspect(wasi_errno_from_result(result.jit_result), content="28")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
 }
 
 ///|
@@ -1928,6 +1928,21 @@ test "wasi jit: clock_time_get process/thread cpu clocks return EBADF (8)" {
 }
 
 ///|
+test "wasi jit: clock_time_get traps on invalid clock id enum" {
+  let source =
+    #|(module
+    #|  (import "wasi_snapshot_preview1" "clock_time_get"
+    #|    (func $clock_time_get (param i32 i64 i32) (result i32)))
+    #|  (memory (export "memory") 1)
+    #|  (func (export "test") (result i32)
+    #|    (call $clock_time_get (i32.const 999) (i64.const 0) (i32.const 0))))
+  let result = compare_wasi(source, "test")
+  inspect(result.match_, content="true")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
+}
+
+///|
 test "wasi jit: clock_res_get process/thread cpu clocks return EBADF (8)" {
   let source =
     #|(module
@@ -1946,6 +1961,21 @@ test "wasi jit: clock_res_get process/thread cpu clocks return EBADF (8)" {
   inspect(thread_result.match_, content="true")
   inspect(wasi_errno_from_result(thread_result.interp_result), content="8")
   inspect(wasi_errno_from_result(thread_result.jit_result), content="8")
+}
+
+///|
+test "wasi jit: clock_res_get traps on invalid clock id enum" {
+  let source =
+    #|(module
+    #|  (import "wasi_snapshot_preview1" "clock_res_get"
+    #|    (func $clock_res_get (param i32 i32) (result i32)))
+    #|  (memory (export "memory") 1)
+    #|  (func (export "test") (result i32)
+    #|    (call $clock_res_get (i32.const 999) (i32.const 0))))
+  let result = compare_wasi(source, "test")
+  inspect(result.match_, content="true")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
 }
 
 ///|
@@ -2066,6 +2096,21 @@ test "wasi jit: fd_seek stdin returns ESPIPE (70)" {
     #|  (func (export "test") (result i32)
     #|    (call $fd_seek (i32.const 0) (i64.const 0) (i32.const 0) (i32.const 200))))
   inspect(compare_wasi(source, "test"), content="matched")
+}
+
+///|
+test "wasi jit: fd_seek traps on invalid whence enum" {
+  let source =
+    #|(module
+    #|  (import "wasi_snapshot_preview1" "fd_seek"
+    #|    (func $fd_seek (param i32 i64 i32 i32) (result i32)))
+    #|  (memory (export "memory") 1)
+    #|  (func (export "test") (result i32)
+    #|    (call $fd_seek (i32.const 0) (i64.const 0) (i32.const 3) (i32.const 200))))
+  let result = compare_wasi(source, "test")
+  inspect(result.match_, content="true")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
 }
 
 ///|
@@ -2459,7 +2504,7 @@ test "wasi jit: fd_fdstat_set_flags returns EBADF for non-file fd before DSYNC c
 }
 
 ///|
-test "wasi jit: fd_fdstat_set_flags rejects unknown bits with EINVAL (28)" {
+test "wasi jit: fd_fdstat_set_flags traps on unknown bits" {
   let source =
     #|(module
     #|  (import "wasi_snapshot_preview1" "path_open"
@@ -2478,8 +2523,8 @@ test "wasi jit: fd_fdstat_set_flags rejects unknown bits with EINVAL (28)" {
     ("/tmp", "/"),
   ])
   inspect(result.match_, content="true")
-  inspect(wasi_errno_from_result(result.interp_result), content="28")
-  inspect(wasi_errno_from_result(result.jit_result), content="28")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
 }
 
 ///|
@@ -2672,7 +2717,7 @@ test "wasi jit: sock_accept traps on unknown fdflags bits" {
 }
 
 ///|
-test "wasi jit: sock_recv rejects unknown riflags bits with EINVAL (28)" {
+test "wasi jit: sock_recv traps on unknown riflags bits" {
   let source =
     #|(module
     #|  (import "wasi_snapshot_preview1" "sock_recv"
@@ -2683,12 +2728,12 @@ test "wasi jit: sock_recv rejects unknown riflags bits with EINVAL (28)" {
     #|    (call $sock_recv (i32.const 0) (i32.const 0) (i32.const 1) (i32.const 0x04) (i32.const 16) (i32.const 20))))
   let result = compare_wasi(source, "test")
   inspect(result.match_, content="true")
-  inspect(wasi_errno_from_result(result.interp_result), content="28")
-  inspect(wasi_errno_from_result(result.jit_result), content="28")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
 }
 
 ///|
-test "wasi jit: sock_shutdown rejects unknown sdflags bits with EINVAL (28)" {
+test "wasi jit: sock_shutdown traps on unknown sdflags bits" {
   let source =
     #|(module
     #|  (import "wasi_snapshot_preview1" "sock_shutdown"
@@ -2698,8 +2743,8 @@ test "wasi jit: sock_shutdown rejects unknown sdflags bits with EINVAL (28)" {
     #|    (call $sock_shutdown (i32.const 0) (i32.const 0x04))))
   let result = compare_wasi(source, "test")
   inspect(result.match_, content="true")
-  inspect(wasi_errno_from_result(result.interp_result), content="28")
-  inspect(wasi_errno_from_result(result.jit_result), content="28")
+  inspect(wasi_errno_from_result(result.interp_result), content="-1")
+  inspect(wasi_errno_from_result(result.jit_result), content="-1")
 }
 
 ///|

--- a/testsuite/wasi_jit_wbtest.mbt
+++ b/testsuite/wasi_jit_wbtest.mbt
@@ -2555,6 +2555,38 @@ test "wasi jit: fd_fdstat_set_rights valid fd returns ENOTSUP (58)" {
 }
 
 ///|
+test "wasi jit: fd_fdstat_set_rights stdio returns EBADF (8)" {
+  let source =
+    #|(module
+    #|  (import "wasi_snapshot_preview1" "fd_fdstat_set_rights"
+    #|    (func $fd_fdstat_set_rights (param i32 i64 i64) (result i32)))
+    #|  (memory (export "memory") 1)
+    #|  (func (export "test") (result i32)
+    #|    (call $fd_fdstat_set_rights (i32.const 0) (i64.const 0) (i64.const 0))))
+  let result = compare_wasi(source, "test")
+  inspect(result.match_, content="true")
+  inspect(wasi_errno_from_result(result.interp_result), content="8")
+  inspect(wasi_errno_from_result(result.jit_result), content="8")
+}
+
+///|
+test "wasi jit: fd_fdstat_set_rights preopen returns ENOTSUP (58)" {
+  let source =
+    #|(module
+    #|  (import "wasi_snapshot_preview1" "fd_fdstat_set_rights"
+    #|    (func $fd_fdstat_set_rights (param i32 i64 i64) (result i32)))
+    #|  (memory (export "memory") 1)
+    #|  (func (export "test") (result i32)
+    #|    (call $fd_fdstat_set_rights (i32.const 3) (i64.const 0) (i64.const 0))))
+  let result = compare_wasi_with_options(source, "test", preopens=[
+    ("/tmp", "/"),
+  ])
+  inspect(result.match_, content="true")
+  inspect(wasi_errno_from_result(result.interp_result), content="58")
+  inspect(wasi_errno_from_result(result.jit_result), content="58")
+}
+
+///|
 test "wasi jit: fd_sync stdin returns EBADF (8)" {
   let source =
     #|(module

--- a/wasi/functions.mbt
+++ b/wasi/functions.mbt
@@ -2253,6 +2253,9 @@ pub fn fd_fdstat_set_rights_impl(
   _fs_rights_base : Int64,
   _fs_rights_inheriting : Int64,
 ) -> Int {
+  if is_stdio_descriptor(ctx, fd) {
+    return Errno::Badf.to_i32()
+  }
   if !ctx.is_valid_fd(fd) {
     return Errno::Badf.to_i32()
   }

--- a/wasi/wasi.mbt
+++ b/wasi/wasi.mbt
@@ -191,7 +191,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "clock_time_get",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let clock_id = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -203,6 +203,9 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let time_ptr = match args[2] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      if clock_id < 0 || clock_id > 3 {
+        trap_invalid_wasi_abi_arg()
       }
       let mem = store.get_wasi_memory()
       let result = clock_time_get(mem, clock_id, precision, time_ptr)
@@ -294,7 +297,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "fd_seek",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let fd = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -310,6 +313,9 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let newoffset_ptr = match args[3] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      if whence < 0 || whence > 2 {
+        trap_invalid_wasi_abi_arg()
       }
       let mem = store.get_wasi_memory()
       let result = fd_seek(ctx, mem, fd, offset, whence, newoffset_ptr)
@@ -491,7 +497,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "clock_res_get",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let clock_id = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -499,6 +505,9 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let resolution_ptr = match args[1] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      if clock_id < 0 || clock_id > 3 {
+        trap_invalid_wasi_abi_arg()
       }
       let mem = store.get_wasi_memory()
       let result = clock_res_get(mem, clock_id, resolution_ptr)
@@ -724,7 +733,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "path_filestat_get",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let dir_fd = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -744,6 +753,10 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let buf_ptr = match args[4] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      let known_lookupflags_mask = 0x01
+      if (flags & known_lookupflags_mask.lnot()) != 0 {
+        trap_invalid_wasi_abi_arg()
       }
       let mem = store.get_wasi_memory()
       let result = path_filestat_get_impl(
@@ -777,7 +790,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "fd_filestat_set_times",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let fd = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -794,6 +807,10 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
       }
+      let known_fstflags_mask = 0x0F
+      if (fst_flags & known_fstflags_mask.lnot()) != 0 {
+        trap_invalid_wasi_abi_arg()
+      }
       let result = fd_filestat_set_times_impl(ctx, fd, atim, mtim, fst_flags)
       [@types.Value::I32(result)]
     },
@@ -804,7 +821,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "path_filestat_set_times",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let dir_fd = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -832,6 +849,14 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let fst_flags = match args[6] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      let known_lookupflags_mask = 0x01
+      if (flags & known_lookupflags_mask.lnot()) != 0 {
+        trap_invalid_wasi_abi_arg()
+      }
+      let known_fstflags_mask = 0x0F
+      if (fst_flags & known_fstflags_mask.lnot()) != 0 {
+        trap_invalid_wasi_abi_arg()
       }
       let mem = store.get_wasi_memory()
       let result = path_filestat_set_times_impl(
@@ -903,7 +928,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "fd_fdstat_set_flags",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let fd = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -911,6 +936,10 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let flags = match args[1] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      let known_fdflags_mask = 0x1F
+      if (flags & known_fdflags_mask.lnot()) != 0 {
+        trap_invalid_wasi_abi_arg()
       }
       let result = fd_fdstat_set_flags_impl(ctx, fd, flags)
       [@types.Value::I32(result)]
@@ -1042,7 +1071,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "path_link",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let old_fd = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -1070,6 +1099,10 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let new_path_len = match args[6] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      let known_lookupflags_mask = 0x01
+      if (old_flags & known_lookupflags_mask.lnot()) != 0 {
+        trap_invalid_wasi_abi_arg()
       }
       let mem = store.get_wasi_memory()
       let result = path_link_impl(
@@ -1119,7 +1152,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "sock_recv",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let fd = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -1143,6 +1176,10 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let ro_flags_ptr = match args[5] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      let known_sock_recv_riflags_mask = 0x03
+      if (ri_flags & known_sock_recv_riflags_mask.lnot()) != 0 {
+        trap_invalid_wasi_abi_arg()
       }
       let mem = store.get_wasi_memory()
       let result = sock_recv_impl(
@@ -1191,7 +1228,7 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
   linker.add_host_func(
     "wasi_snapshot_preview1",
     "sock_shutdown",
-    fn(args) {
+    fn(args) raise @runtime.RuntimeError {
       let fd = match args[0] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
@@ -1199,6 +1236,10 @@ pub fn register_wasi(linker : @runtime.Linker, ctx : WasiContext) -> Unit {
       let how = match args[1] {
         I32(v) => v
         _ => return [@types.Value::I32(Errno::Inval.to_i32())]
+      }
+      let known_sock_shutdown_sdflags_mask = 0x03
+      if (how & known_sock_shutdown_sdflags_mask.lnot()) != 0 {
+        trap_invalid_wasi_abi_arg()
       }
       let result = sock_shutdown_impl(ctx, fd, how)
       [@types.Value::I32(result)]

--- a/wasi/wasi_wbtest.mbt
+++ b/wasi/wasi_wbtest.mbt
@@ -868,6 +868,9 @@ test "wasi: path_open rejects sync fdflags with ENOTSUP" {
     2004,
   )
   inspect(reopen_result, content="58")
+  if reopen_result == 0 {
+    fd_close(ctx, mem.read_i32(2004)) |> ignore
+  }
   path_unlink_file_impl(ctx, mem, 3, 100, test_path.length()) |> ignore
 }
 

--- a/wasi/wasi_wbtest.mbt
+++ b/wasi/wasi_wbtest.mbt
@@ -2349,9 +2349,16 @@ test "wasi: sock APIs reject invalid flags before descriptor-kind check" {
 }
 
 ///|
-test "wasi: fd_fdstat_set_rights returns ENOTSUP for valid fd" {
+test "wasi: fd_fdstat_set_rights returns EBADF for stdio" {
   let ctx = WasiContextBuilder::new().build()
   let result = fd_fdstat_set_rights_impl(ctx, 0, 0L, 0L)
+  inspect(result, content="8")
+}
+
+///|
+test "wasi: fd_fdstat_set_rights returns ENOTSUP for preopen fd" {
+  let ctx = WasiContextBuilder::new().preopen_dir("/tmp", "/").build()
+  let result = fd_fdstat_set_rights_impl(ctx, 3, 0L, 0L)
   inspect(result, content="58")
 }
 


### PR DESCRIPTION
## Summary
- align WASIp1 invalid enum/bitflags handling with wasmtime (trap at ABI boundary)
- restore path_open sync fdflags (SYNC/DSYNC/RSYNC) behavior to ENOTSUP(58)
- align fd_fdstat_set_rights on stdio to EBADF(8) while keeping preopen/valid fd as ENOTSUP(58)
- add/adjust wasi + jit wbtests for the above parity points

## Verification
- moon check
- moon test -p Milky2018/wasmoon/wasi -f wasi_wbtest.mbt
- moon test -p Milky2018/wasmoon/testsuite -f wasi_jit_wbtest.mbt
- moon test
