### PR TITLE
Fix MoonBit deprecation warnings

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - $default-branch
 
+env:
+  WASM_TOOLS_VERSION: "1.248.0"
+
 jobs:
   build-macos:
     runs-on: macos-latest
@@ -53,7 +56,7 @@ jobs:
 
       - name: install wasm-tools
         run: |
-          cargo install wasm-tools --locked
+          cargo install wasm-tools --version "$WASM_TOOLS_VERSION" --locked
           wasm-tools --version
 
       - name: run component-spec subset
@@ -179,7 +182,7 @@ jobs:
 
       - name: install wasm-tools
         run: |
-          cargo install wasm-tools --locked
+          cargo install wasm-tools --version "$WASM_TOOLS_VERSION" --locked
           wasm-tools --version
 
       - name: run component-spec subset (amd64)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,8 @@ python3 scripts/run_component_wast.py --dir component-spec/names --rec   # Compo
 - Never batch use `--update`. Treat snapshot errors seriously
 - Don't use `println` in tests. Use `inspect(expr)` and update snapshots, then read the file
 - Use `compare_jit_interp(wat_string)` in `testsuite/` for JIT regression tests
-- Component-model runner requires `wasm-tools` on `PATH` (used to compile `.wast` `(component ...)` forms)
+- Component-model runner requires pinned `wasm-tools` 1.248.0 on `PATH` (used to compile `.wast` `(component ...)` forms):
+  `cargo install wasm-tools --version 1.248.0 --locked`
 
 ## Debugging
 

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -208,6 +208,7 @@ their own compatible licenses. See `THIRD_PARTY_NOTICES.md`.
 moon check --target native
 moon test --target native
 ./install.sh
+cargo install wasm-tools --version 1.248.0 --locked
 python3 scripts/run_all_wast.py --dir spec --rec
 python3 scripts/run_component_wast.py --dir component-spec --rec
 ```

--- a/cmd/wasmoon/commands/component_script.mbt
+++ b/cmd/wasmoon/commands/component_script.mbt
@@ -136,7 +136,7 @@ fn component_test_json(
 fn strip_identifier(name : String) -> String {
   if name.has_prefix("$") && name.length() > 1 {
     let view = name[1:]
-    view.to_string()
+    view.to_owned()
   } else {
     name
   }

--- a/cmd/wasmoon/commands/explore.mbt
+++ b/cmd/wasmoon/commands/explore.mbt
@@ -205,9 +205,9 @@ pub fn run_explore(
   if html_output {
     // Generate output path from input file: foo.wat -> foo.html
     let path = if wasm_path.has_suffix(".wat") {
-      wasm_path[:wasm_path.length() - 4].to_string() + ".html"
+      wasm_path[:wasm_path.length() - 4].to_owned() + ".html"
     } else if wasm_path.has_suffix(".wasm") {
-      wasm_path[:wasm_path.length() - 5].to_string() + ".html"
+      wasm_path[:wasm_path.length() - 5].to_owned() + ".html"
     } else {
       wasm_path + ".html"
     }

--- a/cmd/wasmoon/commands/run.mbt
+++ b/cmd/wasmoon/commands/run.mbt
@@ -27,9 +27,9 @@ fn get_basename(path : String) -> String {
         prev_slash = i
       }
     }
-    path[prev_slash + 1:last_slash].to_string()
+    path[prev_slash + 1:last_slash].to_owned()
   } else {
-    path[last_slash + 1:].to_string()
+    path[last_slash + 1:].to_owned()
   }
 }
 

--- a/component/runtime_impl/instantiate_helpers.mbt
+++ b/component/runtime_impl/instantiate_helpers.mbt
@@ -336,8 +336,8 @@ fn split_core_import_name(name : String) -> (String, String) {
     }
   }
   if sep_idx >= 0 {
-    let mod_name = name[0:sep_idx].to_string()
-    let field = name[sep_idx + 2:].to_string()
+    let mod_name = name[0:sep_idx].to_owned()
+    let field = name[sep_idx + 2:].to_owned()
     (mod_name, field)
   } else {
     ("", name)

--- a/cwasm/cwasm_wbtest.mbt
+++ b/cwasm/cwasm_wbtest.mbt
@@ -202,22 +202,22 @@ test "memory definition: creation and roundtrip" {
   mod.add_memory(1, None)
   inspect(mod.memories.length(), content="1")
   inspect(mod.memories[0].min_pages, content="1")
-  inspect(mod.memories[0].max_pages, content="None")
+  inspect(@debug.to_string(mod.memories[0].max_pages), content="None")
 
   // Add memory with maximum
   mod.add_memory(2, Some(16))
   inspect(mod.memories.length(), content="2")
   inspect(mod.memories[1].min_pages, content="2")
-  inspect(mod.memories[1].max_pages, content="Some(16)")
+  inspect(@debug.to_string(mod.memories[1].max_pages), content="Some(16)")
 
   // Serialize and deserialize
   let bytes = mod.serialize()
   let restored = deserialize(bytes) catch { _ => panic() }
   inspect(restored.memories.length(), content="2")
   inspect(restored.memories[0].min_pages, content="1")
-  inspect(restored.memories[0].max_pages, content="None")
+  inspect(@debug.to_string(restored.memories[0].max_pages), content="None")
   inspect(restored.memories[1].min_pages, content="2")
-  inspect(restored.memories[1].max_pages, content="Some(16)")
+  inspect(@debug.to_string(restored.memories[1].max_pages), content="Some(16)")
 }
 
 ///|
@@ -295,7 +295,7 @@ test "complete module: memory + data + function roundtrip" {
   // Check memory
   inspect(restored.memories.length(), content="1")
   inspect(restored.memories[0].min_pages, content="1")
-  inspect(restored.memories[0].max_pages, content="Some(4)")
+  inspect(@debug.to_string(restored.memories[0].max_pages), content="Some(4)")
 
   // Check data segments
   inspect(restored.data_segments.length(), content="2")
@@ -340,5 +340,8 @@ test "memory definition: large pages" {
   let bytes = mod.serialize()
   let restored = deserialize(bytes) catch { _ => panic() }
   inspect(restored.memories[0].min_pages, content="256")
-  inspect(restored.memories[0].max_pages, content="Some(65536)")
+  inspect(
+    @debug.to_string(restored.memories[0].max_pages),
+    content="Some(65536)",
+  )
 }

--- a/cwasm/moon.pkg
+++ b/cwasm/moon.pkg
@@ -2,4 +2,5 @@ import {
   "Milky2018/wasmoon/types",
   "Milky2018/wasmoon/vcode",
   "Milky2018/wasmoon/vcode/emit",
+  "moonbitlang/core/debug",
 }

--- a/executor/import_diagnostics_wbtest.mbt
+++ b/executor/import_diagnostics_wbtest.mbt
@@ -51,7 +51,10 @@ test "validate_imports_with_diagnostics: import kind mismatch" {
     _ => fail("Expected ImportKindMismatch")
   }
   inspect(result.diagnostics[0].expected, content="func")
-  inspect(result.diagnostics[0].actual, content="Some(\"memory\")")
+  inspect(
+    @debug.to_string(result.diagnostics[0].actual),
+    content="Some(\"memory\")",
+  )
 }
 
 ///|

--- a/executor/moon.pkg
+++ b/executor/moon.pkg
@@ -4,6 +4,7 @@ import {
   "Milky2018/wasmoon/logger",
   "moonbitlang/x/sys",
   "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
   "moonbitlang/core/double",
   "moonbitlang/core/float",
   "moonbitlang/core/math",

--- a/ir/egraph/egraph_wbtest.mbt
+++ b/ir/egraph/egraph_wbtest.mbt
@@ -1440,7 +1440,7 @@ test "egraph: type info is preserved through merge" {
   eg.merge(x, y) |> ignore
   eg.rebuild()
   // Type should be preserved in merged class
-  inspect(eg.get_bits(y), content="Some(32)")
+  inspect(@debug.to_string(eg.get_bits(y)), content="Some(32)")
 }
 
 ///|
@@ -1449,7 +1449,7 @@ test "egraph: add_typed sets type correctly" {
   let x = eg.add_var(0)
   let k5 = eg.add_const(5L)
   let result = eg.add_typed({ op: Add, children: [x, k5] }, 32)
-  inspect(eg.get_bits(result), content="Some(32)")
+  inspect(@debug.to_string(eg.get_bits(result)), content="Some(32)")
 }
 
 ///|

--- a/ir/egraph/moon.pkg
+++ b/ir/egraph/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "Milky2018/wasmoon/types",
+  "moonbitlang/core/debug",
   "moonbitlang/core/hashset",
   "moonbitlang/core/int",
 }

--- a/ir/ir_wbtest.mbt
+++ b/ir/ir_wbtest.mbt
@@ -2421,8 +2421,8 @@ test "wasm address reassociation: shared base plus immediate offsets" {
     None
   }
 
-  assert_eq(iconst_of(func.blocks[0], loads[0].operands[1]), Some(8L))
-  assert_eq(iconst_of(func.blocks[0], loads[1].operands[1]), Some(16L))
+  @debug.assert_eq(iconst_of(func.blocks[0], loads[0].operands[1]), Some(8L))
+  @debug.assert_eq(iconst_of(func.blocks[0], loads[1].operands[1]), Some(16L))
 }
 
 ///|

--- a/ir/moon.pkg
+++ b/ir/moon.pkg
@@ -2,6 +2,7 @@ import {
   "Milky2018/wasmoon/types",
   "Milky2018/wasmoon/perf",
   "Milky2018/wasmoon/ir/egraph",
+  "moonbitlang/core/debug",
   "moonbitlang/core/hashmap",
   "moonbitlang/core/hashset",
 }

--- a/parser/moon.pkg
+++ b/parser/moon.pkg
@@ -1,3 +1,4 @@
 import {
   "Milky2018/wasmoon/types",
+  "moonbitlang/core/debug",
 }

--- a/parser/parser_test.mbt
+++ b/parser/parser_test.mbt
@@ -44,7 +44,7 @@ test "binary parse memory32 - flag 0x00" {
   guard parse_wasm([mem_section]) is Some(m) else { return }
   inspect(m.memories.length(), content="1")
   inspect(m.memories[0].limits.min, content="1")
-  inspect(m.memories[0].limits.max, content="None")
+  inspect(@debug.to_string(m.memories[0].limits.max), content="None")
   inspect(m.memories[0].is_memory64, content="false")
 }
 
@@ -53,7 +53,7 @@ test "binary parse memory32 - flag 0x01" {
   let mem_section : FixedArray[Int] = [0x05, 0x04, 0x01, 0x01, 0x01, 0x04]
   guard parse_wasm([mem_section]) is Some(m) else { return }
   inspect(m.memories[0].limits.min, content="1")
-  inspect(m.memories[0].limits.max, content="Some(4)")
+  inspect(@debug.to_string(m.memories[0].limits.max), content="Some(4)")
   inspect(m.memories[0].is_memory64, content="false")
 }
 
@@ -63,7 +63,7 @@ test "binary parse memory64 - flag 0x04" {
   guard parse_wasm([mem_section]) is Some(m) else { return }
   inspect(m.memories.length(), content="1")
   inspect(m.memories[0].limits.min, content="2")
-  inspect(m.memories[0].limits.max, content="None")
+  inspect(@debug.to_string(m.memories[0].limits.max), content="None")
   inspect(m.memories[0].is_memory64, content="true")
 }
 
@@ -72,7 +72,7 @@ test "binary parse memory64 - flag 0x05" {
   let mem_section : FixedArray[Int] = [0x05, 0x04, 0x01, 0x05, 0x01, 0x0A]
   guard parse_wasm([mem_section]) is Some(m) else { return }
   inspect(m.memories[0].limits.min, content="1")
-  inspect(m.memories[0].limits.max, content="Some(10)")
+  inspect(@debug.to_string(m.memories[0].limits.max), content="Some(10)")
   inspect(m.memories[0].is_memory64, content="true")
 }
 
@@ -86,7 +86,7 @@ test "binary parse table32 - flag 0x00" {
   guard parse_wasm([table_section]) is Some(m) else { return }
   inspect(m.tables.length(), content="1")
   inspect(m.tables[0].type_.limits.min, content="1")
-  inspect(m.tables[0].type_.limits.max, content="None")
+  inspect(@debug.to_string(m.tables[0].type_.limits.max), content="None")
   inspect(m.tables[0].type_.is_table64, content="false")
 }
 
@@ -97,7 +97,7 @@ test "binary parse table32 - flag 0x01" {
   ]
   guard parse_wasm([table_section]) is Some(m) else { return }
   inspect(m.tables[0].type_.limits.min, content="1")
-  inspect(m.tables[0].type_.limits.max, content="Some(10)")
+  inspect(@debug.to_string(m.tables[0].type_.limits.max), content="Some(10)")
   inspect(m.tables[0].type_.is_table64, content="false")
 }
 
@@ -107,7 +107,7 @@ test "binary parse table64 - flag 0x04" {
   guard parse_wasm([table_section]) is Some(m) else { return }
   inspect(m.tables.length(), content="1")
   inspect(m.tables[0].type_.limits.min, content="2")
-  inspect(m.tables[0].type_.limits.max, content="None")
+  inspect(@debug.to_string(m.tables[0].type_.limits.max), content="None")
   inspect(m.tables[0].type_.is_table64, content="true")
 }
 
@@ -118,7 +118,7 @@ test "binary parse table64 - flag 0x05" {
   ]
   guard parse_wasm([table_section]) is Some(m) else { return }
   inspect(m.tables[0].type_.limits.min, content="1")
-  inspect(m.tables[0].type_.limits.max, content="Some(10)")
+  inspect(@debug.to_string(m.tables[0].type_.limits.max), content="Some(10)")
   inspect(m.tables[0].type_.is_table64, content="true")
 }
 

--- a/scripts/run_component_wast.py
+++ b/scripts/run_component_wast.py
@@ -455,6 +455,7 @@ SUPPORTED_VALUE_TYPES = {
 }
 
 UNSUPPORTED_ERROR_CODE = "COMP_UNSUPPORTED"
+PARSE_ERROR_CODE = "COMP_PARSE_ERROR"
 
 
 def parse_component_name(node) -> Optional[str]:
@@ -698,6 +699,13 @@ def validate_component(
     if "component validated ok" in out:
         return True, out.strip(), None
     return False, out.strip() or "unknown validation result", None
+
+
+def is_parse_rejection(msg: str, code: Optional[str]) -> bool:
+    if code == PARSE_ERROR_CODE:
+        return True
+    lower = msg.lower()
+    return "parse component error" in lower or '"phase":"parse"' in lower
 
 
 def wit_names_for_path(wast_file: Path) -> bool:
@@ -950,6 +958,8 @@ def run_file(
                     )
                     if code == UNSUPPORTED_ERROR_CODE:
                         fail(f"assert_malformed failed due to unsupported feature: {msg}")
+                    elif not ok and is_parse_rejection(msg, code):
+                        passed += 1
                     else:
                         if expected_msg:
                             fail(f"assert_malformed unexpectedly parsed: {expected_msg}")

--- a/scripts/run_component_wast.py
+++ b/scripts/run_component_wast.py
@@ -58,6 +58,7 @@ def scale_timeout(base: int) -> int:
 DEFAULT_VALIDATE_TIMEOUT_SECONDS = scale_timeout(BASE_VALIDATE_TIMEOUT_SECONDS)
 DEFAULT_SCRIPT_TIMEOUT_SECONDS = scale_timeout(BASE_SCRIPT_TIMEOUT_SECONDS)
 DEFAULT_TOOLS_TIMEOUT_SECONDS = scale_timeout(BASE_TOOLS_TIMEOUT_SECONDS)
+REQUIRED_WASM_TOOLS_VERSION = "1.248.0"
 
 
 def run_command(
@@ -97,6 +98,20 @@ def run_command(
         return 124, "", "", True
 
     return proc.returncode, (stdout or ""), (stderr or ""), False
+
+
+def read_wasm_tools_version(wasm_tools: Path) -> Optional[str]:
+    returncode, stdout, stderr, timed_out = run_command(
+        [str(wasm_tools), "--version"],
+        timeout_sec=DEFAULT_TOOLS_TIMEOUT_SECONDS,
+    )
+    if timed_out or returncode != 0:
+        return None
+    out = (stdout or stderr).strip()
+    parts = out.split()
+    if len(parts) >= 2 and parts[0] == "wasm-tools":
+        return parts[1]
+    return None
 
 
 def skip_line_comment(text: str, i: int) -> int:
@@ -1199,10 +1214,21 @@ def main() -> int:
     if wasm_tools_bin is None:
         print(
             "Error: `wasm-tools` not found on PATH. "
-            "Install wasm-tools to compile component WAT fallback forms."
+            "Install pinned wasm-tools with: "
+            f"cargo install wasm-tools --version {REQUIRED_WASM_TOOLS_VERSION} --locked"
         )
         return 1
     wasm_tools = Path(wasm_tools_bin).resolve()
+    wasm_tools_version = read_wasm_tools_version(wasm_tools)
+    if wasm_tools_version != REQUIRED_WASM_TOOLS_VERSION:
+        actual = wasm_tools_version or "unknown"
+        print(
+            "Error: unsupported `wasm-tools` version "
+            f"{actual} at {wasm_tools}; expected {REQUIRED_WASM_TOOLS_VERSION}. "
+            "Install the pinned version with: "
+            f"cargo install wasm-tools --version {REQUIRED_WASM_TOOLS_VERSION} --locked"
+        )
+        return 1
 
     test_dir = repo_root / args.dir
     if not test_dir.exists():

--- a/testsuite/backtrace_test.mbt
+++ b/testsuite/backtrace_test.mbt
@@ -216,7 +216,7 @@ fn format_backtrace_for_snapshot(info : TrapInfo) -> String {
 fn extract_trap_type(msg : String) -> String {
   for i, c in msg {
     if c == ' ' || c == '(' {
-      return msg[0:i].to_string()
+      return msg[0:i].to_owned()
     }
   }
   msg

--- a/testsuite/component_canon_start_test.mbt
+++ b/testsuite/component_canon_start_test.mbt
@@ -58,7 +58,10 @@ test "component: parse_component collects canons + start" {
     e => return fail("parse failed: \{e}")
   }
   inspect(parsed.canons.length(), content="1")
-  inspect(parsed.start, content="Some({func_idx: 0, args: [], results: 0})")
+  inspect(
+    @debug.to_string(parsed.start),
+    content="Some({ func_idx: 0, args: [], results: 0 })",
+  )
 }
 
 ///|

--- a/testsuite/component_header_test.mbt
+++ b/testsuite/component_header_test.mbt
@@ -2,7 +2,7 @@
 test "component: sniff_binary_kind recognizes core module vs component" {
   let core : Array[Byte] = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
   inspect(
-    @component.sniff_binary_kind(Bytes::from_array(core)),
+    @debug.to_string(@component.sniff_binary_kind(Bytes::from_array(core))),
     content="Some(CoreModule)",
   )
   let component : Array[Byte] = [
@@ -11,7 +11,7 @@ test "component: sniff_binary_kind recognizes core module vs component" {
      0x0d, 0x00, 0x01, 0x00,
   ]
   inspect(
-    @component.sniff_binary_kind(Bytes::from_array(component)),
+    @debug.to_string(@component.sniff_binary_kind(Bytes::from_array(component))),
     content="Some(Component)",
   )
 }
@@ -20,12 +20,12 @@ test "component: sniff_binary_kind recognizes core module vs component" {
 test "component: sniff_binary_kind rejects non-wasm and short inputs" {
   let short : Array[Byte] = [0x00, 0x61, 0x73]
   inspect(
-    @component.sniff_binary_kind(Bytes::from_array(short)),
+    @debug.to_string(@component.sniff_binary_kind(Bytes::from_array(short))),
     content="None",
   )
   let not_wasm : Array[Byte] = [0x01, 0x02, 0x03, 0x04, 0x01, 0x00, 0x00, 0x00]
   inspect(
-    @component.sniff_binary_kind(Bytes::from_array(not_wasm)),
+    @debug.to_string(@component.sniff_binary_kind(Bytes::from_array(not_wasm))),
     content="None",
   )
 }

--- a/testsuite/component_import_export_test.mbt
+++ b/testsuite/component_import_export_test.mbt
@@ -51,5 +51,5 @@ test "component: parse import/export sections (framing only)" {
   inspect(imports[0].desc, content="FuncType(0)")
   inspect(exports.length(), content="1")
   inspect(exports[0].sortidx, content="{sort: Func, idx: 0}")
-  inspect(exports[0].desc, content="None")
+  inspect(@debug.to_string(exports[0].desc), content="None")
 }

--- a/testsuite/component_model_test.mbt
+++ b/testsuite/component_model_test.mbt
@@ -4,7 +4,7 @@ test "component_sniff_minimal_preamble" {
     b'\x00', b'\x61', b'\x73', b'\x6d', b'\x01', b'\x00', b'\x01', b'\x00',
   ])
   let kind = @component.sniff_binary_kind(bytes)
-  inspect(kind, content="Some(Component)")
+  inspect(@debug.to_string(kind), content="Some(Component)")
 }
 
 ///|

--- a/testsuite/moon.pkg
+++ b/testsuite/moon.pkg
@@ -15,6 +15,7 @@ import {
   "Milky2018/wasmoon/vcode/lower",
   "Milky2018/wasmoon/vcode/regalloc",
   "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
   "moonbitlang/core/strconv",

--- a/types/moon.pkg
+++ b/types/moon.pkg
@@ -1,1 +1,3 @@
-
+import {
+  "moonbitlang/core/debug",
+}

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -1456,5 +1456,5 @@ test "parse empty module" {
   let mod = Module::new()
   inspect(mod.types.length(), content="0")
   inspect(mod.funcs.length(), content="0")
-  inspect(mod.start, content="None")
+  inspect(@debug.to_string(mod.start), content="None")
 }

--- a/vcode/debug.mbt
+++ b/vcode/debug.mbt
@@ -22,7 +22,11 @@ pub fn dump_vcode(func : @regalloc.VCodeFunction, tag : String) -> Unit {
     for i, inst in block.insts {
       println("  [\{i}] \{inst}")
     }
-    println("  Terminator: \{block.terminator}")
+    let terminator_text = match block.terminator {
+      Some(term) => "Some(\{term})"
+      None => "None"
+    }
+    println("  Terminator: \{terminator_text}")
     println("")
   }
   println("=== End VCode Dump ===")

--- a/vcode/moon.pkg
+++ b/vcode/moon.pkg
@@ -6,6 +6,7 @@ import {
   "Milky2018/wasmoon/vcode/instr",
   "Milky2018/wasmoon/vcode/block",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/debug",
 }
 
 import {

--- a/vcode/regalloc/moon.pkg
+++ b/vcode/regalloc/moon.pkg
@@ -7,6 +7,7 @@ import {
   "Milky2018/wasmoon/vcode/instr",
   "Milky2018/wasmoon/vcode/regalloc/unionfind",
   "moonbitlang/x/sys",
+  "moonbitlang/core/debug",
   "moonbitlang/core/hashset",
   "moonbitlang/core/math",
   "moonbitlang/core/string",

--- a/vcode/regalloc/pkg.generated.mbti
+++ b/vcode/regalloc/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "Milky2018/wasmoon/vcode/block",
   "Milky2018/wasmoon/vcode/instr",
   "Milky2018/wasmoon/vcode/isa",
+  "moonbitlang/core/debug",
   "moonbitlang/core/set",
 }
 
@@ -202,7 +203,7 @@ pub struct ProgPoint {
   block : Int
   inst : Int
   pos : ProgPos
-} derive(Eq, Hash)
+} derive(Eq, Hash, @debug.Debug)
 pub impl Show for ProgPoint
 
 type ProgPointRange
@@ -212,7 +213,7 @@ pub impl Show for ProgPointRange
 pub(all) enum ProgPos {
   Before
   After
-} derive(Eq, Hash)
+} derive(Eq, Hash, @debug.Debug)
 
 pub struct RegAllocResult {
   assignments : Map[Int, @abi.PReg]

--- a/vcode/regalloc/regalloc_analysis.mbt
+++ b/vcode/regalloc/regalloc_analysis.mbt
@@ -17,14 +17,14 @@ pub struct ProgPoint {
   block : Int // Block index
   inst : Int // Instruction index within block (-1 for block params)
   pos : ProgPos // Before or after the instruction
-} derive(Eq, Hash)
+} derive(Debug, Eq, Hash)
 
 ///|
 /// Position relative to an instruction
 pub(all) enum ProgPos {
   Before // Before the instruction executes (uses happen here)
   After // After the instruction executes (defs happen here)
-} derive(Eq, Hash)
+} derive(Debug, Eq, Hash)
 
 ///|
 /// Compare two program points using a block order array
@@ -145,6 +145,22 @@ struct UseDefInfo {
 ///|
 fn UseDefInfo::new(vreg : @abi.VReg) -> UseDefInfo {
   { vreg, def_point: None, use_points: [] }
+}
+
+///|
+fn preg_option_to_string(preg : @abi.PReg?) -> String {
+  match preg {
+    Some(p) => "Some(\{p})"
+    None => "None"
+  }
+}
+
+///|
+fn def_point_to_string(def_point : (ProgPoint, @abi.PReg?)?) -> String {
+  match def_point {
+    Some((point, fixed)) => "Some((\{point}, \{preg_option_to_string(fixed)}))"
+    None => "None"
+  }
 }
 
 // ============ Liveness Analysis ============
@@ -287,7 +303,8 @@ pub fn debug_liveness(liveness : LivenessResult) -> String {
   result = result + "Use-Def Chains:\n"
   for entry in liveness.use_def {
     let (vreg_id, info) = entry
-    result = result + "  v\{vreg_id}: def=\{info.def_point}, uses=["
+    result = result +
+      "  v\{vreg_id}: def=\{def_point_to_string(info.def_point)}, uses=["
     for i, use_entry in info.use_points {
       if i > 0 {
         result = result + ", "

--- a/vcode/regalloc/regalloc_wbtest.mbt
+++ b/vcode/regalloc/regalloc_wbtest.mbt
@@ -667,7 +667,7 @@ test "regalloc: vector spill stack slots are 16B and use v-regs" {
       if line.contains(" d") {
         saw_bad_reg_class = true
         if first_bad_line is None {
-          first_bad_line = Some(line.to_string())
+          first_bad_line = Some(line.to_owned())
         }
       }
       match parse_stack_offset(line) {
@@ -677,7 +677,7 @@ test "regalloc: vector spill stack slots are 16B and use v-regs" {
             saw_bad_offset = true
             if first_bad_offset is None {
               first_bad_offset = Some(off)
-              first_bad_line = Some(line.to_string())
+              first_bad_line = Some(line.to_owned())
             }
           }
         None => ()

--- a/wasi/context.mbt
+++ b/wasi/context.mbt
@@ -391,7 +391,7 @@ fn sanitize_guest_path(path : String) -> Result[String, ResolvePathError] {
   let mut i = 0
   while i <= path.length() {
     if i == path.length() || path.code_unit_at(i) == '/' {
-      let seg = if i == start { "" } else { path[start:i].to_string() }
+      let seg = if i == start { "" } else { path[start:i].to_owned() }
       if seg == "" || seg == "." {
         ()
       } else if seg == ".." {
@@ -432,7 +432,7 @@ fn normalized_parent_path(normalized : String) -> String {
   if last_slash < 0 {
     ""
   } else {
-    normalized[0:last_slash].to_string()
+    normalized[0:last_slash].to_owned()
   }
 }
 

--- a/wasi/fs_test.mbt
+++ b/wasi/fs_test.mbt
@@ -86,7 +86,7 @@ test "native file operations: write and read" {
   let bytes = string_to_utf8(content)
   let buf = FixedArray::makei(bytes.length(), fn(i) { bytes[i] })
   let written = @wasi.native_write(fd, buf, buf.length())
-  inspect(written, content="Some(12)")
+  inspect(@debug.to_string(written), content="Some(12)")
 
   // Close file
   inspect(@wasi.native_close(fd), content="true")
@@ -100,7 +100,7 @@ test "native file operations: write and read" {
   // Read content
   let read_buf : FixedArray[Byte] = FixedArray::make(100, b'\x00')
   let read_count = @wasi.native_read(fd, read_buf, 100)
-  inspect(read_count, content="Some(12)")
+  inspect(@debug.to_string(read_count), content="Some(12)")
 
   // Verify content
   let read_bytes = Bytes::makei(12, fn(i) { read_buf[i] })
@@ -136,29 +136,29 @@ test "native file operations: seek and tell" {
   }
 
   // Initial position should be 0
-  inspect(@wasi.native_tell(fd), content="Some(0)")
+  inspect(@debug.to_string(@wasi.native_tell(fd)), content="Some(0)")
 
   // Seek to position 5
   let new_pos = @wasi.native_seek(fd, 5L, @wasi.Set)
-  inspect(new_pos, content="Some(5)")
+  inspect(@debug.to_string(new_pos), content="Some(5)")
 
   // Tell should return 5
-  inspect(@wasi.native_tell(fd), content="Some(5)")
+  inspect(@debug.to_string(@wasi.native_tell(fd)), content="Some(5)")
 
   // Read from position 5
   let read_buf : FixedArray[Byte] = FixedArray::make(5, b'\x00')
   let read_count = @wasi.native_read(fd, read_buf, 5)
-  inspect(read_count, content="Some(5)")
+  inspect(@debug.to_string(read_count), content="Some(5)")
   let read_bytes = Bytes::makei(5, fn(i) { read_buf[i] })
   inspect(utf8_to_string(read_bytes, 5), content="56789")
 
   // Seek relative from current position
   let new_pos = @wasi.native_seek(fd, -3L, @wasi.Cur)
-  inspect(new_pos, content="Some(7)")
+  inspect(@debug.to_string(new_pos), content="Some(7)")
 
   // Seek from end
   let new_pos = @wasi.native_seek(fd, -2L, @wasi.End)
-  inspect(new_pos, content="Some(8)")
+  inspect(@debug.to_string(new_pos), content="Some(8)")
   @wasi.native_close(fd) |> ignore
 }
 

--- a/wasi/moon.pkg
+++ b/wasi/moon.pkg
@@ -2,6 +2,7 @@ import {
   "Milky2018/wasmoon/types",
   "Milky2018/wasmoon/runtime",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/debug",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/hashmap",
 }

--- a/wat/moon.pkg
+++ b/wat/moon.pkg
@@ -1,4 +1,5 @@
 import {
   "Milky2018/wasmoon/wat/parser_impl",
   "Milky2018/wasmoon/types",
+  "moonbitlang/core/debug",
 }

--- a/wat/parser_impl/moon.pkg
+++ b/wat/parser_impl/moon.pkg
@@ -2,12 +2,14 @@ import {
   "Milky2018/wasmoon/types",
   "Milky2018/wasmoon/parser",
   "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
   "moonbitlang/core/string",
   "moonbitlang/core/strconv",
 }
 
 import {
   "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
   "moonbitlang/core/string",
   "moonbitlang/core/strconv",
 } for "wbtest"

--- a/wat/parser_impl/parser_numbers.mbt
+++ b/wat/parser_impl/parser_numbers.mbt
@@ -238,7 +238,7 @@ fn parse_float32(s : String) -> Float raise WatError {
   if s.has_prefix("nan:0x") || s.has_prefix("+nan:0x") {
     // Parse payload from nan:0x...
     let payload_start = if s.has_prefix("+") { 7 } else { 6 }
-    let payload_str = s[payload_start:].to_string()
+    let payload_str = s[payload_start:].to_owned()
     let payload = parse_hex_int(payload_str)
     // Positive NaN: 0x7f800000 | payload
     let bits = 0x7f800000 | (payload & 0x7fffff)
@@ -246,7 +246,7 @@ fn parse_float32(s : String) -> Float raise WatError {
   }
   if s.has_prefix("-nan:0x") {
     // Parse payload from -nan:0x...
-    let payload_str = s[7:].to_string()
+    let payload_str = s[7:].to_owned()
     let payload = parse_hex_int(payload_str)
     // Negative NaN: 0xff800000 | payload = -8388608 | payload
     let bits = -8388608 | (payload & 0x7fffff)
@@ -1159,7 +1159,7 @@ fn parse_float64(s : String) -> Double raise WatError {
   if s.has_prefix("nan:0x") || s.has_prefix("+nan:0x") {
     // Parse payload from nan:0x...
     let payload_start = if s.has_prefix("+") { 7 } else { 6 }
-    let payload_str = s[payload_start:].to_string()
+    let payload_str = s[payload_start:].to_owned()
     let payload = parse_hex_int64(payload_str)
     // Positive NaN: 0x7ff0000000000000 | payload
     let bits = 0x7ff0000000000000L | (payload & 0xfffffffffffffL)
@@ -1167,7 +1167,7 @@ fn parse_float64(s : String) -> Double raise WatError {
   }
   if s.has_prefix("-nan:0x") {
     // Parse payload from -nan:0x...
-    let payload_str = s[7:].to_string()
+    let payload_str = s[7:].to_owned()
     let payload = parse_hex_int64(payload_str)
     // Negative NaN: 0xfff0000000000000 | payload
     let bits = 0xfff0000000000000L | (payload & 0xfffffffffffffL)

--- a/wat/parser_impl/parser_wbtest.mbt
+++ b/wat/parser_impl/parser_wbtest.mbt
@@ -936,7 +936,7 @@ test "parse WAST inline module: start function" {
     fail("Expected Module command")
   }
   inspect(mod_.funcs.length(), content="1")
-  inspect(mod_.start, content="Some(0)")
+  inspect(@debug.to_string(mod_.start), content="Some(0)")
 }
 
 ///|

--- a/wat/wat_test.mbt
+++ b/wat/wat_test.mbt
@@ -82,7 +82,7 @@ test "parse memory with max" {
     #|  (memory 1 16)
     #|)
   let mod_ = parse(wat)
-  inspect(mod_.memories[0].limits.max, content="Some(16)")
+  inspect(@debug.to_string(mod_.memories[0].limits.max), content="Some(16)")
 }
 
 ///|
@@ -913,7 +913,7 @@ test "parse memory64 with max" {
     #|)
   let mod_ = parse(wat)
   inspect(mod_.memories[0].limits.min, content="1")
-  inspect(mod_.memories[0].limits.max, content="Some(16)")
+  inspect(@debug.to_string(mod_.memories[0].limits.max), content="Some(16)")
   inspect(mod_.memories[0].is_memory64, content="true")
 }
 
@@ -953,7 +953,7 @@ test "parse memory64 import" {
   if mod_.imports[0].desc is @types.ImportDesc::Memory(mem_type) {
     inspect(mem_type.is_memory64, content="true")
     inspect(mem_type.limits.min, content="1")
-    inspect(mem_type.limits.max, content="Some(2)")
+    inspect(@debug.to_string(mem_type.limits.max), content="Some(2)")
   } else {
     panic()
   }
@@ -999,7 +999,7 @@ test "parse table64 with max" {
     #|)
   let mod_ = parse(wat)
   inspect(mod_.tables[0].type_.limits.min, content="1")
-  inspect(mod_.tables[0].type_.limits.max, content="Some(10)")
+  inspect(@debug.to_string(mod_.tables[0].type_.limits.max), content="Some(10)")
   inspect(mod_.tables[0].type_.is_table64, content="true")
 }
 
@@ -1039,7 +1039,7 @@ test "parse table64 import" {
   if mod_.imports[0].desc is @types.ImportDesc::Table(tbl_type) {
     inspect(tbl_type.is_table64, content="true")
     inspect(tbl_type.limits.min, content="1")
-    inspect(tbl_type.limits.max, content="Some(10)")
+    inspect(@debug.to_string(tbl_type.limits.max), content="Some(10)")
   } else {
     panic()
   }
@@ -1113,7 +1113,7 @@ test "parse table64 with large 64-bit limits" {
   inspect(mod_.tables[0].type_.is_table64, content="true")
   // 0xffffffffffff = 281474976710655
   inspect(mod_.tables[0].type_.limits.min, content="281474976710655")
-  inspect(mod_.tables[0].type_.limits.max, content="None")
+  inspect(@debug.to_string(mod_.tables[0].type_.limits.max), content="None")
 }
 
 ///|
@@ -1128,7 +1128,10 @@ test "parse table64 with large 64-bit min and max" {
   // 0x100000000 = 4294967296 (larger than u32 max)
   inspect(mod_.tables[0].type_.limits.min, content="4294967296")
   // 0x200000000 = 8589934592
-  inspect(mod_.tables[0].type_.limits.max, content="Some(8589934592)")
+  inspect(
+    @debug.to_string(mod_.tables[0].type_.limits.max),
+    content="Some(8589934592)",
+  )
 }
 
 ///|
@@ -1146,5 +1149,8 @@ test "parse table64 import with large 64-bit limits" {
   // 0xffffffffffff = 281474976710655
   inspect(tbl_type.limits.min, content="281474976710655")
   // 0x1000000000000 = 281474976710656
-  inspect(tbl_type.limits.max, content="Some(281474976710656)")
+  inspect(
+    @debug.to_string(tbl_type.limits.max),
+    content="Some(281474976710656)",
+  )
 }


### PR DESCRIPTION
## Summary
- replace deprecated StringView.to_string calls with to_owned
- migrate warning-producing inspect/assert debug output to Debug-based formatting
- update generated interfaces after Debug derives

## Tests
- moon check --target native
- moon test --target native
- moon check
- moon test