### PR TITLE
Separate MilkIR O1 and O2 pipelines

### DIFF
--- a/issues/ISS-168.md
+++ b/issues/ISS-168.md
@@ -1,0 +1,37 @@
+# ISS-168: Separate MilkIR O1 and O2 optimization pipelines
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 1
+- Labels: milkir, optimizer, pipeline, docs, tests, agent
+- Assignee: codex
+- Created: 2026-07-14
+- Updated: 2026-07-14
+- External ref: none
+
+## Description
+MilkIR documents O1 as basic optimization and O2 as the default level with control-flow optimization, but both levels currently run the same e-graph, global GVN, and CFG cleanup pipeline. The README exposes this implementation accident by describing O2 as an alias for O1, so callers cannot select a cheaper optimization tier.
+
+## Design
+Keep mandatory cleanup, constant folding, alias canonicalization, and dead-code elimination at O1. Reserve e-graph rewriting, budgeted global value numbering, and full CFG cleanup for O2. Lock the distinction through the public `optimize_with_level` interface using the same input function at both levels, and update the documented optimization-level contract.
+
+## Acceptance Criteria
+- [x] O1 and O2 no longer call the same complete optimization pipeline.
+- [x] O1 retains mandatory cleanup, constant folding, alias canonicalization, and dead-code elimination at every function size.
+- [x] O2 additionally runs e-graph rewriting, global GVN, and CFG cleanup.
+- [x] A black-box regression test snapshots observably different O1 and O2 IR for the same global-CSE opportunity.
+- [x] MilkIR documentation describes distinct intended uses for O1 and O2.
+- [x] Strict warning checks, all-target MilkIR tests, full native tests, generated-interface review, and module-boundary audit pass.
+
+## Relationships
+- Depends on: ISS-149
+- Parent: none
+- Related: ISS-017, ISS-151
+- Discovered from: ISS-149
+
+## Notes
+- 2026-07-14: Claimed after review confirmed that `optimize_o1` and the default O2 entry point both call `optimize_cranelift_style` with e-graph enabled.
+
+## Close Notes
+- 2026-07-14: Split O1 into the mandatory inexpensive cleanup pipeline and kept e-graph rewriting, budgeted global GVN, and CFG transforms in O2. Added a public black-box snapshot proving that only O2 merges a repeated expression. Verified with strict all-target checks, all-target tests, native tests with register-allocation validation, `moon info`, formatting, diff checks, and the module-boundary audit.

--- a/issues/README.md
+++ b/issues/README.md
@@ -181,6 +181,7 @@ graph TD
   ISS_165["ISS-165: Remove the legacy VectorOp matrix and validate SIMD parity"]
   ISS_166["ISS-166: Eliminate MoonBit warning 73 annotations"]
   ISS_167["ISS-167: Add comprehensive MilkIR black-box contract tests"]
+  ISS_168["ISS-168: Separate MilkIR O1 and O2 optimization pipelines"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005
@@ -322,6 +323,7 @@ graph TD
   ISS_163 --> ISS_164
   ISS_164 --> ISS_165
   ISS_166 --> ISS_167
+  ISS_149 --> ISS_168
 ```
 
 ## Warnings

--- a/modules/milkir/README.mbt.md
+++ b/modules/milkir/README.mbt.md
@@ -294,8 +294,8 @@ The optimization levels are:
 | Level | Intended use |
 | --- | --- |
 | `O0` | Minimal pipeline: removes dead code plus constant and unused block parameters. |
-| `O1` | The standard Cranelift-style simplification pipeline. |
-| `O2` | The default level and an alias for the standard `O1` pass set. |
+| `O1` | Inexpensive simplification: mandatory cleanup, constant folding, alias canonicalization, and dead-code elimination. |
+| `O2` | The default pipeline: O1-style cleanup plus e-graph rewriting, budgeted global value numbering, and CFG simplification. |
 | `O3` | The `O2` pipeline, loop-invariant code motion, checked counted-loop unrolling, strength reduction, and a final `O2` cleanup. |
 
 Use `optimize(func)` for the default pipeline or `optimize_with_level(func, level)` when the caller chooses the level explicitly. Optimizers assume a valid SSA and block-parameter structure. Verify before optimization when the input comes from a frontend, then verify again after developing a new transformation.

--- a/modules/milkir/facade_optimize_test.mbt
+++ b/modules/milkir/facade_optimize_test.mbt
@@ -101,6 +101,56 @@ test "public O1 folds a constant expression" {
 }
 
 ///|
+fn build_repeated_expression(
+  name : String,
+) -> @milkir.Function raise @milkir.VerifyError {
+  let builder = @milkir.FunctionBuilder::FunctionBuilder(name)
+  let left = builder.add_param(I32)
+  let right = builder.add_param(I32)
+  builder.add_result(I32)
+  let first = builder.iadd(left, right)
+  let second = builder.iadd(left, right)
+  let product = builder.imul(first, second)
+  builder.return_([product])
+  builder.finalize()
+}
+
+///|
+test "public O1 and O2 select distinct optimization pipelines" {
+  let o1 = build_repeated_expression("repeated_o1")
+  let o2 = build_repeated_expression("repeated_o2")
+  @milkir.optimize_with_level(o1, O1) |> ignore
+  @milkir.optimize_with_level(o2, O2) |> ignore
+  inspect(
+    o1.print(),
+    content=(
+      #|function repeated_o1(v0:i32, v1:i32) -> i32 {
+      #|block0:
+      #|    v2:i32 = iadd v0, v1
+      #|    v3:i32 = iadd v0, v1
+      #|    v4:i32 = imul v2, v3
+      #|    return v4
+      #|}
+      #|
+    ),
+  )
+  inspect(
+    o2.print(),
+    content=(
+      #|function repeated_o2(v0:i32, v1:i32) -> i32 {
+      #|block0:
+      #|    v2:i32 = iadd v0, v1
+      #|    v4:i32 = imul v2, v2
+      #|    return v4
+      #|}
+      #|
+    ),
+  )
+  o1.verify()
+  o2.verify()
+}
+
+///|
 test "public O2 eliminates a duplicate expression" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder("common_subexpression")
   let left = builder.add_param(I32)

--- a/modules/milkir/opt_driver.mbt
+++ b/modules/milkir/opt_driver.mbt
@@ -3,8 +3,8 @@
 ///|
 /// Optimization level
 /// - 0: No optimization
-/// - 1: Basic optimizations (constant folding, copy propagation, CSE, DCE)
-/// - 2: Default optimizations (includes control flow optimizations)
+/// - 1: Inexpensive optimizations (constant folding, alias cleanup, DCE)
+/// - 2: Default optimizations (adds e-graph, global GVN, and CFG transforms)
 /// - 3: Aggressive optimizations (includes loop optimizations)
 pub(all) enum OptLevel {
   O0 // No optimization
@@ -211,10 +211,7 @@ fn run_mandatory_final_cleanup(func : Function) -> OptResult {
 }
 
 ///|
-fn optimize_cranelift_style(
-  func : Function,
-  run_egraph? : Bool = true,
-) -> OptResult {
+fn optimize_o2_pipeline(func : Function) -> OptResult {
   let result = OptResult::OptResult()
   // Mandatory passes are independent of function size and run before budgets
   // are selected, so dead and aliased IR does not consume expensive work.
@@ -222,7 +219,7 @@ fn optimize_cranelift_style(
   if pre_cleanup.changed {
     result.mark_changed()
   }
-  if run_egraph && run_egraph_pass(func) {
+  if run_egraph_pass(func) {
     result.mark_changed()
   }
   let gvn_result = run_gvn_pass(func)
@@ -258,15 +255,15 @@ pub fn optimize_with_level(func : Function, level : OptLevel) -> OptResult {
 }
 
 ///|
-/// O1: Basic optimizations only
+/// O1: Mandatory cleanup and inexpensive simplification only.
 fn optimize_o1(func : Function) -> OptResult {
-  optimize_cranelift_style(func, run_egraph=true)
+  run_optimized_mandatory_pre_cleanup(func)
 }
 
 ///|
 /// Run default optimizations (Cranelift-aligned O2 path).
 pub fn optimize(func : Function) -> OptResult {
-  optimize_cranelift_style(func, run_egraph=true)
+  optimize_o2_pipeline(func)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- give MilkIR O1 and O2 distinct optimization pipelines
- keep mandatory cleanup, constant folding, alias canonicalization, and DCE in O1
- reserve e-graph rewriting, budgeted GVN, and full CFG cleanup for O2
- add a black-box snapshot demonstrating the observable tier difference
- close ISS-168 and update the MilkIR optimization-level documentation

## Impact

Callers can now choose a genuinely cheaper O1 tier instead of receiving the same optimization work and behavior as O2.

## Validation

- strict all-target checks and tests were run for the feature commit
- full native tests with register-allocation validation passed for the feature commit
- after merging current `main`, the pre-commit gate reran `moon fmt`, `moon info`, and `moon check --target native`
- the Markdown issue index was regenerated from the issue files
- `git diff --check`
