### PR TITLE
Fix Wasmtime path during perf CI setup

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           curl -fsSL https://wasmtime.dev/install.sh | bash
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          wasmtime --version
+          "$HOME/.wasmtime/bin/wasmtime" --version
 
       - name: run perf benchmark runner
         id: perf_runner


### PR DESCRIPTION
## Summary

- invoke the freshly installed Wasmtime binary through its absolute installation path during perf CI setup

## Why

Appending `$HOME/.wasmtime/bin` to `GITHUB_PATH` only affects later workflow steps. The install step previously invoked `wasmtime --version` before that path update became active, so setup could fail even though installation succeeded.

## Impact

The perf workflow verifies the exact Wasmtime binary it just installed and can proceed to the benchmark runner.

## Validation

- workflow diff is limited to the installation-step path fix
