### PR TITLE
Add cooperative runtime cancellation safepoints

### DIFF
--- a/docs/native_call_export_api.md
+++ b/docs/native_call_export_api.md
@@ -40,8 +40,25 @@ This separates WebAssembly runtime traps (`Trap`) from host callback failures (`
 
 Current support level:
 
-- `cancel` is checked before invocation.
+- `cancel` is checked before invocation and cooperatively at every Wasm function entry and loop header.
+- Cancellation is invocation-local. The callback runs synchronously on the execution thread.
+- A synchronous blocking host function is not interrupted while it runs; embedders must bound blocking host work separately.
 - `timeout_ms`, `fuel`, and `budget` are accepted but currently return `UnsupportedOption`, so embedders can do explicit capability probing.
+
+## JIT cancellation
+
+JIT cancellation is opt-in at compilation time. Compile with `compile_module(..., enable_cancellation=true)` (or the lower-level `compile_module_to_jit` equivalent) and invoke the resulting module with `JITModule::call_with_context_controlled(..., cancel=...)`.
+
+The controlled JIT call returns `JITCallResult`:
+
+- `Completed(Array[Int64])`
+- `Cancelled`
+- `Failed(JITTrap)`
+- `UnsupportedCancellation`
+
+The `.cwasm` artifact records whether cancellation safepoints were emitted. Passing a cancellation callback to an uninstrumented artifact returns `UnsupportedCancellation` before machine code starts. The legacy `call_with_context(...)` API remains unchanged.
+
+A `JITModule` supports one active invocation at a time. Do not call the same module concurrently or re-enter it from its cancellation callback; the callback is stored in that module's execution context for the duration of the call.
 
 ## Backward compatibility
 

--- a/issues/ISS-170.md
+++ b/issues/ISS-170.md
@@ -1,0 +1,43 @@
+# ISS-170: Add cooperative cancellation safepoints to Wasm execution
+
+## Metadata
+- Type: feature
+- Status: closed
+- Priority: 1
+- Labels: runtime, executor, jit, cwasm, safety, tests, agent
+- Assignee: Codex
+- Created: 2026-07-14
+- Updated: 2026-07-14
+- External ref: none
+
+## Description
+The controlled export API can classify cancellation before invocation, but neither the interpreter nor generated native code observes cancellation while guest code is running. A non-terminating guest therefore cannot be cancelled after entry. Add cooperative safepoint checks with a structured `Cancelled` result across interpreter and JIT execution.
+
+## Design
+Use the existing invocation-local cancellation callback as the public control surface. Check it before execution and at shared semantic safepoints: function entry and loop backedges. Native code must call a generic runtime cancellation helper through symbolic relocation rather than importing product-specific state into reusable compiler packages. Record cancellation instrumentation in `.cwasm` compatibility metadata and reject mismatched artifacts before execution. Cancellation applies only while Wasm code is running; synchronous blocking host calls remain outside the guarantee.
+
+## Acceptance Criteria
+- [x] Interpreter execution observes cancellation at function entry and loop backedges and returns `CallExportFailureKind::Cancelled`.
+- [x] AArch64 and AMD64 JIT execution observe the same cancellation safepoints and return the same structured classification.
+- [x] Cancellation instrumentation has an explicit `.cwasm` compatibility marker and incompatible artifacts are rejected structurally.
+- [x] Existing legacy invocation APIs retain their current behavior.
+- [x] Documentation states the safepoint and blocking-host-call boundaries.
+- [x] Targeted tests, `moon check --target native --warn-list +73`, `moon test --target native --warn-list +73`, `moon info`, and `moon fmt` pass, except for a documented unrelated nightly/toolchain failure if encountered.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: none
+- Discovered from: none
+
+## Notes
+- 2026-07-14: Started implementation after comparing Wasmtime's epoch/deadline design. Wasmoon keeps invocation-local structured cancellation while adopting function-entry and loop-backedge safepoints and explicit precompiled-artifact compatibility.
+
+## Close Notes
+
+- Added invocation-local interpreter polling before execution, at Wasm function entry, and at loop headers, preserving the existing structured `Cancelled` category.
+- Added opt-in JIT instrumentation, a runtime cancellation callback/helper, `JITCallResult`, and pre-entry rejection for uninstrumented artifacts.
+- Bumped CWASM to v8 with explicit compilation feature bits; roundtrip, old-version rejection, and unknown-bit rejection are covered.
+- Verified native arm64 cancellation execution and cancellation-helper relocations through both AMD64 and AArch64 code generation.
+- Passed `moon fmt`, `moon info`, `moon check --target native --warn-list +73 --diagnostic-limit=200`, targeted cancellation/CWASM/runtime-symbol tests, `python3 scripts/audit_module_boundaries.py`, and `git diff --check`.
+- Full `moon test --target native --warn-list +73 --diagnostic-limit=300` completed 1858/1864. The six failures are pre-existing nightly GC JIT failures (`gc precise roots unavailable`); cancellation instrumentation is disabled in those calls and no GC test/source changed. An isolated GC JIT rerun completed 17/18, with the remaining known native JIT SIGSEGV fluctuation.

--- a/issues/README.md
+++ b/issues/README.md
@@ -181,6 +181,7 @@ graph TD
   ISS_165["ISS-165: Remove the legacy VectorOp matrix and validate SIMD parity"]
   ISS_166["ISS-166: Eliminate MoonBit warning 73 annotations"]
   ISS_167["ISS-167: Add comprehensive MilkIR black-box contract tests"]
+  ISS_170["ISS-170: Add cooperative cancellation safepoints to Wasm execution"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005

--- a/modules/wasmoon/cmd/wasmoon/commands/pkg.generated.mbti
+++ b/modules/wasmoon/cmd/wasmoon/commands/pkg.generated.mbti
@@ -10,9 +10,9 @@ import {
 }
 
 // Values
-pub fn compile_module(Bytes, opt_level? : Int, enable_dwarf? : Bool, on_progress? : (CompileProgress) -> Unit?) -> @cwasm.PrecompiledModule?
+pub fn compile_module(Bytes, opt_level? : Int, enable_dwarf? : Bool, on_progress? : (CompileProgress) -> Unit?, enable_cancellation? : Bool) -> @cwasm.PrecompiledModule?
 
-pub fn compile_module_to_jit(@types.Module, Bool, Bool, actual_memory_max? : Int?, Int, Bool, on_progress? : (CompileProgress) -> Unit?, compile_start? : @perf.Instant?, local_compile_mask? : Array[Bool]?, force_subtype_indirect_check? : Bool?, use_reusable_pipeline? : Bool) -> (@cwasm.PrecompiledModule, @wasmoon_jit.JITDebugDB?)?
+pub fn compile_module_to_jit(@types.Module, Bool, Bool, actual_memory_max? : Int?, Int, Bool, on_progress? : (CompileProgress) -> Unit?, compile_start? : @perf.Instant?, local_compile_mask? : Array[Bool]?, force_subtype_indirect_check? : Bool?, use_reusable_pipeline? : Bool, enable_cancellation? : Bool) -> (@cwasm.PrecompiledModule, @wasmoon_jit.JITDebugDB?)?
 
 pub fn func_to_wat(String, @types.FuncType, Array[@types.ValueType], Array[@types.Instruction]) -> String
 

--- a/modules/wasmoon/cmd/wasmoon/commands/run.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/run.mbt
@@ -1282,6 +1282,12 @@ fn run_with_jit(
                   // NOTE: Memory and globals are now freed by JITContext finalizer (GC-managed)
                   return exit_failure()
                 }
+                JITCancelled => {
+                  @wasmoon_jit.gc_teardown(jm.get_context_ptr())
+                  @wast.sync_jit_globals_to_store(jit_ctx, store)
+                  @logger.error("JIT invocation cancelled")
+                  return exit_failure()
+                }
               }
               // Tear down GC context after JIT call
               @wasmoon_jit.gc_teardown(jm.get_context_ptr())
@@ -1342,6 +1348,7 @@ pub fn compile_module(
   opt_level? : Int = 2,
   enable_dwarf? : Bool = false,
   on_progress? : (CompileProgress) -> Unit? = fn(_event) { None },
+  enable_cancellation? : Bool = false,
 ) -> @cwasm.PrecompiledModule? {
   let compile_start = @perf.tick_now()
   emit_compile_progress(on_progress, Parse, compile_start, 0, 0)
@@ -1392,6 +1399,7 @@ pub fn compile_module(
     enable_dwarf,
     on_progress~,
     compile_start=Some(compile_start),
+    enable_cancellation~,
   )
   match compiled {
     Some((precompiled, _debug_db)) => Some(precompiled)
@@ -1488,6 +1496,7 @@ pub fn compile_module_to_jit(
   local_compile_mask? : Array[Bool]? = None,
   force_subtype_indirect_check? : Bool? = None,
   use_reusable_pipeline? : Bool = true,
+  enable_cancellation? : Bool = false,
 ) -> (@cwasm.PrecompiledModule, @wasmoon_jit.JITDebugDB?)? {
   use_reusable_pipeline |> ignore
   let progress_start = compile_start.unwrap_or(@perf.tick_now())
@@ -1495,7 +1504,10 @@ pub fn compile_module_to_jit(
   let module_tick = if perf_on { Some(@perf.tick_now()) } else { None }
   let target_arch = @wasmoon_jit.host_target_arch()
   let isa = @wasmoon_jit.target_arch_to_isa(target_arch)
-  let precompiled = @cwasm.PrecompiledModule::PrecompiledModule(target_arch)
+  let precompiled = @cwasm.PrecompiledModule::PrecompiledModule(
+    target_arch,
+    features=CompilationFeatures(cancellation_safepoints=enable_cancellation),
+  )
   let debug_db : @wasmoon_jit.JITDebugDB? = if dump_on_trap {
     Some(JITDebugDB())
   } else {
@@ -1558,7 +1570,9 @@ pub fn compile_module_to_jit(
   }
   let translation_ctx = @wasm_frontend.translation_context_from_module(
     mod_,
-    @wasmoon.wasm_frontend_embedding_environment(),
+    @wasmoon.wasm_frontend_embedding_environment(
+      cancellation_safepoints=enable_cancellation,
+    ),
     memory_max_override=actual_memory_max,
   )
   // Record imports in precompiled module

--- a/modules/wasmoon/cmd/wasmoon/commands/run_wbtest.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/run_wbtest.mbt
@@ -54,6 +54,18 @@ test "compile api: emits stage progress and returns artifact" {
 }
 
 ///|
+test "compile api: records cancellation safepoints" {
+  guard compile_module(
+      minimal_i32_const_module_bytes(),
+      enable_cancellation=true,
+    )
+    is Some(compiled) else {
+    fail("compile returned unsupported")
+  }
+  debug_inspect(compiled.features, content="{ cancellation_safepoints: true }")
+}
+
+///|
 test "compile api: parse failure emits failed stage" {
   let events : Array[CompileProgress] = []
   let compiled = compile_module(Bytes::from_array([0x00, 0x01, 0x02]), on_progress=fn(

--- a/modules/wasmoon/executor/call_export_control_wbtest.mbt
+++ b/modules/wasmoon/executor/call_export_control_wbtest.mbt
@@ -120,6 +120,57 @@ test "call_exported_func_with_options: cancel before invocation" {
 }
 
 ///|
+test "call_exported_func_with_options: cancel at loop safepoint" {
+  let mod : @types.Module = {
+    ..@types.Module::empty(),
+    types: [@types.SubType::func([], [I32])],
+    type_rec_groups: [0],
+    funcs: [0],
+    codes: [
+      {
+        locals: [I32],
+        body: [
+          I32Const(0),
+          LocalSet(0),
+          Loop(Empty, [
+            LocalGet(0),
+            I32Const(1),
+            I32Add,
+            LocalTee(0),
+            I32Const(5),
+            I32LtS,
+            BrIf(0),
+          ]),
+          LocalGet(0),
+        ],
+      },
+    ],
+    exports: [{ name: "main", desc: Func(0) }],
+  }
+  let (store, instance) = instantiate_module(mod)
+  let polls = [0]
+  let options = CallExportOptions::CallExportOptions(
+    cancel=Some(fn() {
+      polls[0] = polls[0] + 1
+      polls[0] >= 4
+    }),
+  )
+  debug_inspect(
+    call_exported_func_with_options(store, instance, "main", [], options~),
+    content=(
+      #|Err(
+      #|  {
+      #|    kind: Cancelled,
+      #|    message: "invocation cancelled at wasm safepoint",
+      #|    runtime_error: None,
+      #|  },
+      #|)
+    ),
+  )
+  debug_inspect(polls, content="[4]")
+}
+
+///|
 test "call_exported_func_with_options: unsupported budget options are structured" {
   let mod = @types.Module::simple([], [I32], [I32Const(1)], "main")
   let (store, instance) = instantiate_module(mod)

--- a/modules/wasmoon/executor/context.mbt
+++ b/modules/wasmoon/executor/context.mbt
@@ -75,6 +75,16 @@ priv struct LabelInfo {
 } derive(Debug)
 
 ///|
+priv struct CancellationPoller {
+  callback : () -> Bool
+}
+
+///|
+impl Debug for CancellationPoller with fn to_repr(_self) {
+  Repr::literal("<callback>")
+}
+
+///|
 /// Execution context for running WASM code
 struct ExecContext {
   stack : @runtime.Stack
@@ -86,12 +96,14 @@ struct ExecContext {
   gc_stress : Bool
   gc_stress_every : Int
   mut gc_stress_alloc_count : Int
+  cancel : CancellationPoller?
 } derive(Debug)
 
 ///|
 fn ExecContext::ExecContext(
   store : @runtime.Store,
   instance : @runtime.ModuleInstance,
+  cancel? : (() -> Bool)? = None,
 ) -> ExecContext {
   {
     stack: Stack(),
@@ -103,6 +115,15 @@ fn ExecContext::ExecContext(
     gc_stress: gc_stress_enabled(),
     gc_stress_every: gc_stress_every(),
     gc_stress_alloc_count: 0,
+    cancel: cancel.map(fn(callback) { { callback, } }),
+  }
+}
+
+///|
+/// Poll the invocation-local cancellation callback at a Wasm safepoint.
+fn ExecContext::check_cancellation(self : ExecContext) -> Unit raise {
+  if self.cancel is Some(poller) && (poller.callback)() {
+    raise InvocationSignal::Cancelled
   }
 }
 

--- a/modules/wasmoon/executor/error.mbt
+++ b/modules/wasmoon/executor/error.mbt
@@ -18,4 +18,5 @@ priv enum ExecBlockResult {
 /// Internal signal used to preserve host-call error provenance.
 priv suberror InvocationSignal {
   HostInvocation(Error)
+  Cancelled
 } derive(Debug)

--- a/modules/wasmoon/executor/instantiate.mbt
+++ b/modules/wasmoon/executor/instantiate.mbt
@@ -1741,7 +1741,7 @@ pub(all) enum CallExportFailureKind {
   HostInvocation
   Cancelled
   UnsupportedOption
-}
+} derive(Debug)
 
 ///|
 /// Structured failure for controlled export invocation.
@@ -1752,17 +1752,31 @@ pub struct CallExportFailure {
 }
 
 ///|
+pub impl Debug for CallExportFailure with fn to_repr(self) {
+  Repr::record({
+    "kind": to_repr(self.kind),
+    "message": to_repr(self.message),
+    "runtime_error": match self.runtime_error {
+      Some(error) =>
+        Repr::ctor("Some", [(None, Repr::literal(error.to_string()))])
+      None => Repr::ctor("None", [])
+    },
+  })
+}
+
+///|
 /// Result type for controlled export invocation.
 pub(all) enum CallExportResult {
   Ok(Array[@types.Value])
   Err(CallExportFailure)
-}
+} derive(Debug)
 
 ///|
 /// Options for controlled export invocation.
 ///
 /// Current engine support:
-/// - `cancel` is checked before invocation.
+/// - `cancel` is checked before invocation and at Wasm function and loop
+///   safepoints. A blocking host function is not interrupted while it runs.
 /// - `timeout_ms`, `fuel`, and `budget` are parsed and surfaced as structured
 ///   `UnsupportedOption` errors for integration-time capability probing.
 pub struct CallExportOptions {
@@ -1842,7 +1856,11 @@ pub fn call_exported_func_with_options(
     Some(exp) =>
       match exp.desc {
         Func(func_idx) => {
-          let ctx = ExecContext::ExecContext(store, instance)
+          let ctx = ExecContext::ExecContext(
+            store,
+            instance,
+            cancel=options.cancel,
+          )
           let results = ctx.call_func(func_idx, args) catch {
             BranchWith(_, _) | Return =>
               return Err(
@@ -1862,6 +1880,13 @@ pub fn call_exported_func_with_options(
                 ),
               )
             }
+            InvocationSignal::Cancelled =>
+              return Err(
+                call_export_failure(
+                  Cancelled,
+                  "invocation cancelled at wasm safepoint",
+                ),
+              )
             e => {
               let runtime_err = normalize_runtime_error(e)
               return Err(

--- a/modules/wasmoon/executor/instr_call.mbt
+++ b/modules/wasmoon/executor/instr_call.mbt
@@ -244,6 +244,7 @@ fn ExecContext::call_wasm_func_with_instance(
   let mut current_args = args
   let mut should_continue = true
   while should_continue {
+    self.check_cancellation()
     // Set the context to the target function's module
     self.instance = current_instance
 

--- a/modules/wasmoon/executor/instr_control.mbt
+++ b/modules/wasmoon/executor/instr_control.mbt
@@ -84,6 +84,7 @@ fn ExecContext::exec_control(
       }
       self.push_label(true, param_arity) // Loop branches use param arity
       while true {
+        self.check_cancellation()
         let result = try self.exec_block(body) catch {
           e => ExecBlockRaised(e)
         } noraise {

--- a/modules/wasmoon/executor/pkg.generated.mbti
+++ b/modules/wasmoon/executor/pkg.generated.mbti
@@ -40,6 +40,7 @@ pub struct CallExportFailure {
   message : String
   runtime_error : @runtime.RuntimeError?
 }
+pub impl @debug.Debug for CallExportFailure
 
 pub(all) enum CallExportFailureKind {
   ExportNotFound
@@ -48,7 +49,7 @@ pub(all) enum CallExportFailureKind {
   HostInvocation
   Cancelled
   UnsupportedOption
-}
+} derive(@debug.Debug)
 
 pub struct CallExportOptions {
   timeout_ms : Int?
@@ -61,7 +62,7 @@ pub fn CallExportOptions::CallExportOptions(timeout_ms? : Int?, fuel? : Int?, bu
 pub(all) enum CallExportResult {
   Ok(Array[@types.Value])
   Err(CallExportFailure)
-}
+} derive(@debug.Debug)
 
 type ExecContext derive(@debug.Debug)
 pub fn ExecContext::call_func(Self, Int, Array[@types.Value]) -> Array[@types.Value] raise

--- a/modules/wasmoon/jit/ffi_jit.mbt
+++ b/modules/wasmoon/jit/ffi_jit.mbt
@@ -9,6 +9,7 @@
 pub suberror JITTrap {
   JITTrap(String)
   JITExit(Int)
+  JITCancelled
 } derive(Debug)
 
 ///|
@@ -230,6 +231,19 @@ fn JITContext::clear_hostcall_callback(self : JITContext) -> Unit {
 }
 
 ///|
+fn JITContext::set_cancellation_callback(
+  self : JITContext,
+  callback : () -> Bool,
+) -> Unit {
+  self.ctx.set_cancellation_callback(callback)
+}
+
+///|
+fn JITContext::clear_cancellation_callback(self : JITContext) -> Unit {
+  self.ctx.clear_cancellation_callback()
+}
+
+///|
 /// Clear WASI stdin callback
 fn JITContext::clear_wasi_stdin_callback(self : JITContext) -> Unit {
   @wasmoon_jit.clear_wasi_stdin_callback(self.ptr())
@@ -334,6 +348,9 @@ fn JITContext::call_multi_return(
   if trap_code != 0 {
     if @wasmoon_jit.is_wasi_exit_trap_code(trap_code) {
       raise JITExit(@wasmoon_jit.take_wasi_exit_code(self.ptr()))
+    }
+    if @wasmoon_jit.is_cancelled_trap_code(trap_code) {
+      raise JITCancelled
     }
     raise JITTrap(@wasmoon_jit.jit_trap_message(trap_code))
   }

--- a/modules/wasmoon/jit/jit_runtime.mbt
+++ b/modules/wasmoon/jit/jit_runtime.mbt
@@ -78,6 +78,7 @@ struct JITModule {
   direct_call_targets : Map[Int, Int64]
   mut wasi_stdout_callback : ((Bytes) -> Unit)?
   mut wasi_stderr_callback : ((Bytes) -> Unit)?
+  mut cancellation_safepoints : Bool
 }
 
 ///|
@@ -94,6 +95,7 @@ pub fn JITModule::JITModule() -> JITModule {
     direct_call_targets: Map([]),
     wasi_stdout_callback: None,
     wasi_stderr_callback: None,
+    cancellation_safepoints: false,
   }
 }
 
@@ -210,6 +212,7 @@ pub fn JITModule::load_with_imports(
   debug_db? : @wasmoon_jit.JITDebugDB? = None,
 ) -> JITModule raise JITModuleLoadError {
   let jit_module = JITModule::JITModule()
+  jit_module.cancellation_safepoints = precompiled.features.cancellation_safepoints
   let total_funcs = @wasmoon_jit.required_context_function_count(
     precompiled,
     func_signatures.length(),
@@ -648,11 +651,54 @@ pub fn JITModule::call_with_context(
           raise JITTrap(@wasmoon_jit.format_trap_report_message(report))
         }
         Some(JITExit(code)) => raise JITExit(code)
+        Some(JITCancelled) => raise JITCancelled
         None => ()
       }
       results
     }
     None => [] // No context, cannot call
+  }
+}
+
+///|
+/// Structured result for a cooperative JIT invocation.
+pub(all) enum JITCallResult {
+  Completed(Array[Int64])
+  Cancelled
+  Failed(JITTrap)
+  UnsupportedCancellation
+} derive(Debug)
+
+///|
+/// Invoke JIT code with an invocation-local cooperative cancellation callback.
+/// Instrumented code polls at Wasm function entries and loop headers. Blocking
+/// host functions are not interrupted while they run.
+pub fn JITModule::call_with_context_controlled(
+  self : JITModule,
+  func : JITFunction,
+  args : Array[Int64],
+  cancel? : (() -> Bool)? = None,
+) -> JITCallResult {
+  if cancel is Some(_) && !self.cancellation_safepoints {
+    return UnsupportedCancellation
+  }
+  match self.context {
+    None => Completed([])
+    Some(ctx) => {
+      if cancel is Some(callback) {
+        ctx.set_cancellation_callback(callback)
+      }
+      let result = try self.call_with_context(func, args) catch {
+        JITCancelled => Cancelled
+        error => Failed(error)
+      } noraise {
+        values => Completed(values)
+      }
+      if cancel is Some(_) {
+        ctx.clear_cancellation_callback()
+      }
+      result
+    }
   }
 }
 

--- a/modules/wasmoon/jit/pkg.generated.mbti
+++ b/modules/wasmoon/jit/pkg.generated.mbti
@@ -25,6 +25,7 @@ pub impl Show for JITModuleLoadError
 pub suberror JITTrap {
   JITTrap(String)
   JITExit(Int)
+  JITCancelled
 } derive(@debug.Debug)
 pub impl Show for JITTrap
 
@@ -36,6 +37,13 @@ pub suberror PolycallError {
 
 // Types and methods
 type AddressRange derive(@debug.Debug)
+
+pub(all) enum JITCallResult {
+  Completed(Array[Int64])
+  Cancelled
+  Failed(JITTrap)
+  UnsupportedCancellation
+} derive(@debug.Debug)
 
 pub struct JITFunction {
   func_idx : Int
@@ -50,6 +58,7 @@ pub fn JITModule::JITModule() -> Self
 pub fn JITModule::alloc_guarded_memory(Self, Int, Int?) -> Int64
 pub fn JITModule::alloc_wasm_stack(Self, Int64) -> Bool
 pub fn JITModule::call_with_context(Self, JITFunction, Array[Int64]) -> Array[Int64] raise JITTrap
+pub fn JITModule::call_with_context_controlled(Self, JITFunction, Array[Int64], cancel? : (() -> Bool)?) -> JITCallResult
 pub fn[Arg : DynamicArgs, Ret : DynamicReturn] JITModule::call_with_context_poly(Self, JITFunction, Arg) -> Ret raise PolycallError
 pub fn JITModule::clear_hostcall_callback(Self) -> Unit
 pub fn JITModule::clear_segments(Self) -> Unit

--- a/modules/wasmoon/pkg.generated.mbti
+++ b/modules/wasmoon/pkg.generated.mbti
@@ -20,7 +20,7 @@ pub fn plan_wasm_function_with_compiler_infra(@embedding.EmbeddingEnvironment, @
 
 pub fn runtime_assembly() -> RuntimeAssembly
 
-pub fn wasm_frontend_embedding_environment(runtime_symbol_prefix? : String, hidden_context_type? : @milkir.Type?) -> @embedding.EmbeddingEnvironment
+pub fn wasm_frontend_embedding_environment(runtime_symbol_prefix? : String, hidden_context_type? : @milkir.Type?, cancellation_safepoints? : Bool) -> @embedding.EmbeddingEnvironment
 
 // Errors
 pub suberror WasmCompilerPipelineError {

--- a/modules/wasmoon/runtime_assembly.mbt
+++ b/modules/wasmoon/runtime_assembly.mbt
@@ -40,6 +40,7 @@ pub impl Show for WasmCompilerPipelineError with fn output(self, logger) {
 pub fn wasm_frontend_embedding_environment(
   runtime_symbol_prefix? : String = "wasmoon",
   hidden_context_type? : @milkir.Type? = Some(Ptr),
+  cancellation_safepoints? : Bool = false,
 ) -> @wasm_frontend.EmbeddingEnvironment {
   let vm = @wasmoon_jit.vmcontext_layout()
   let memory = @wasmoon_jit.memory_descriptor_layout()
@@ -66,6 +67,7 @@ pub fn wasm_frontend_embedding_environment(
       base_offset: memory.base_offset,
       current_length_offset: memory.current_length_offset,
     }),
+    cancellation_safepoints~,
   )
 }
 
@@ -75,6 +77,7 @@ fn wasm_body_embedding_env(
 ) -> @wasm_frontend.EmbeddingEnvironment {
   let defaults = wasm_frontend_embedding_environment(
     runtime_symbol_prefix=env.runtime_symbol_prefix,
+    cancellation_safepoints=env.cancellation_safepoints(),
   )
   EmbeddingEnvironment(
     runtime_symbol_prefix=env.runtime_symbol_prefix,
@@ -88,6 +91,7 @@ fn wasm_body_embedding_env(
       None => defaults.memory_descriptor_layout()
     },
     wasm_runtime_symbols=Some(env.wasm_runtime_symbols()),
+    cancellation_safepoints=env.cancellation_safepoints(),
   )
 }
 

--- a/modules/wasmoon/testsuite/cancellation_test.mbt
+++ b/modules/wasmoon/testsuite/cancellation_test.mbt
@@ -1,0 +1,72 @@
+///|
+test "JIT controlled call cancels at loop safepoint" {
+  let source =
+    #|(module
+    #|  (func (export "run") (result i32)
+    #|    (local $i i32)
+    #|    (loop $loop
+    #|      local.get $i
+    #|      i32.const 1
+    #|      i32.add
+    #|      local.tee $i
+    #|      i32.const 5
+    #|      i32.lt_s
+    #|      br_if $loop)
+    #|    local.get $i))
+  let mod_ = @wat.parse(source)
+  guard @commands.compile_module_to_jit(
+      mod_,
+      false,
+      false,
+      0,
+      false,
+      enable_cancellation=true,
+    )
+    is Some((precompiled, debug_db)) else {
+    fail("JIT compile returned unsupported")
+  }
+  let jm = @jit.JITModule::load(
+    precompiled,
+    @wast.build_func_signatures(mod_),
+    debug_db~,
+  )
+  guard jm.get_func_by_name("run") is Some(func) else {
+    fail("compiled function not found")
+  }
+  let polls = [0]
+  debug_inspect(
+    jm.call_with_context_controlled(
+      func,
+      [],
+      cancel=Some(fn() {
+        polls[0] = polls[0] + 1
+        polls[0] >= 3
+      }),
+    ),
+    content="Cancelled",
+  )
+  debug_inspect(polls, content="[3]")
+}
+
+///|
+test "JIT controlled call rejects an uninstrumented artifact" {
+  let source =
+    #|(module (func (export "run") (result i32) i32.const 42))
+  let mod_ = @wat.parse(source)
+  guard @commands.compile_module_to_jit(mod_, false, false, 0, false)
+    is Some((precompiled, debug_db)) else {
+    fail("JIT compile returned unsupported")
+  }
+  let jm = @jit.JITModule::load(
+    precompiled,
+    @wast.build_func_signatures(mod_),
+    debug_db~,
+  )
+  guard jm.get_func_by_name("run") is Some(func) else {
+    fail("compiled function not found")
+  }
+  debug_inspect(
+    jm.call_with_context_controlled(func, [], cancel=Some(fn() { false })),
+    content="UnsupportedCancellation",
+  )
+}

--- a/modules/wasmoon/wasm_frontend/embedding/pkg.generated.mbti
+++ b/modules/wasmoon/wasm_frontend/embedding/pkg.generated.mbti
@@ -18,8 +18,10 @@ pub(all) struct EmbeddingEnvironment {
   runtime_layout : RuntimeLayout?
   memory_descriptor_layout : MemoryDescriptorLayout?
   wasm_runtime_symbols : @wasm_milkir.RuntimeSymbols
+  cancellation_safepoints : Bool
 } derive(@debug.Debug)
-pub fn EmbeddingEnvironment::EmbeddingEnvironment(runtime_symbol_prefix? : String, hidden_context_type? : @milkir.Type?, runtime_layout? : RuntimeLayout?, memory_descriptor_layout? : MemoryDescriptorLayout?, wasm_runtime_symbols? : @wasm_milkir.RuntimeSymbols?) -> Self
+pub fn EmbeddingEnvironment::EmbeddingEnvironment(runtime_symbol_prefix? : String, hidden_context_type? : @milkir.Type?, runtime_layout? : RuntimeLayout?, memory_descriptor_layout? : MemoryDescriptorLayout?, wasm_runtime_symbols? : @wasm_milkir.RuntimeSymbols?, cancellation_safepoints? : Bool) -> Self
+pub fn EmbeddingEnvironment::cancellation_safepoints(Self) -> Bool
 pub fn EmbeddingEnvironment::hidden_context_param(Self) -> @milkir.Type?
 pub fn EmbeddingEnvironment::memory_descriptor_layout(Self) -> MemoryDescriptorLayout?
 pub fn EmbeddingEnvironment::runtime_layout(Self) -> RuntimeLayout?

--- a/modules/wasmoon/wasm_frontend/embedding/types.mbt
+++ b/modules/wasmoon/wasm_frontend/embedding/types.mbt
@@ -29,6 +29,7 @@ pub(all) struct EmbeddingEnvironment {
   runtime_layout : RuntimeLayout?
   memory_descriptor_layout : MemoryDescriptorLayout?
   wasm_runtime_symbols : @wasm_milkir.RuntimeSymbols
+  cancellation_safepoints : Bool
 } derive(Debug)
 
 ///|
@@ -38,6 +39,7 @@ pub fn EmbeddingEnvironment::EmbeddingEnvironment(
   runtime_layout? : RuntimeLayout? = None,
   memory_descriptor_layout? : MemoryDescriptorLayout? = None,
   wasm_runtime_symbols? : @wasm_milkir.RuntimeSymbols? = None,
+  cancellation_safepoints? : Bool = false,
 ) -> EmbeddingEnvironment {
   let wasm_runtime_symbols = wasm_runtime_symbols.unwrap_or(
     @wasm_milkir.RuntimeSymbols::with_runtime_prefix(
@@ -50,7 +52,15 @@ pub fn EmbeddingEnvironment::EmbeddingEnvironment(
     runtime_layout,
     memory_descriptor_layout,
     wasm_runtime_symbols,
+    cancellation_safepoints,
   }
+}
+
+///|
+pub fn EmbeddingEnvironment::cancellation_safepoints(
+  self : EmbeddingEnvironment,
+) -> Bool {
+  self.cancellation_safepoints
 }
 
 ///|

--- a/modules/wasmoon/wasm_frontend/ir/func_env.mbt
+++ b/modules/wasmoon/wasm_frontend/ir/func_env.mbt
@@ -16,6 +16,7 @@ priv struct FuncEnvironment {
   runtime_layout : @embedding.RuntimeLayout
   memory_descriptor_layout : @embedding.MemoryDescriptorLayout
   runtime_symbols : @wasm_milkir.RuntimeSymbols
+  cancellation_symbol : @milkir.ExternalSymbol?
   // Global variable types (for determining load/store width)
   global_types : Array[@types.GlobalType]
   // Minimum guaranteed memory size in bytes for each memory index
@@ -61,6 +62,11 @@ fn FuncEnvironment::FuncEnvironment(
     runtime_layout,
     memory_descriptor_layout,
     runtime_symbols: embedding_env.wasm_runtime_symbols(),
+    cancellation_symbol: if embedding_env.cancellation_safepoints() {
+      Some(embedding_env.runtime_symbol("runtime.cancel_poll"))
+    } else {
+      None
+    },
     global_types,
     memory_mins,
     memory_is_64,
@@ -68,6 +74,17 @@ fn FuncEnvironment::FuncEnvironment(
     memory_trap_block: None,
     atomic_unaligned_trap_block: None,
     bounds_check_cache: HashMap([]),
+  }
+}
+
+///|
+fn FuncEnvironment::emit_cancellation_safepoint(
+  self : FuncEnvironment,
+  builder : FunctionBuilder,
+  vmctx : Value,
+) -> Unit {
+  if self.cancellation_symbol is Some(symbol) {
+    builder.call_symbol(symbol, None, [vmctx]) |> ignore
   }
 }
 

--- a/modules/wasmoon/wasm_frontend/ir/translator_core.mbt
+++ b/modules/wasmoon/wasm_frontend/ir/translator_core.mbt
@@ -669,6 +669,7 @@ fn Translator::translate(
   self : Translator,
   instrs : Array[@types.Instruction],
 ) -> Function {
+  self.func_env.emit_cancellation_safepoint(self.builder, self.vmctx)
   // Initialize locals with default values in the default entry block.
   //
   // Cranelift alignment:
@@ -1417,6 +1418,7 @@ fn Translator::translate_loop(
 
   // Switch to loop header
   self.builder.switch_to_block(loop_header)
+  self.func_env.emit_cancellation_safepoint(self.builder, self.vmctx)
   if outer_is_unreachable {
     self.builder.trap("unreachable loop header")
   }

--- a/modules/wasmoon/wast/runner.mbt
+++ b/modules/wasmoon/wast/runner.mbt
@@ -887,6 +887,16 @@ pub fn invoke_action(
                   sync_jit_tables_to_store(jit, ctx.store)
                   raise RuntimeError(msg)
                 }
+                JITCancelled => {
+                  @wasmoon_jit.gc_teardown(jit.jit_module.get_context_ptr())
+                  if temp_gc_func_table_ptr != 0L {
+                    @wasmoon_jit.free_memory(temp_gc_func_table_ptr)
+                    temp_gc_func_table_ptr = 0L
+                  }
+                  sync_jit_globals_to_store(jit, ctx.store)
+                  sync_jit_tables_to_store(jit, ctx.store)
+                  raise RuntimeError("invocation cancelled")
+                }
               }
               // Tear down GC context after JIT call
               @wasmoon_jit.gc_teardown(jit.jit_module.get_context_ptr())

--- a/modules/wasmoon_jit/README.mbt.md
+++ b/modules/wasmoon_jit/README.mbt.md
@@ -11,6 +11,8 @@ bridge glue, and integration planning for loading generated code.
 - `Milky2018/wasmoon_jit`: runtime layout, JIT integration planning,
   trampolines, native glue, runtime symbols, and helper APIs.
 - `Milky2018/wasmoon_jit/cwasm`: serialized precompiled-code artifacts.
+
+The current CWASM format records machine-code compilation features, including whether cooperative cancellation safepoints were emitted. Readers accept only the current format version; this prevents callers from assuming cancellation support for older or otherwise incompatible artifacts.
 - `Milky2018/wasmoon_jit/perf`: optional JIT performance metrics.
 - `Milky2018/wasmoon_jit/jit_ffi`: native stubs used by the JIT runtime.
 

--- a/modules/wasmoon_jit/cwasm/cwasm.mbt
+++ b/modules/wasmoon_jit/cwasm/cwasm.mbt
@@ -43,7 +43,40 @@ const CWASM_MAGIC_3 : Int = 0x73 // 's'
 /// v5: Added type signatures, globals, tables, and element segments
 /// v6: Added direct-call fixups
 /// v7: Added per-function GC safepoint metadata and stackmap blob
-const CWASM_VERSION : Int = 7
+/// v8: Added compilation feature bits
+const CWASM_VERSION : Int = 8
+
+///|
+/// Compilation features that affect the generated machine-code contract.
+pub(all) struct CompilationFeatures {
+  cancellation_safepoints : Bool
+} derive(Debug, Eq)
+
+///|
+pub fn CompilationFeatures::CompilationFeatures(
+  cancellation_safepoints? : Bool = false,
+) -> CompilationFeatures {
+  { cancellation_safepoints, }
+}
+
+///|
+fn CompilationFeatures::to_bits(self : CompilationFeatures) -> Int {
+  if self.cancellation_safepoints {
+    1
+  } else {
+    0
+  }
+}
+
+///|
+fn compilation_features_from_bits(
+  bits : Int,
+) -> CompilationFeatures raise DeserializeError {
+  if (bits & 0xFFFF_FFFE) != 0 {
+    raise DeserializeError("Unsupported compilation feature bits: \{bits}")
+  }
+  CompilationFeatures(cancellation_safepoints=(bits & 1) != 0)
+}
 
 // ============ Target Architecture ============
 
@@ -430,6 +463,8 @@ pub(all) struct PrecompiledModule {
   version : Int
   // Target architecture
   target : TargetArch
+  // Machine-code features required by invocation APIs.
+  features : CompilationFeatures
   // Imported functions
   imports : Array[ImportEntry]
   // Compiled functions
@@ -453,10 +488,12 @@ pub(all) struct PrecompiledModule {
 ///|
 pub fn PrecompiledModule::PrecompiledModule(
   target : TargetArch,
+  features? : CompilationFeatures = CompilationFeatures(),
 ) -> PrecompiledModule {
   {
     version: CWASM_VERSION,
     target,
+    features,
     imports: [],
     functions: [],
     memories: [],
@@ -605,6 +642,9 @@ pub fn PrecompiledModule::serialize(self : PrecompiledModule) -> Array[Int] {
 
   // Write target architecture
   result.push(self.target.to_byte())
+
+  // Write compilation feature bits
+  write_u32(result, self.features.to_bits())
 
   // Write number of imports
   write_u32(result, self.imports.length())
@@ -887,6 +927,9 @@ pub fn deserialize(
   // Read target architecture
   let target = TargetArch::from_byte(reader.read_byte())
 
+  // Read compilation feature bits
+  let features = compilation_features_from_bits(reader.read_u32())
+
   // Read imports
   let imports : Array[ImportEntry] = []
   let import_count = reader.read_u32()
@@ -1066,6 +1109,7 @@ pub fn deserialize(
   {
     version: CWASM_VERSION,
     target,
+    features,
     imports,
     functions,
     memories,

--- a/modules/wasmoon_jit/cwasm/cwasm_test.mbt
+++ b/modules/wasmoon_jit/cwasm/cwasm_test.mbt
@@ -20,11 +20,21 @@ test "PrecompiledModule serialize and deserialize roundtrip" {
   inspect(serialized.length() > 0, content="true")
   // Deserialize
   let pcm2 = @cwasm.deserialize(serialized)
-  inspect(pcm2.version, content="7")
+  inspect(pcm2.version, content="8")
   inspect(pcm2.target, content="aarch64")
   inspect(pcm2.function_count(), content="1")
   inspect(pcm2.functions[0].num_params, content="2")
   inspect(pcm2.functions[0].num_results, content="1")
+}
+
+///|
+test "PrecompiledModule preserves cancellation safepoints feature" {
+  let pcm = @cwasm.PrecompiledModule::PrecompiledModule(
+    AArch64,
+    features=CompilationFeatures(cancellation_safepoints=true),
+  )
+  let restored = @cwasm.deserialize(pcm.serialize())
+  debug_inspect(restored.features, content="{ cancellation_safepoints: true }")
 }
 
 ///|

--- a/modules/wasmoon_jit/cwasm/cwasm_wbtest.mbt
+++ b/modules/wasmoon_jit/cwasm/cwasm_wbtest.mbt
@@ -35,9 +35,35 @@ test "compiled entry: creation" {
 ///|
 test "precompiled module: creation" {
   let mod = PrecompiledModule::PrecompiledModule(AArch64)
-  inspect(mod.version, content="7")
+  inspect(mod.version, content="8")
   inspect(mod.target.to_string(), content="aarch64")
   inspect(mod.function_count(), content="0")
+}
+
+///|
+test "precompiled module: reject incompatible cancellation metadata" {
+  let mod = PrecompiledModule::PrecompiledModule(AArch64)
+  let old_version = mod.serialize()
+  old_version[4] = 7
+  let old_version_error = try {
+    deserialize(old_version) |> ignore
+    "accepted"
+  } catch {
+    error => error.to_string()
+  }
+  inspect(old_version_error, content="Unsupported version: 7")
+  let unknown_features = mod.serialize()
+  unknown_features[9] = 2
+  let unknown_features_error = try {
+    deserialize(unknown_features) |> ignore
+    "accepted"
+  } catch {
+    error => error.to_string()
+  }
+  inspect(
+    unknown_features_error,
+    content="Unsupported compilation feature bits: 2",
+  )
 }
 
 ///|
@@ -117,7 +143,7 @@ test "serialize and deserialize: roundtrip" {
 
   // Deserialize
   let restored = deserialize(bytes) catch { _ => panic() }
-  inspect(restored.version, content="7")
+  inspect(restored.version, content="8")
   inspect(restored.target.to_string(), content="aarch64")
   inspect(restored.function_count(), content="1")
   inspect(restored.functions[0].func_idx, content="42")
@@ -340,7 +366,7 @@ test "complete module: memory + data + function roundtrip" {
   let restored = deserialize(bytes) catch { _ => panic() }
 
   // Check version
-  inspect(restored.version, content="7")
+  inspect(restored.version, content="8")
 
   // Check memory
   inspect(restored.memories.length(), content="1")

--- a/modules/wasmoon_jit/cwasm/pkg.generated.mbti
+++ b/modules/wasmoon_jit/cwasm/pkg.generated.mbti
@@ -24,6 +24,11 @@ pub(all) struct CallFixup {
   veneer_offset : Int
 }
 
+pub(all) struct CompilationFeatures {
+  cancellation_safepoints : Bool
+} derive(Eq, @debug.Debug)
+pub fn CompilationFeatures::CompilationFeatures(cancellation_safepoints? : Bool) -> Self
+
 pub(all) struct CompiledEntry {
   func_idx : Int
   name : String
@@ -96,6 +101,7 @@ pub impl Show for MemoryDef
 pub(all) struct PrecompiledModule {
   version : Int
   target : TargetArch
+  features : CompilationFeatures
   imports : Array[ImportEntry]
   functions : Array[CompiledEntry]
   memories : Array[MemoryDef]
@@ -106,7 +112,7 @@ pub(all) struct PrecompiledModule {
   elements : Array[ElemEntry]
   mut start_func : Int?
 }
-pub fn PrecompiledModule::PrecompiledModule(TargetArch) -> Self
+pub fn PrecompiledModule::PrecompiledModule(TargetArch, features? : CompilationFeatures) -> Self
 pub fn PrecompiledModule::add_data_segment(Self, Int, Int, Array[Int]) -> Unit
 pub fn PrecompiledModule::add_element(Self, Int, Int, Array[Int]) -> Unit
 pub fn PrecompiledModule::add_function(Self, CompiledEntry) -> Unit

--- a/modules/wasmoon_jit/jit_ffi/ffi.mbt
+++ b/modules/wasmoon_jit/jit_ffi/ffi.mbt
@@ -77,6 +77,23 @@ pub extern "c" fn c_jit_set_hostcall_callback(
 pub extern "c" fn c_jit_clear_hostcall_callback(ctx_ptr : Int64) -> Unit = "wasmoon_jit_clear_hostcall_callback"
 
 ///|
+/// Get the cooperative cancellation poll helper pointer.
+pub extern "c" fn c_jit_get_cancel_poll_ptr() -> Int64 = "wasmoon_jit_get_cancel_poll_ptr"
+
+///|
+/// Set an invocation-local cooperative cancellation callback.
+#owned(closure)
+pub extern "c" fn c_jit_set_cancellation_callback(
+  ctx_ptr : Int64,
+  call_closure : FuncRef[(() -> Bool) -> Int],
+  closure : () -> Bool,
+) -> Unit = "wasmoon_jit_set_cancellation_callback"
+
+///|
+/// Clear the cooperative cancellation callback.
+pub extern "c" fn c_jit_clear_cancellation_callback(ctx_ptr : Int64) -> Unit = "wasmoon_jit_clear_cancellation_callback"
+
+///|
 /// Current hostcall func_idx (thread-local).
 pub extern "c" fn c_jit_get_hostcall_func_idx() -> Int = "wasmoon_jit_get_hostcall_func_idx"
 

--- a/modules/wasmoon_jit/jit_ffi/jit.c
+++ b/modules/wasmoon_jit/jit_ffi/jit.c
@@ -156,6 +156,52 @@ MOONBIT_FFI_EXPORT int64_t wasmoon_jit_get_hostcall_ptr(void) {
     return (int64_t)wasmoon_jit_hostcall;
 }
 
+// ============ Cooperative Cancellation ============
+
+typedef int32_t (*cancellation_callback_fn)(void *closure);
+
+static void clear_cancellation_callback(jit_context_t *ctx) {
+    if (!ctx) return;
+    if (ctx->cancellation_callback_data) {
+        moonbit_decref(ctx->cancellation_callback_data);
+        ctx->cancellation_callback_data = NULL;
+    }
+    ctx->cancellation_callback = NULL;
+}
+
+MOONBIT_FFI_EXPORT void wasmoon_jit_set_cancellation_callback(
+    int64_t ctx_ptr,
+    cancellation_callback_fn callback,
+    void *closure
+) {
+    jit_context_t *ctx = (jit_context_t *)ctx_ptr;
+    if (!ctx) return;
+    clear_cancellation_callback(ctx);
+    ctx->cancellation_callback = (void *)callback;
+    if (closure) moonbit_incref(closure);
+    ctx->cancellation_callback_data = closure;
+}
+
+MOONBIT_FFI_EXPORT void wasmoon_jit_clear_cancellation_callback(int64_t ctx_ptr) {
+    clear_cancellation_callback((jit_context_t *)ctx_ptr);
+}
+
+MOONBIT_FFI_EXPORT int32_t wasmoon_jit_cancel_poll(jit_context_t *ctx) {
+    if (!ctx || !ctx->cancellation_callback) return 0;
+    cancellation_callback_fn cb =
+        (cancellation_callback_fn)ctx->cancellation_callback;
+    if (cb(ctx->cancellation_callback_data) != 0) {
+        g_trap_code = 11;
+        if (g_trap_active) siglongjmp(g_trap_jmp_buf, 1);
+        return 11;
+    }
+    return 0;
+}
+
+MOONBIT_FFI_EXPORT int64_t wasmoon_jit_get_cancel_poll_ptr(void) {
+    return (int64_t)wasmoon_jit_cancel_poll;
+}
+
 MOONBIT_FFI_EXPORT int32_t wasmoon_jit_get_hostcall_func_idx(void) {
     return g_hostcall_func_idx;
 }

--- a/modules/wasmoon_jit/jit_ffi/jit_context.c
+++ b/modules/wasmoon_jit/jit_ffi/jit_context.c
@@ -193,6 +193,8 @@ jit_context_t *alloc_context_internal(int func_count) {
     ctx->wasi_stdin_callback_data = NULL;
     ctx->hostcall_callback = NULL;
     ctx->hostcall_callback_data = NULL;
+    ctx->cancellation_callback = NULL;
+    ctx->cancellation_callback_data = NULL;
     ctx->wasi_stdout_capture = 0;
     ctx->wasi_stdout_buf = NULL;
     ctx->wasi_stdout_len = 0;
@@ -348,6 +350,13 @@ void free_context_internal(jit_context_t *ctx) {
         ctx->hostcall_callback_data = NULL;
     }
     ctx->hostcall_callback = NULL;
+
+    // Free cancellation callback closure (if registered).
+    if (ctx->cancellation_callback_data) {
+        moonbit_decref(ctx->cancellation_callback_data);
+        ctx->cancellation_callback_data = NULL;
+    }
+    ctx->cancellation_callback = NULL;
 
     // Free WASI resources (fds, args/env, stdio buffers)
     wasmoon_jit_free_wasi_fds((int64_t)ctx);

--- a/modules/wasmoon_jit/jit_ffi/jit_ffi.h
+++ b/modules/wasmoon_jit/jit_ffi/jit_ffi.h
@@ -186,6 +186,11 @@ typedef struct {
     void *hostcall_callback;          // Function pointer for hostcall callback
     void *hostcall_callback_data;     // Closure data for hostcall callback
 
+    // Invocation-local cooperative cancellation callback. Generated code only
+    // passes the context to a C helper; these fields stay outside the fixed ABI.
+    void *cancellation_callback;
+    void *cancellation_callback_data;
+
     // ============ Bulk Memory/Table Segment State ============
     // Per-instance (per jit_context_t) storage for bulk memory/table operations:
     //   memory.init/data.drop/table.init/elem.drop and GC array.*_{data,elem}.

--- a/modules/wasmoon_jit/jit_ffi/pkg.generated.mbti
+++ b/modules/wasmoon_jit/jit_ffi/pkg.generated.mbti
@@ -108,6 +108,8 @@ pub fn c_jit_call_with_stack_switch(Int64, Int64, Int64, FixedArray[Int64], Int)
 
 pub fn c_jit_call_with_stack_switch_managed(JITContext, Int64, Int64, FixedArray[Int64], Int) -> Int
 
+pub fn c_jit_clear_cancellation_callback(Int64) -> Unit
+
 pub fn c_jit_clear_hostcall_callback(Int64) -> Unit
 
 pub fn c_jit_clear_trap() -> Unit
@@ -213,6 +215,8 @@ pub fn c_jit_gc_use_func_safepoints(Int64, Int) -> Unit
 pub fn c_jit_get_args_get_ptr() -> Int64
 
 pub fn c_jit_get_args_sizes_get_ptr() -> Int64
+
+pub fn c_jit_get_cancel_poll_ptr() -> Int64
 
 pub fn c_jit_get_clock_res_get_ptr() -> Int64
 
@@ -477,6 +481,8 @@ pub fn c_jit_memory_init_bytes(Int64, Int64, Bytes, Int) -> Int
 pub fn c_jit_memory_read(Int64, Int64, FixedArray[Byte], Int) -> Int
 
 pub fn c_jit_read_i64(Int64) -> Int64
+
+pub fn c_jit_set_cancellation_callback(Int64, FuncRef[(() -> Bool) -> Int], () -> Bool) -> Unit
 
 pub fn c_jit_set_hostcall_callback(Int64, FuncRef[(() -> Int) -> Int], () -> Int) -> Unit
 

--- a/modules/wasmoon_jit/native_runtime.mbt
+++ b/modules/wasmoon_jit/native_runtime.mbt
@@ -127,8 +127,14 @@ pub fn jit_trap_message(code : Int) -> String {
     8 => "jit backend trap"
     9 => "out of memory"
     10 => "gc precise roots unavailable"
+    11 => "invocation cancelled"
     _ => "unknown trap"
   }
+}
+
+///|
+pub fn is_cancelled_trap_code(code : Int) -> Bool {
+  code == 11
 }
 
 ///|
@@ -581,6 +587,28 @@ pub fn NativeJITContext::clear_hostcall_callback(
   self : NativeJITContext,
 ) -> Unit {
   @jit_ffi.c_jit_clear_hostcall_callback(self.ptr())
+}
+
+///|
+pub fn NativeJITContext::set_cancellation_callback(
+  self : NativeJITContext,
+  callback : () -> Bool,
+) -> Unit {
+  let call_closure : FuncRef[(() -> Bool) -> Int] = fn(f : () -> Bool) {
+    if f() {
+      1
+    } else {
+      0
+    }
+  }
+  @jit_ffi.c_jit_set_cancellation_callback(self.ptr(), call_closure, callback)
+}
+
+///|
+pub fn NativeJITContext::clear_cancellation_callback(
+  self : NativeJITContext,
+) -> Unit {
+  @jit_ffi.c_jit_clear_cancellation_callback(self.ptr())
 }
 
 ///|

--- a/modules/wasmoon_jit/pkg.generated.mbti
+++ b/modules/wasmoon_jit/pkg.generated.mbti
@@ -328,6 +328,8 @@ pub fn init_wasi_context(Int64, Array[String], Array[String], Array[(String, Str
 
 pub fn install_direct_call_stubs_for_target(@cwasm.TargetArch) -> DirectCallStubSet raise DirectCallStubInstallError
 
+pub fn is_cancelled_trap_code(Int) -> Bool
+
 pub fn is_funcref_ptr(Int64) -> Bool
 
 pub fn is_i31(Int64) -> Bool
@@ -864,12 +866,14 @@ pub fn NativeJITContext::alloc_guarded_memory(Self, Int, Int?) -> Int64
 pub fn NativeJITContext::alloc_indirect_table(Self, Int) -> Bool
 pub fn NativeJITContext::alloc_wasm_stack(Self, Int64) -> Bool
 pub fn NativeJITContext::call_trampoline(Self, Int64, Int64, FixedArray[Int64], Int, Bool) -> Int
+pub fn NativeJITContext::clear_cancellation_callback(Self) -> Unit
 pub fn NativeJITContext::clear_hostcall_callback(Self) -> Unit
 pub fn NativeJITContext::func_table_ptr(Self) -> Int64
 pub fn NativeJITContext::has_wasm_stack(Self) -> Bool
 pub fn NativeJITContext::memory_ptr(Self, Int) -> Int64
 pub fn NativeJITContext::memory_size(Self, Int) -> Int64
 pub fn NativeJITContext::ptr(Self) -> Int64
+pub fn NativeJITContext::set_cancellation_callback(Self, () -> Bool) -> Unit
 pub fn NativeJITContext::set_func(Self, Int, Int64) -> Unit
 pub fn NativeJITContext::set_globals(Self, Int64) -> Unit
 pub fn NativeJITContext::set_hostcall_callback(Self, () -> Int) -> Unit

--- a/modules/wasmoon_jit/runtime_symbols.mbt
+++ b/modules/wasmoon_jit/runtime_symbols.mbt
@@ -232,6 +232,11 @@ pub fn RuntimeSymbolResolver::with_wasmoon_runtime_symbols() -> RuntimeSymbolRes
     jit_runtime_fixup_idx(13),
   )
   resolver.add_symbol_fixup(
+    "wasmoon.runtime.cancel_poll",
+    @jit_ffi.c_jit_get_cancel_poll_ptr(),
+    jit_runtime_fixup_idx(14),
+  )
+  resolver.add_symbol_fixup(
     "wasmoon.runtime.exception.try_begin",
     @jit_ffi.c_jit_get_exception_try_begin_ptr(),
     exception_runtime_fixup_idx(0),
@@ -412,6 +417,7 @@ pub fn resolve_runtime_func_fixup_idx(idx : Int) -> Int64? {
     -21011 => Some(@jit_ffi.c_jit_get_table_init_ptr())
     -21012 => Some(@jit_ffi.c_jit_get_elem_drop_ptr())
     -21013 => Some(@jit_ffi.c_jit_get_hostcall_ptr())
+    -21014 => Some(@jit_ffi.c_jit_get_cancel_poll_ptr())
     -22000 => Some(@jit_ffi.c_jit_get_exception_try_begin_ptr())
     -22001 => Some(@jit_ffi.c_jit_get_exception_try_end_ptr())
     -22002 => Some(@jit_ffi.c_jit_get_exception_throw_ptr())

--- a/modules/wasmoon_jit/wasmoon_jit_test.mbt
+++ b/modules/wasmoon_jit/wasmoon_jit_test.mbt
@@ -53,11 +53,42 @@ test "resolve wasm function symbols into cwasm call fixups" {
 test "resolve cwasm runtime helper fixup ids in wasmoon_jit" {
   inspect(gc_runtime_fixup_idx(0), content="-20000")
   inspect(jit_runtime_fixup_idx(13), content="-21013")
+  inspect(jit_runtime_fixup_idx(14), content="-21014")
   inspect(exception_runtime_fixup_idx(11), content="-22011")
   inspect(resolve_runtime_func_fixup_idx(-20000) is Some(_), content="true")
   inspect(resolve_runtime_func_fixup_idx(-21013) is Some(_), content="true")
+  inspect(resolve_runtime_func_fixup_idx(-21014) is Some(_), content="true")
   inspect(resolve_runtime_func_fixup_idx(-22011) is Some(_), content="true")
   inspect(resolve_runtime_func_fixup_idx(-1) is None, content="true")
+}
+
+///|
+test "emit cancellation poll relocations for both JIT targets" {
+  let builder = @milkir.FunctionBuilder::FunctionBuilder("cancel_poll")
+  let vmctx = builder.add_param(I64)
+  builder.call_symbol(ExternalSymbol("wasmoon.runtime.cancel_poll"), None, [
+    vmctx,
+  ])
+  |> ignore
+  builder.return_([])
+  for target in [@machv_emit.EmitTarget::X64, AArch64] {
+    let plan = plan_wasm_body_milkir_integration_for_target(
+      builder.get_function(),
+      target,
+    )
+    let fixup_ids : Array[Int] = []
+    for fixup in plan.object.get_func_addr_fixups() {
+      if machv_reloc_target_to_cwasm_func_idx(fixup.target) is Some(idx) {
+        fixup_ids.push(idx)
+      }
+    }
+    for fixup in plan.object.get_call_fixups() {
+      if machv_reloc_target_to_cwasm_func_idx(fixup.target) is Some(idx) {
+        fixup_ids.push(idx)
+      }
+    }
+    debug_inspect(fixup_ids, content="[-21014]")
+  }
 }
 
 ///|
@@ -109,6 +140,7 @@ test "default wasmoon runtime resolver maps segment and table fixups" {
     ("wasmoon.runtime.table_copy", -21010),
     ("wasmoon.runtime.table_init", -21011),
     ("wasmoon.runtime.elem_drop", -21012),
+    ("wasmoon.runtime.cancel_poll", -21014),
   ]
   for item in names {
     let (name, fixup_idx) = item


### PR DESCRIPTION
## Summary

- poll invocation-local cancellation at interpreter function and loop safepoints
- add opt-in JIT cancellation instrumentation with structured outcomes
- persist cancellation support in CWASM v8 feature metadata
- document blocking-host-call and single-active-invocation boundaries

## Validation

- moon fmt
- moon info
- moon check --target native --warn-list +73 --diagnostic-limit=200
- targeted interpreter, JIT, CWASM, public compile API, and dual-target relocation tests
- python3 scripts/audit_module_boundaries.py
- git diff --check

Full native suite: 1858/1864. The six failures are the known nightly GC JIT failures reporting gc precise roots unavailable; cancellation instrumentation is disabled in those calls and no GC test/source changed. An isolated GC JIT rerun completed 17/18, with the remaining known native JIT SIGSEGV fluctuation.

Closes ISS-170.