### PR TITLE
Release updated compiler modules

### DIFF
--- a/modules/aarch64_target/moon.mod
+++ b/modules/aarch64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/aarch64_target"
 
-version = "0.1.1"
+version = "0.1.2"
 
 readme = "README.mbt.md"
 
@@ -13,9 +13,9 @@ keywords = [ "aarch64", "compiler", "codegen", "jit" ]
 description = "AArch64 ISA target for lowering MilkIR into MachV"
 
 import {
-  "Milky2018/milkir@0.1.1",
-  "Milky2018/machv@0.2.1",
-  "Milky2018/milkir_machv@0.2.1",
+  "Milky2018/milkir@0.2.0",
+  "Milky2018/machv@0.2.2",
+  "Milky2018/milkir_machv@0.3.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/machv/moon.mod
+++ b/modules/machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 

--- a/modules/machv_emit/moon.mod
+++ b/modules/machv_emit/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv_emit"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "Reusable MachV machine-code emitter"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/machv@0.2.1",
-  "Milky2018/machv_regalloc@0.2.1",
+  "Milky2018/machv@0.2.2",
+  "Milky2018/machv_regalloc@0.2.2",
 }
 
 preferred_target = "native"

--- a/modules/machv_regalloc/moon.mod
+++ b/modules/machv_regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv_regalloc"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "MachV adapter for the reusable register allocator"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/machv@0.2.1",
-  "Milky2018/regalloc@0.1.1",
+  "Milky2018/machv@0.2.2",
+  "Milky2018/regalloc@0.2.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/milkir/moon.mod
+++ b/modules/milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir"
 
-version = "0.1.1"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/modules/milkir_machv/moon.mod
+++ b/modules/milkir_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir_machv"
 
-version = "0.2.1"
+version = "0.3.0"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "MilkIR-to-MachV lowering"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/milkir@0.1.1",
-  "Milky2018/machv@0.2.1",
+  "Milky2018/milkir@0.2.0",
+  "Milky2018/machv@0.2.2",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/regalloc/moon.mod
+++ b/modules/regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/regalloc"
 
-version = "0.1.1"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/modules/wasm_core/moon.mod
+++ b/modules/wasm_core/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_core"
 
-version = "0.1.1"
+version = "0.1.2"
 
 readme = "README.mbt.md"
 

--- a/modules/wasm_isa_lower/moon.mod
+++ b/modules/wasm_isa_lower/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_isa_lower"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 
@@ -14,10 +14,10 @@ description = "WebAssembly MilkIR dialect adapter for MachV lowering"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/wasm_milkir@0.1.1",
-  "Milky2018/milkir@0.1.1",
-  "Milky2018/machv@0.2.1",
-  "Milky2018/milkir_machv@0.2.1",
+  "Milky2018/wasm_milkir@0.2.0",
+  "Milky2018/milkir@0.2.0",
+  "Milky2018/machv@0.2.2",
+  "Milky2018/milkir_machv@0.3.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasm_milkir/moon.mod
+++ b/modules/wasm_milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_milkir"
 
-version = "0.1.1"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 
@@ -13,7 +13,7 @@ keywords = [ "wasm", "webassembly", "milkir", "compiler", "dialect" ]
 description = "WebAssembly dialect adapter for MilkIR extension operations"
 
 import {
-  "Milky2018/milkir@0.1.1",
+  "Milky2018/milkir@0.2.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasmoon/moon.mod
+++ b/modules/wasmoon/moon.mod
@@ -1,21 +1,21 @@
 name = "Milky2018/wasmoon"
 
-version = "0.6.5"
+version = "0.7.0"
 
 import {
   "moonbitlang/x@0.4.38",
   "TheWaWaR/clap@0.2.6",
-  "Milky2018/wasm_core@0.1.1",
-  "Milky2018/wasm_milkir@0.1.1",
-  "Milky2018/wasm_isa_lower@0.2.1",
-  "Milky2018/milkir@0.1.1",
-  "Milky2018/machv@0.2.1",
-  "Milky2018/milkir_machv@0.2.1",
-  "Milky2018/machv_regalloc@0.2.1",
-  "Milky2018/machv_emit@0.2.1",
-  "Milky2018/x64_target@0.1.1",
-  "Milky2018/aarch64_target@0.1.1",
-  "Milky2018/wasmoon_jit@0.1.1",
+  "Milky2018/wasm_core@0.1.2",
+  "Milky2018/wasm_milkir@0.2.0",
+  "Milky2018/wasm_isa_lower@0.2.2",
+  "Milky2018/milkir@0.2.0",
+  "Milky2018/machv@0.2.2",
+  "Milky2018/milkir_machv@0.3.0",
+  "Milky2018/machv_regalloc@0.2.2",
+  "Milky2018/machv_emit@0.2.2",
+  "Milky2018/x64_target@0.1.2",
+  "Milky2018/aarch64_target@0.1.2",
+  "Milky2018/wasmoon_jit@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/modules/wasmoon_jit/moon.mod
+++ b/modules/wasmoon_jit/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasmoon_jit"
 
-version = "0.1.1"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 
@@ -14,14 +14,14 @@ description = "Wasmoon-specific JIT integration and native runtime glue"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/wasm_core@0.1.1",
-  "Milky2018/wasm_milkir@0.1.1",
-  "Milky2018/wasm_isa_lower@0.2.1",
-  "Milky2018/milkir@0.1.1",
-  "Milky2018/machv@0.2.1",
-  "Milky2018/milkir_machv@0.2.1",
-  "Milky2018/machv_regalloc@0.2.1",
-  "Milky2018/machv_emit@0.2.1",
+  "Milky2018/wasm_core@0.1.2",
+  "Milky2018/wasm_milkir@0.2.0",
+  "Milky2018/wasm_isa_lower@0.2.2",
+  "Milky2018/milkir@0.2.0",
+  "Milky2018/machv@0.2.2",
+  "Milky2018/milkir_machv@0.3.0",
+  "Milky2018/machv_regalloc@0.2.2",
+  "Milky2018/machv_emit@0.2.2",
 }
 
 preferred_target = "native"

--- a/modules/x64_target/moon.mod
+++ b/modules/x64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/x64_target"
 
-version = "0.1.1"
+version = "0.1.2"
 
 readme = "README.mbt.md"
 
@@ -13,9 +13,9 @@ keywords = [ "x64", "x86-64", "compiler", "codegen" ]
 description = "x64 ISA target for lowering MilkIR into MachV"
 
 import {
-  "Milky2018/milkir@0.1.1",
-  "Milky2018/machv@0.2.1",
-  "Milky2018/milkir_machv@0.2.1",
+  "Milky2018/milkir@0.2.0",
+  "Milky2018/machv@0.2.2",
+  "Milky2018/milkir_machv@0.3.0",
 }
 
 preferred_target = "wasm-gc"


### PR DESCRIPTION
## Summary

- publish all 13 independently versioned modules changed since the previous release
- use minor version bumps for modules with breaking public API changes
- use patch version bumps for implementation, documentation, or compatible facade changes
- update every internal dependency constraint to the newly published version

## Published versions

### Minor releases

- `Milky2018/milkir` 0.2.0
- `Milky2018/regalloc` 0.2.0
- `Milky2018/milkir_machv` 0.3.0
- `Milky2018/wasm_milkir` 0.2.0
- `Milky2018/wasmoon_jit` 0.2.0
- `Milky2018/wasmoon` 0.7.0

### Patch releases

- `Milky2018/machv` 0.2.2
- `Milky2018/machv_emit` 0.2.2
- `Milky2018/machv_regalloc` 0.2.2
- `Milky2018/wasm_core` 0.1.2
- `Milky2018/wasm_isa_lower` 0.2.2
- `Milky2018/aarch64_target` 0.1.2
- `Milky2018/x64_target` 0.1.2

All packages were published in dependency order. Each real publish returned `Server status: 200 OK`, and each downstream package was independently packaged and checked against the refreshed registry index.

## Validation

- `moon info`
- `moon fmt`
- `moon check --target native --warn-list +73 --diagnostic-limit=300`
- `moon package --list` for every published module
- `moon publish --dry-run` for every published module; the server accepted every dry run, although the current nightly CLI incorrectly exits with status 255 after reporting success
- `moon test --target native --warn-list +73 --diagnostic-limit=300`: 1864/1865 passed; the known nightly GC JIT failure remains in `gc_jit_test.mbt` with `JITTrap("gc precise roots unavailable")`
- `git diff --check`
