### PR TITLE
refactor: move dialect validation and lowering to adapter seams

### DIFF
--- a/modules/milkir/README.mbt.md
+++ b/modules/milkir/README.mbt.md
@@ -64,7 +64,7 @@ block0:                             execution starts in block0
 }
 ```
 
-`finalize()` verifies the current function before returning it and raises `VerifyError` for malformed SSA, CFG, or instruction contracts. It is a validation checkpoint, not a freeze operation: the returned `Function` remains mutable and does not carry a persistent "verified" state. `get_function()` remains the explicit escape hatch for in-progress construction and transformation code. Callers may continue transforming either value, but every consuming adapter must verify the function after its final mutation and immediately before lowering it.
+`finalize()` verifies the current function before returning it and raises `VerifyError` for malformed SSA, CFG, or generic instruction contracts. For extension instructions, generic verification checks only the dialect/opcode envelope and the explicit operand/result signature; the owning adapter validates dialect semantics. Finalization is a validation checkpoint, not a freeze operation: the returned `Function` remains mutable and does not carry a persistent "verified" state. `get_function()` remains the explicit escape hatch for in-progress construction and transformation code. Callers may continue transforming either value, but every consuming adapter must verify the function after its final mutation and immediately before lowering it.
 
 The important detail is that `x`, `one`, and `answer` are not runtime integers in the MoonBit program that builds the IR. They are MilkIR `Value`s: typed handles that name values in the function being compiled.
 
@@ -332,9 +332,9 @@ An embedding adapter may assign roles such as VMContext to those arguments when 
 
 ## Dialect-specific operations
 
-`Ext(ExtOp, Signature)` represents dialect-specific operations. MilkIR stores a dialect name, opcode name, integer immediates, and an explicit operand/result contract, while the dialect package provides builders, semantic validation, decoding, and lowering.
+`Ext(ExtOp, Signature)` represents dialect-specific operations. MilkIR stores only a dialect name, opcode name, integer immediates, and an explicit operand/result contract. Validator closures are not part of `Function`; the dialect package owns builders, semantic validation, decoding, and lowering.
 
-A dialect-owned builder must register its validator on the `Function` before emitting extension operations. `Function::verify` and `FunctionBuilder::finalize` reject extension dialects without a registered validator and convert validator diagnostics into `VerifyError::UnverifiableInstruction`. An adapter should additionally call `Function::verify_with_extension_validator` with its own trusted validator before lowering, so the adapter boundary does not rely on a validator supplied by the IR producer.
+`Function::verify` and `FunctionBuilder::finalize` validate generic IR structure without interpreting dialect semantics. At the adapter seam, `Function::verify_with_extension_validator` receives the owned dialect name and validator explicitly, rejects extensions owned by another dialect, and converts diagnostics into `VerifyError::UnverifiableInstruction`. Dialect lowering likewise requires an explicit adapter verifier, so validation behavior depends only on the adapter selected by the consumer, never on function construction history.
 
 ```moonbit check
 ///|

--- a/modules/milkir/builder.mbt
+++ b/modules/milkir/builder.mbt
@@ -26,10 +26,11 @@ pub fn FunctionBuilder::get_function(self : FunctionBuilder) -> Function {
 }
 
 ///|
-/// Verify the current function and return the same mutable function.
+/// Verify generic MilkIR structure and return the same mutable function.
 ///
 /// Finalization is a validation checkpoint, not a frozen or persistent
-/// validated state. Any later mutation requires validation at the next
+/// validated state. Extension semantics remain the owning adapter's
+/// responsibility. Any later mutation requires validation at the next
 /// consuming seam.
 pub fn FunctionBuilder::finalize(
   self : FunctionBuilder,

--- a/modules/milkir/facade_operations_test.mbt
+++ b/modules/milkir/facade_operations_test.mbt
@@ -114,7 +114,6 @@ test "public vector builders cover lanes, bitwise ops, and memory" {
 ///|
 test "public extension builders preserve typed multi-value contracts" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder("extension")
-  builder.get_function().register_extension_validator("demo", fn(_) { None })
   let input = builder.add_param(I32)
   builder.add_result(I32)
   builder.add_result(I64)

--- a/modules/milkir/facade_optimize_test.mbt
+++ b/modules/milkir/facade_optimize_test.mbt
@@ -212,7 +212,6 @@ test "public O3 derives power-of-two strength-reduction constants" {
 ///|
 test "public optimizer preserves observable and trapping operations" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder("effects")
-  builder.get_function().register_extension_validator("demo", fn(_) { None })
   let address = builder.add_param(Ptr)
   let value = builder.add_param(I32)
   let offset = builder.add_param(I64)

--- a/modules/milkir/facade_verify_test.mbt
+++ b/modules/milkir/facade_verify_test.mbt
@@ -34,21 +34,11 @@ test "public finalize rejects a return type mismatch" {
 }
 
 ///|
-test "public finalize rejects an unregistered extension dialect" {
+test "public finalize leaves extension semantics to an adapter" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder("unknown_dialect")
   builder.emit_void_ext_inst(ExtOp("demo", "effect", []), [])
   builder.return_([])
-  try builder.finalize() catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|UnverifiableInstruction(message="extension dialect 'demo' has no registered validator")
-        ),
-      )
-  } noraise {
-    _ => fail("expected finalize to reject the unregistered dialect")
-  }
+  builder.finalize() |> ignore
 }
 
 ///|
@@ -137,15 +127,13 @@ test "extension validators receive the complete read-only instruction shape" {
   let input = builder.add_param(I64)
   builder.add_result(I32)
   let views : Array[ExtensionInstView] = []
-  builder
-  .get_function()
-  .register_extension_validator("demo", view => {
+  let result = builder.emit_ext_inst(I32, ExtOp("demo", "shape", []), [input])
+  builder.return_([result])
+  let func = builder.finalize()
+  func.verify_with_extension_validator("demo", view => {
     views.push(view)
     None
   })
-  let result = builder.emit_ext_inst(I32, ExtOp("demo", "shape", []), [input])
-  builder.return_([result])
-  builder.finalize() |> ignore
   debug_inspect(
     views,
     content=(
@@ -158,4 +146,23 @@ test "extension validators receive the complete read-only instruction shape" {
       #|]
     ),
   )
+}
+
+///|
+test "adapter validation rejects extensions owned by another dialect" {
+  let builder = @milkir.FunctionBuilder::FunctionBuilder("foreign_dialect")
+  builder.emit_void_ext_inst(ExtOp("demo", "effect", []), [])
+  builder.return_([])
+  let func = builder.finalize()
+  try func.verify_with_extension_validator("wasm", fn(_) { None }) catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|UnverifiableInstruction(message="extension dialect 'demo' is not owned by adapter 'wasm'")
+        ),
+      )
+  } noraise {
+    _ => fail("expected the adapter to reject a foreign dialect")
+  }
 }

--- a/modules/milkir/ir.mbt
+++ b/modules/milkir/ir.mbt
@@ -233,12 +233,6 @@ pub struct ExtensionInstView {
 } derive(Debug)
 
 ///|
-priv struct ExtensionValidator {
-  dialect : String
-  validate : (ExtensionInstView) -> String?
-}
-
-///|
 pub fn ExtOp::matches_descriptor(
   self : ExtOp,
   descriptor : ExtOpDescriptor,
@@ -846,7 +840,6 @@ pub(all) enum Terminator {
 /// Function - a complete IR function
 pub struct Function {
   priv owner : Ref[FunctionOwnerContext]
-  priv extension_validators : Array[ExtensionValidator]
   name : String
   params : Array[(Value, Type)] // Function parameters
   results : Array[Type] // Return types
@@ -875,7 +868,6 @@ pub impl Debug for Function with fn to_repr(self) {
 pub fn Function::new_empty(name : String) -> Function {
   {
     owner: FunctionOwnerContext::new(),
-    extension_validators: [],
     name,
     params: [],
     results: [],
@@ -885,21 +877,6 @@ pub fn Function::new_empty(name : String) -> Function {
     next_inst_id: 0,
     next_block_id: 0,
   }
-}
-
-///|
-/// Register the validator owned by an extension dialect used in this function.
-pub fn Function::register_extension_validator(
-  self : Function,
-  dialect : String,
-  validate : (ExtensionInstView) -> String?,
-) -> Unit {
-  for registered in self.extension_validators {
-    if registered.dialect == dialect {
-      return
-    }
-  }
-  self.extension_validators.push({ dialect, validate })
 }
 
 ///|

--- a/modules/milkir/pkg.generated.mbti
+++ b/modules/milkir/pkg.generated.mbti
@@ -172,11 +172,10 @@ pub fn Function::new_inst(Self, Opcode, Array[Value], Array[Value]) -> Inst
 pub fn Function::new_value(Self, Type) -> Value
 pub fn Function::param(Self, Int) -> Value?
 pub fn Function::print(Self) -> String
-pub fn Function::register_extension_validator(Self, String, (ExtensionInstView) -> String?) -> Unit
 pub fn Function::signature(Self) -> Signature
 pub fn Function::verify(Self) -> Unit raise VerifyError
 pub fn Function::verify_core(Self) -> Unit raise VerifyError
-pub fn Function::verify_with_extension_validator(Self, (ExtensionInstView) -> String?) -> Unit raise VerifyError
+pub fn Function::verify_with_extension_validator(Self, String, (ExtensionInstView) -> String?) -> Unit raise VerifyError
 pub fn Function::with_signature(String, Signature) -> Self
 pub impl @debug.Debug for Function
 

--- a/modules/milkir/verify.mbt
+++ b/modules/milkir/verify.mbt
@@ -107,7 +107,7 @@ pub fn Function::verify(self : Function) -> Unit raise VerifyError {
   let idom = CFG::build(self).compute_dominators()
   for block in self.blocks {
     for inst_index, inst in block.instructions {
-      verify_inst(self, inst, definitions, block.id, inst_index, idom)
+      verify_inst(inst, definitions, block.id, inst_index, idom)
     }
     if block.terminator is Some(term) {
       verify_terminator(
@@ -178,17 +178,24 @@ pub fn Function::verify_core(self : Function) -> Unit raise VerifyError {
 }
 
 ///|
-/// Verify the function and apply an owning adapter's validator to every
-/// extension operation before crossing the adapter seam.
+/// Verify generic MilkIR structure, require every extension to belong to the
+/// owning dialect, and apply that adapter's validator before crossing its seam.
 pub fn Function::verify_with_extension_validator(
   self : Function,
+  dialect : String,
   validate : (ExtensionInstView) -> String?,
 ) -> Unit raise VerifyError {
   self.verify()
   for block in self.blocks {
     for inst in block.instructions {
       if inst.opcode is Ext(_, _) {
-        if validate(extension_inst_view(inst)) is Some(message) {
+        let view = extension_inst_view(inst)
+        if view.op.dialect != dialect {
+          raise UnverifiableInstruction(
+            message="extension dialect '\{view.op.dialect}' is not owned by adapter '\{dialect}'",
+          )
+        }
+        if validate(view) is Some(message) {
           raise UnverifiableInstruction(message~)
         }
       }
@@ -357,7 +364,6 @@ fn verify_i32(value : Value, context : String) -> Unit raise VerifyError {
 
 ///|
 fn verify_inst(
-  func : Function,
   inst : Inst,
   definitions : @hashmap.HashMap[Int, ValueDefinition],
   use_block : Int,
@@ -368,9 +374,6 @@ fn verify_inst(
     verify_defined(arg, definitions, use_block, use_position, idom)
   }
   verify_opcode_contract(inst)
-  if inst.opcode is Ext(_, _) {
-    verify_extension(func, inst)
-  }
 }
 
 ///|
@@ -386,22 +389,6 @@ fn extension_inst_view(inst : Inst) -> ExtensionInstView {
       inst.results[i].ty
     }),
   }
-}
-
-///|
-fn verify_extension(func : Function, inst : Inst) -> Unit raise VerifyError {
-  let view = extension_inst_view(inst)
-  for registered in func.extension_validators {
-    if registered.dialect == view.op.dialect {
-      if (registered.validate)(view) is Some(message) {
-        raise UnverifiableInstruction(message~)
-      }
-      return
-    }
-  }
-  raise UnverifiableInstruction(
-    message="extension dialect '\{view.op.dialect}' has no registered validator",
-  )
 }
 
 ///|

--- a/modules/milkir/verify_contract_wbtest.mbt
+++ b/modules/milkir/verify_contract_wbtest.mbt
@@ -249,7 +249,6 @@ test "verify rejects extension instructions that disagree with their contract" {
 ///|
 test "verify_core rejects unresolved dialect operations" {
   let func = Function::new_empty("dialect_is_not_core")
-  func.register_extension_validator("wasm", fn(_) { None })
   let entry = func.new_block([])
   let ext = ExtOp::ExtOp("wasm", "example", [])
   entry.append_inst(func.new_inst(Ext(ext, Signature([], [])), [], []))

--- a/modules/milkir_machv/lower/lower.mbt
+++ b/modules/milkir_machv/lower/lower.mbt
@@ -1893,10 +1893,13 @@ pub fn lower_core_function_with_config(
 }
 
 ///|
-/// Lower dialect-bearing MilkIR with an explicit owning adapter.
+/// Lower dialect-bearing MilkIR with an explicit owning adapter verifier and
+/// instruction lowerer.
 pub fn lower_dialect_function_with_config(
   ir_func : @milkir.Function,
   config : LoweringConfig,
+  dialect : String,
+  validate_extension : (@milkir.ExtensionInstView) -> String?,
   extension_lowerer : (
     LoweringContext,
     @milkir.Inst,
@@ -1904,7 +1907,7 @@ pub fn lower_dialect_function_with_config(
     @milkir.ExtOp,
   ) -> ExtensionLowerResult,
 ) -> @machv.Function raise @milkir.VerifyError {
-  ir_func.verify()
+  ir_func.verify_with_extension_validator(dialect, validate_extension)
   lower_function_with_config_unchecked(
     ir_func,
     config.with_extension_lowerer(extension_lowerer),
@@ -1935,9 +1938,12 @@ pub fn lower_function(
 }
 
 ///|
-/// Lower dialect-bearing MilkIR to MachV with its required owning adapter.
+/// Lower dialect-bearing MilkIR to MachV with its required owning adapter
+/// verifier and instruction lowerer.
 pub fn lower_dialect_function(
   ir_func : @milkir.Function,
+  dialect : String,
+  validate_extension : (@milkir.ExtensionInstView) -> String?,
   extension_lowerer : (
     LoweringContext,
     @milkir.Inst,
@@ -1960,7 +1966,9 @@ pub fn lower_dialect_function(
     num_imports,
     run_ir_opt,
   }
-  lower_dialect_function_with_config(ir_func, config, extension_lowerer)
+  lower_dialect_function_with_config(
+    ir_func, config, dialect, validate_extension, extension_lowerer,
+  )
 }
 
 ///|

--- a/modules/milkir_machv/lower/lower.mbt
+++ b/modules/milkir_machv/lower/lower.mbt
@@ -54,12 +54,6 @@ struct LoweringConfig {
   embedding_abi : @abi.EmbeddingABI?
   external_helper_symbols : Map[String, String]
   trap_payload_resolver : (String) -> Int
-  extension_lowerer : ((
-    LoweringContext,
-    @milkir.Inst,
-    @block.Block,
-    @milkir.ExtOp,
-  ) -> ExtensionLowerResult)?
   num_imports : Int
   run_ir_opt : Bool
 }
@@ -71,7 +65,6 @@ pub fn LoweringConfig::LoweringConfig(isa : @isa.ISA) -> LoweringConfig {
     embedding_abi: None,
     external_helper_symbols: Map([]),
     trap_payload_resolver: fn(_reason) { 0 },
-    extension_lowerer: None,
     num_imports: -1,
     run_ir_opt: true,
   }
@@ -87,7 +80,6 @@ pub fn LoweringConfig::with_embedding_abi(
     embedding_abi: Some(embedding_abi),
     external_helper_symbols: self.external_helper_symbols,
     trap_payload_resolver: self.trap_payload_resolver,
-    extension_lowerer: self.extension_lowerer,
     num_imports: self.num_imports,
     run_ir_opt: self.run_ir_opt,
   }
@@ -103,7 +95,6 @@ pub fn LoweringConfig::with_external_helper_symbols(
     embedding_abi: self.embedding_abi,
     external_helper_symbols,
     trap_payload_resolver: self.trap_payload_resolver,
-    extension_lowerer: self.extension_lowerer,
     num_imports: self.num_imports,
     run_ir_opt: self.run_ir_opt,
   }
@@ -119,28 +110,6 @@ pub fn LoweringConfig::with_trap_payload_resolver(
     embedding_abi: self.embedding_abi,
     external_helper_symbols: self.external_helper_symbols,
     trap_payload_resolver,
-    extension_lowerer: self.extension_lowerer,
-    num_imports: self.num_imports,
-    run_ir_opt: self.run_ir_opt,
-  }
-}
-
-///|
-pub fn LoweringConfig::with_extension_lowerer(
-  self : LoweringConfig,
-  extension_lowerer : (
-    LoweringContext,
-    @milkir.Inst,
-    @block.Block,
-    @milkir.ExtOp,
-  ) -> ExtensionLowerResult,
-) -> LoweringConfig {
-  {
-    isa: self.isa,
-    embedding_abi: self.embedding_abi,
-    external_helper_symbols: self.external_helper_symbols,
-    trap_payload_resolver: self.trap_payload_resolver,
-    extension_lowerer: Some(extension_lowerer),
     num_imports: self.num_imports,
     run_ir_opt: self.run_ir_opt,
   }
@@ -156,7 +125,6 @@ pub fn LoweringConfig::with_num_imports(
     embedding_abi: self.embedding_abi,
     external_helper_symbols: self.external_helper_symbols,
     trap_payload_resolver: self.trap_payload_resolver,
-    extension_lowerer: self.extension_lowerer,
     num_imports,
     run_ir_opt: self.run_ir_opt,
   }
@@ -172,7 +140,6 @@ pub fn LoweringConfig::with_ir_optimization(
     embedding_abi: self.embedding_abi,
     external_helper_symbols: self.external_helper_symbols,
     trap_payload_resolver: self.trap_payload_resolver,
-    extension_lowerer: self.extension_lowerer,
     num_imports: self.num_imports,
     run_ir_opt: enabled,
   }
@@ -1730,6 +1697,12 @@ fn intcc_to_cond(cc : @milkir.IntCC) -> @instr.Cond {
 fn lower_function_with_config_unchecked(
   ir_func : @milkir.Function,
   config : LoweringConfig,
+  extension_lowerer : ((
+    LoweringContext,
+    @milkir.Inst,
+    @block.Block,
+    @milkir.ExtOp,
+  ) -> ExtensionLowerResult)?,
 ) -> @machv.Function {
   // Keep this optional for call sites that already ran full IR optimization.
   if config.run_ir_opt {
@@ -1742,7 +1715,7 @@ fn lower_function_with_config_unchecked(
     config.embedding_abi,
     config.external_helper_symbols,
     config.trap_payload_resolver,
-    config.extension_lowerer,
+    extension_lowerer,
     config.num_imports,
   )
 
@@ -1885,11 +1858,8 @@ pub fn lower_core_function_with_config(
   ir_func : @milkir.Function,
   config : LoweringConfig,
 ) -> @machv.Function raise @milkir.VerifyError {
-  if config.extension_lowerer is Some(_) {
-    abort("core MilkIR lowering does not accept a dialect adapter")
-  }
   ir_func.verify_core()
-  lower_function_with_config_unchecked(ir_func, config)
+  lower_function_with_config_unchecked(ir_func, config, None)
 }
 
 ///|
@@ -1908,10 +1878,7 @@ pub fn lower_dialect_function_with_config(
   ) -> ExtensionLowerResult,
 ) -> @machv.Function raise @milkir.VerifyError {
   ir_func.verify_with_extension_validator(dialect, validate_extension)
-  lower_function_with_config_unchecked(
-    ir_func,
-    config.with_extension_lowerer(extension_lowerer),
-  )
+  lower_function_with_config_unchecked(ir_func, config, Some(extension_lowerer))
 }
 
 ///|
@@ -1930,7 +1897,6 @@ pub fn lower_function(
     embedding_abi,
     external_helper_symbols,
     trap_payload_resolver,
-    extension_lowerer: None,
     num_imports,
     run_ir_opt,
   }
@@ -1962,7 +1928,6 @@ pub fn lower_dialect_function(
     embedding_abi,
     external_helper_symbols,
     trap_payload_resolver,
-    extension_lowerer: None,
     num_imports,
     run_ir_opt,
   }

--- a/modules/milkir_machv/lower/pkg.generated.mbti
+++ b/modules/milkir_machv/lower/pkg.generated.mbti
@@ -49,9 +49,9 @@ pub fn lower_c_libcall_direct(LoweringContext, @block.Block, @instr.ExternalName
 
 pub fn lower_core_function_with_config(@milkir.Function, LoweringConfig) -> @machv.Function raise @milkir.VerifyError
 
-pub fn lower_dialect_function(@milkir.Function, (LoweringContext, @milkir.Inst, @block.Block, @milkir.ExtOp) -> ExtensionLowerResult, isa? : @isa.ISA, embedding_abi? : @abi.EmbeddingABI?, external_helper_symbols? : Map[String, String], trap_payload_resolver? : (String) -> Int, num_imports? : Int, run_ir_opt? : Bool) -> @machv.Function raise @milkir.VerifyError
+pub fn lower_dialect_function(@milkir.Function, String, (@milkir.ExtensionInstView) -> String?, (LoweringContext, @milkir.Inst, @block.Block, @milkir.ExtOp) -> ExtensionLowerResult, isa? : @isa.ISA, embedding_abi? : @abi.EmbeddingABI?, external_helper_symbols? : Map[String, String], trap_payload_resolver? : (String) -> Int, num_imports? : Int, run_ir_opt? : Bool) -> @machv.Function raise @milkir.VerifyError
 
-pub fn lower_dialect_function_with_config(@milkir.Function, LoweringConfig, (LoweringContext, @milkir.Inst, @block.Block, @milkir.ExtOp) -> ExtensionLowerResult) -> @machv.Function raise @milkir.VerifyError
+pub fn lower_dialect_function_with_config(@milkir.Function, LoweringConfig, String, (@milkir.ExtensionInstView) -> String?, (LoweringContext, @milkir.Inst, @block.Block, @milkir.ExtOp) -> ExtensionLowerResult) -> @machv.Function raise @milkir.VerifyError
 
 pub fn lower_function(@milkir.Function, isa? : @isa.ISA, embedding_abi? : @abi.EmbeddingABI?, external_helper_symbols? : Map[String, String], trap_payload_resolver? : (String) -> Int, num_imports? : Int, run_ir_opt? : Bool) -> @machv.Function raise @milkir.VerifyError
 

--- a/modules/milkir_machv/lower/pkg.generated.mbti
+++ b/modules/milkir_machv/lower/pkg.generated.mbti
@@ -92,7 +92,6 @@ pub(all) enum ExtensionLowerResult {
 type LoweringConfig
 pub fn LoweringConfig::LoweringConfig(@isa.ISA) -> Self
 pub fn LoweringConfig::with_embedding_abi(Self, @abi.EmbeddingABI) -> Self
-pub fn LoweringConfig::with_extension_lowerer(Self, (LoweringContext, @milkir.Inst, @block.Block, @milkir.ExtOp) -> ExtensionLowerResult) -> Self
 pub fn LoweringConfig::with_external_helper_symbols(Self, Map[String, String]) -> Self
 pub fn LoweringConfig::with_ir_optimization(Self, Bool) -> Self
 pub fn LoweringConfig::with_num_imports(Self, Int) -> Self

--- a/modules/milkir_machv/validation_seam_test.mbt
+++ b/modules/milkir_machv/validation_seam_test.mbt
@@ -27,6 +27,8 @@ test "dialect lowering rejects a function mutated after finalization" {
   try
     @lower.lower_dialect_function(
       func,
+      "demo",
+      fn(_) { None },
       fn(_, _, block, _) { Handled(block) },
       run_ir_opt=false,
     )
@@ -34,5 +36,32 @@ test "dialect lowering rejects a function mutated after finalization" {
     err => inspect(err, content="UndefinedValue(value_id=0)")
   } noraise {
     _ => fail("expected dialect lowering to return the validation error")
+  }
+}
+
+///|
+test "dialect lowering applies its explicit adapter verifier" {
+  let builder = @milkir.FunctionBuilder::FunctionBuilder("invalid_dialect")
+  builder.emit_void_ext_inst(ExtOp("demo", "invalid", []), [])
+  builder.return_([])
+  let func = builder.finalize()
+  try
+    @lower.lower_dialect_function(
+      func,
+      "demo",
+      fn(_) { Some("demo adapter rejected the extension") },
+      fn(_, _, block, _) { Handled(block) },
+      run_ir_opt=false,
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|UnverifiableInstruction(message="demo adapter rejected the extension")
+        ),
+      )
+  } noraise {
+    _ => fail("expected dialect lowering to apply adapter validation")
   }
 }

--- a/modules/wasm_isa_lower/lower.mbt
+++ b/modules/wasm_isa_lower/lower.mbt
@@ -171,7 +171,6 @@ pub fn lower_function(
   use_subtype_indirect_check? : Bool = true,
   canonical_type_indices? : Array[Int] = [],
 ) -> @machv.Function raise @milkir.VerifyError {
-  @wasm_milkir.verify_function(func)
   let options : WasmLoweringOptions = {
     use_subtype_indirect_check,
     canonical_type_indices,
@@ -187,6 +186,8 @@ pub fn lower_function(
   }
   @lower.lower_dialect_function(
     func,
+    @wasm_milkir.WASM_DIALECT,
+    @wasm_milkir.validate_extension,
     lower_extension,
     isa~,
     embedding_abi~,

--- a/modules/wasm_isa_lower/lower_test.mbt
+++ b/modules/wasm_isa_lower/lower_test.mbt
@@ -45,7 +45,6 @@ fn test_embedding_abi() -> @abi.EmbeddingABI {
 ///|
 test "Wasm lowering returns validation errors for unknown opcodes" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder("unknown_wasm_opcode")
-  @wasm_milkir.get_exception_tag(builder) |> ignore
   builder.emit_void_ext_inst(ExtOp("wasm", "typo", []), [])
   builder.return_([])
   try lower_function(builder.get_function(), test_context_slots()) catch {
@@ -62,30 +61,10 @@ test "Wasm lowering returns validation errors for unknown opcodes" {
 }
 
 ///|
-test "Wasm lowering does not trust a producer-provided validator" {
-  let builder = @milkir.FunctionBuilder::FunctionBuilder("untrusted_validator")
-  builder.get_function().register_extension_validator("wasm", fn(_) { None })
-  builder.emit_void_ext_inst(ExtOp("wasm", "typo", []), [])
-  builder.return_([])
-  try lower_function(builder.get_function(), test_context_slots()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|UnverifiableInstruction(message="unknown Wasm MilkIR extension opcode 'typo'")
-        ),
-      )
-  } noraise {
-    _ => fail("expected Wasm lowering to apply its trusted validator")
-  }
-}
-
-///|
 test "Wasm lowering returns validation errors for malformed immediates" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder(
     "malformed_wasm_immediate",
   )
-  @wasm_milkir.get_exception_tag(builder) |> ignore
   builder.emit_void_ext_inst(
     ExtOp(
       "wasm",
@@ -113,7 +92,6 @@ test "Wasm lowering rejects missing fixed results before instruction selection" 
   let builder = @milkir.FunctionBuilder::FunctionBuilder(
     "missing_wasm_extension_result",
   )
-  @wasm_milkir.get_exception_tag(builder) |> ignore
   builder.emit_void_ext_inst(@wasm_milkir.encode(GetExceptionTag), [])
   builder.return_([])
   try lower_function(builder.get_function(), test_context_slots()) catch {
@@ -140,7 +118,6 @@ test "Wasm lowering rejects removed memory and table extension names" {
     let builder = @milkir.FunctionBuilder::FunctionBuilder(
       "removed_wasm_opcode",
     )
-    @wasm_milkir.get_exception_tag(builder) |> ignore
     builder.emit_void_ext_inst(ext, [])
     builder.return_([])
     try lower_function(builder.get_function(), test_context_slots()) catch {

--- a/modules/wasm_milkir/README.mbt.md
+++ b/modules/wasm_milkir/README.mbt.md
@@ -7,7 +7,7 @@ builder helpers used with MilkIR. Frontends encode Wasm operations through
 typed `WasmOpcode` constructors, then a lowering adapter checks and decodes
 those extensions before machine lowering.
 
-Typed Wasm builders automatically register the schema-derived validator on the MilkIR function. Finalization therefore rejects unknown opcode names, incorrect immediate counts, and malformed boolean immediates as structured MilkIR verification errors. The Wasm lowering adapter revalidates every extension with `verify_function` before decoding it.
+Typed Wasm builders only emit IR data; they do not attach validator closures to the MilkIR function. Generic MilkIR finalization checks the extension envelope and its explicit signature, while `verify_function` applies the schema-derived Wasm contracts at the adapter seam. Wasm lowering passes that verifier explicitly before decoding any extension.
 
 Typed constructors, serialized opcode names, and immediate layouts are defined once in `wasm_opcodes.schema`. During development, `dev_build` runs the deterministic `tools/generate_wasm_opcodes.py` generator to refresh the committed `dialect_generated.mbt` source. Published packages include that generated MoonBit source, so downstream builds neither load the schema at runtime nor execute development build rules.
 
@@ -51,7 +51,7 @@ test "build a Wasm memory.size extension instruction" {
   builder.return_([size])
   let func = builder.get_function()
   inspect(func.blocks.length(), content="1")
-  inspect(func.verify(), content="()")
+  verify_function(func)
   match func.blocks[0].instructions[1].opcode {
     Call(Direct(symbol, _)) =>
       inspect(symbol.name, content="example.runtime.memory_size")

--- a/modules/wasm_milkir/builder.mbt
+++ b/modules/wasm_milkir/builder.mbt
@@ -43,7 +43,6 @@ fn emit_wasm_inst(
   opcode : WasmOpcode,
   operands : Array[@milkir.Value],
 ) -> @milkir.Value {
-  register_wasm_validator(builder)
   builder.emit_ext_inst(ty, encode(opcode), operands)
 }
 
@@ -53,7 +52,6 @@ fn emit_void_wasm_inst(
   opcode : WasmOpcode,
   operands : Array[@milkir.Value],
 ) -> Unit {
-  register_wasm_validator(builder)
   builder.emit_void_ext_inst(encode(opcode), operands)
 }
 
@@ -68,7 +66,6 @@ fn append_multi_result_inst(
     emit_void_wasm_inst(builder, opcode, args)
     return []
   }
-  register_wasm_validator(builder)
   builder.emit_multi_ext_inst(result_types, encode(opcode), args)
 }
 

--- a/modules/wasm_milkir/dialect.mbt
+++ b/modules/wasm_milkir/dialect.mbt
@@ -1,5 +1,6 @@
 ///|
-const WASM_DIALECT : String = "wasm"
+/// Serialized dialect name used by Wasm MilkIR extension operations.
+pub const WASM_DIALECT : String = "wasm"
 
 ///|
 fn imm(values : Array[Int]) -> FixedArray[Int] {
@@ -84,7 +85,8 @@ pub fn decode_error(ext : @milkir.ExtOp) -> String? {
 }
 
 ///|
-fn validate_instruction(view : @milkir.ExtensionInstView) -> String? {
+/// Validate one read-only Wasm extension instruction at an adapter seam.
+pub fn validate_extension(view : @milkir.ExtensionInstView) -> String? {
   let opcode = match decode_result(view.op) {
     Ok(opcode) => opcode
     Err(message) => return Some(message)
@@ -112,14 +114,7 @@ fn validate_instruction(view : @milkir.ExtensionInstView) -> String? {
 pub fn verify_function(
   func : @milkir.Function,
 ) -> Unit raise @milkir.VerifyError {
-  func.verify_with_extension_validator(validate_instruction)
-}
-
-///|
-fn register_wasm_validator(builder : @milkir.FunctionBuilder) -> Unit {
-  builder
-  .get_function()
-  .register_extension_validator(WASM_DIALECT, validate_instruction)
+  func.verify_with_extension_validator(WASM_DIALECT, validate_extension)
 }
 
 ///|

--- a/modules/wasm_milkir/dialect_schema_wbtest.mbt
+++ b/modules/wasm_milkir/dialect_schema_wbtest.mbt
@@ -82,13 +82,12 @@ test "every schema row enforces its non-contextual minimum shape" {
     let builder = @milkir.FunctionBuilder::FunctionBuilder(
       "schema_contract_\{spec.wire_name}",
     )
-    get_exception_tag(builder) |> ignore
     builder.emit_void_ext_inst(
       ExtOp(WASM_DIALECT, spec.wire_name, valid_immediates(spec)),
       [],
     )
     builder.return_([])
-    try builder.finalize() catch {
+    try verify_function(builder.get_function()) catch {
       _ => rejected.push(spec.wire_name)
     } noraise {
       _ => ()
@@ -148,20 +147,18 @@ test "every schema row enforces its non-contextual minimum shape" {
 test "immediate-dependent operand counts are enforced" {
   let rejected : Array[@milkir.VerifyError] = []
   let fixed = @milkir.FunctionBuilder::FunctionBuilder("array_new_fixed_count")
-  get_exception_tag(fixed) |> ignore
   fixed.emit_ext_inst(Ref, encode(ArrayNewFixed(0, 2)), []) |> ignore
   fixed.return_([])
-  try fixed.finalize() catch {
+  try verify_function(fixed.get_function()) catch {
     err => rejected.push(err)
   } noraise {
     _ => fail("expected array.new_fixed count mismatch to be rejected")
   }
 
   let spill = @milkir.FunctionBuilder::FunctionBuilder("spill_local_count")
-  get_exception_tag(spill) |> ignore
   spill.emit_void_ext_inst(encode(SpillLocalsForThrow(2)), [])
   spill.return_([])
-  try spill.finalize() catch {
+  try verify_function(spill.get_function()) catch {
     err => rejected.push(err)
   } noraise {
     _ => fail("expected spill-locals count mismatch to be rejected")

--- a/modules/wasm_milkir/dialect_test.mbt
+++ b/modules/wasm_milkir/dialect_test.mbt
@@ -38,12 +38,11 @@ test "Wasm extension decode reports unknown opcodes" {
 }
 
 ///|
-test "Wasm dialect validation rejects unknown opcodes during finalize" {
+test "Wasm adapter validation rejects unknown opcodes" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder("unknown_wasm_opcode")
-  get_exception_tag(builder) |> ignore
   builder.emit_void_ext_inst(ExtOp("wasm", "typo", []), [])
   builder.return_([])
-  try builder.finalize() catch {
+  try verify_function(builder.get_function()) catch {
     err =>
       inspect(
         err,
@@ -52,8 +51,16 @@ test "Wasm dialect validation rejects unknown opcodes during finalize" {
         ),
       )
   } noraise {
-    _ => fail("expected finalize to reject the unknown Wasm opcode")
+    _ => fail("expected Wasm validation to reject the unknown opcode")
   }
+}
+
+///|
+test "Wasm adapter validation accepts legal IR without producer metadata" {
+  let builder = @milkir.FunctionBuilder::FunctionBuilder("legal_wasm_opcode")
+  builder.emit_ext_inst(I32, encode(GetExceptionTag), []) |> ignore
+  builder.return_([])
+  verify_function(builder.get_function())
 }
 
 ///|
@@ -72,11 +79,10 @@ test "Wasm extension decode validates bool immediates" {
 }
 
 ///|
-test "Wasm dialect validation rejects malformed immediates during finalize" {
+test "Wasm adapter validation rejects malformed immediates" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder(
     "malformed_wasm_opcode",
   )
-  get_exception_tag(builder) |> ignore
   builder.emit_void_ext_inst(
     ExtOp(
       "wasm",
@@ -86,7 +92,7 @@ test "Wasm dialect validation rejects malformed immediates during finalize" {
     [],
   )
   builder.return_([])
-  try builder.finalize() catch {
+  try verify_function(builder.get_function()) catch {
     err =>
       inspect(
         err,
@@ -95,7 +101,7 @@ test "Wasm dialect validation rejects malformed immediates during finalize" {
         ),
       )
   } noraise {
-    _ => fail("expected finalize to reject malformed Wasm immediates")
+    _ => fail("expected Wasm validation to reject malformed immediates")
   }
 }
 
@@ -104,10 +110,9 @@ test "Wasm dialect validation rejects missing fixed results" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder(
     "missing_wasm_extension_result",
   )
-  get_exception_tag(builder) |> ignore
   builder.emit_void_ext_inst(encode(GetExceptionTag), [])
   builder.return_([])
-  try builder.finalize() catch {
+  try verify_function(builder.get_function()) catch {
     err =>
       inspect(
         err,
@@ -116,7 +121,7 @@ test "Wasm dialect validation rejects missing fixed results" {
         ),
       )
   } noraise {
-    _ => fail("expected finalize to reject a missing Wasm extension result")
+    _ => fail("expected Wasm validation to reject a missing extension result")
   }
 }
 
@@ -125,10 +130,9 @@ test "Wasm dialect validation rejects invalid fixed operand shapes" {
   let builder = @milkir.FunctionBuilder::FunctionBuilder(
     "invalid_wasm_extension_operands",
   )
-  get_exception_tag(builder) |> ignore
   builder.emit_ext_inst(I32, encode(RefEq), []) |> ignore
   builder.return_([])
-  try builder.finalize() catch {
+  try verify_function(builder.get_function()) catch {
     err =>
       inspect(
         err,
@@ -137,7 +141,7 @@ test "Wasm dialect validation rejects invalid fixed operand shapes" {
         ),
       )
   } noraise {
-    _ => fail("expected finalize to reject invalid Wasm extension operands")
+    _ => fail("expected Wasm validation to reject invalid extension operands")
   }
 }
 
@@ -147,13 +151,12 @@ test "Wasm dialect validation rejects fixed operand and result types" {
   let bad_result = @milkir.FunctionBuilder::FunctionBuilder(
     "invalid_wasm_extension_result_type",
   )
-  get_exception_tag(bad_result) |> ignore
   bad_result.emit_ext_inst(F64, encode(GetExceptionTag), []) |> ignore
   bad_result.return_([])
-  try bad_result.finalize() catch {
+  try verify_function(bad_result.get_function()) catch {
     err => rejected.push(err)
   } noraise {
-    _ => fail("expected finalize to reject a wrong Wasm extension result type")
+    _ => fail("expected Wasm validation to reject the wrong extension result")
   }
 
   let bad_operands = @milkir.FunctionBuilder::FunctionBuilder(
@@ -161,13 +164,12 @@ test "Wasm dialect validation rejects fixed operand and result types" {
   )
   let lhs = bad_operands.add_param(I32)
   let rhs = bad_operands.add_param(I32)
-  get_exception_tag(bad_operands) |> ignore
   bad_operands.emit_ext_inst(I32, encode(RefEq), [lhs, rhs]) |> ignore
   bad_operands.return_([])
-  try bad_operands.finalize() catch {
+  try verify_function(bad_operands.get_function()) catch {
     err => rejected.push(err)
   } noraise {
-    _ => fail("expected finalize to reject wrong Wasm extension operand types")
+    _ => fail("expected Wasm validation to reject wrong extension operands")
   }
   debug_inspect(
     rejected,
@@ -209,7 +211,6 @@ fn packed_get_verify_error(
   )
   let ref_value = builder.add_param(Ref)
   let index = builder.add_param(I32)
-  get_exception_tag(builder) |> ignore
   let immediates = match probe {
     StructGetSigned | StructGetUnsigned =>
       FixedArray::makei(3, fn(i) { if i == 2 { byte_width } else { 0 } })
@@ -227,7 +228,7 @@ fn packed_get_verify_error(
   )
   |> ignore
   builder.return_([])
-  try builder.finalize() catch {
+  try verify_function(builder.get_function()) catch {
     err => err
   } noraise {
     _ => abort("expected \{probe.wire_name()} verification to fail")
@@ -297,7 +298,7 @@ test "Wasm call_indirect accepts a table64 index" {
   let callee = builder.add_param(I64)
   call_indirect_multi(builder, 0, 0, [], callee, []) |> ignore
   builder.return_([])
-  builder.finalize() |> ignore
+  verify_function(builder.get_function())
 }
 
 ///|
@@ -308,7 +309,7 @@ test "Wasm return_call_indirect accepts a table64 index" {
   let callee = builder.add_param(I64)
   return_call_indirect_multi(builder, 0, 0, callee, [])
   builder.trap("unreachable after return_call_indirect")
-  builder.finalize() |> ignore
+  verify_function(builder.get_function())
 }
 
 ///|
@@ -320,7 +321,7 @@ test "Wasm indirect calls reject non-integer table indices" {
   let call_callee = call.add_param(F64)
   call_indirect_multi(call, 0, 0, [], call_callee, []) |> ignore
   call.return_([])
-  try call.finalize() catch {
+  try verify_function(call.get_function()) catch {
     err => rejected.push(err)
   } noraise {
     _ => fail("expected call_indirect to reject an f64 table index")
@@ -332,7 +333,7 @@ test "Wasm indirect calls reject non-integer table indices" {
   let return_callee = return_call.add_param(F64)
   return_call_indirect_multi(return_call, 0, 0, return_callee, [])
   return_call.trap("unreachable after return_call_indirect")
-  try return_call.finalize() catch {
+  try verify_function(return_call.get_function()) catch {
     err => rejected.push(err)
   } noraise {
     _ => fail("expected return_call_indirect to reject an f64 table index")

--- a/modules/wasm_milkir/pkg.generated.mbti
+++ b/modules/wasm_milkir/pkg.generated.mbti
@@ -13,6 +13,8 @@ pub const FUNCREF_TAG : Int64 = 0x2000000000000000
 
 pub const NULL_REF : Int64 = 0
 
+pub const WASM_DIALECT : String = "wasm"
+
 pub fn any_convert_extern(@milkir.FunctionBuilder, @milkir.Value) -> @milkir.Value
 
 pub fn array_copy(@milkir.FunctionBuilder, Int, Int, @milkir.Value, @milkir.Value, @milkir.Value, @milkir.Value, @milkir.Value) -> Unit
@@ -138,6 +140,8 @@ pub fn table_init(@milkir.FunctionBuilder, RuntimeSymbols, @milkir.Value, Int, I
 pub fn try_table_begin(@milkir.FunctionBuilder, Int) -> @milkir.Value
 
 pub fn try_table_end(@milkir.FunctionBuilder, Int) -> Unit
+
+pub fn validate_extension(@milkir.ExtensionInstView) -> String?
 
 pub fn verify_function(@milkir.Function) -> Unit raise @milkir.VerifyError
 

--- a/modules/wasmoon/wasm_frontend/wasm_frontend_test.mbt
+++ b/modules/wasmoon/wasm_frontend/wasm_frontend_test.mbt
@@ -30,7 +30,7 @@ test "lower empty wasm function through embedding environment" {
   inspect(func.signature().params.length(), content="1")
   inspect(func.signature().results.length(), content="0")
   inspect(func.blocks.length(), content="1")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -49,7 +49,7 @@ test "lower simple wasm body into MilkIR operations" {
   inspect(func.print().contains("iadd"), content="true")
   inspect(func.print().contains("ireduce"), content="true")
   inspect(func.print().contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -73,7 +73,7 @@ test "lower locals through native linear fast path" {
   inspect(text.contains("iadd"), content="true")
   inspect(text.contains("imul"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -89,7 +89,7 @@ test "lower nop and float locals through native linear fast path" {
   inspect(text.contains("fconst"), content="true")
   inspect(text.contains("fadd"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -106,7 +106,7 @@ test "lower branchless blocks through native linear fast path" {
   inspect(func.blocks.length(), content="1")
   inspect(text.contains("iadd"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -123,7 +123,7 @@ test "lower branchless loop through native linear fast path" {
   inspect(func.blocks.length(), content="1")
   inspect(text.contains("iadd"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -168,14 +168,14 @@ test "top-level frontend lowers structured if through production translator" {
   )
   let func = translate_function(native_test_env(), mod_, 0)
   inspect(func.blocks.length() > 1, content="true")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
 test "return_call terminates the translated MilkIR block" {
   let mod_ = @types.Module::simple([], [], [ReturnCall(0)], "tail_recursive")
   let func = translate_function(native_test_env(), mod_, 0)
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -189,7 +189,7 @@ test "unreachable structured continuations remain verifier-safe" {
   for i, body in bodies {
     let mod_ = @types.Module::simple([], [], body, "unreachable_control_\{i}")
     let func = translate_function(native_test_env(), mod_, 0)
-    inspect(func.verify(), content="()")
+    @wasm_milkir.verify_function(func)
   }
 }
 
@@ -208,7 +208,7 @@ test "lower direct block branch through native linear fast path" {
   inspect(text.contains("iconst 7"), content="true")
   inspect(text.contains("iconst 9"), content="false")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -237,7 +237,7 @@ test "lower terminal block br_if through native linear fast path" {
   inspect(func.blocks.length(), content="1")
   inspect(text.contains("iconst 7"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -254,7 +254,7 @@ test "lower terminal current-block br_table through native linear fast path" {
   inspect(func.blocks.length(), content="1")
   inspect(text.contains("iconst 7"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -295,7 +295,7 @@ test "lower empty if through native linear fast path" {
   let text = func.print()
   inspect(text.contains("iconst 7"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -311,7 +311,7 @@ test "lower nop-only if through native linear fast path" {
   let text = func.print()
   inspect(text.contains("iconst 9"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -337,7 +337,7 @@ test "lower globals through native VMContext loads and stores" {
   inspect(text.contains("store.i32"), content="true")
   inspect(text.contains("load.i32"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -366,7 +366,7 @@ test "lower table size and get through native VMContext loads" {
   inspect(text.contains("ireduce"), content="true")
   inspect(text.contains("trap \"table out of bounds\""), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -389,14 +389,14 @@ test "production table.get preserves the table element carrier" {
     tables: [table],
   }
   let func = translate_function(native_test_env(), mod_, 0)
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
   let imported = {
     ..mod_,
     imports: [{ mod_name: "host", name: "table", desc: Table(table.type_) }],
     tables: [],
   }
   let imported_func = translate_function(native_test_env(), imported, 0)
-  inspect(imported_func.verify(), content="()")
+  @wasm_milkir.verify_function(imported_func)
 }
 
 ///|
@@ -424,7 +424,7 @@ test "lower table set through native table fill runtime call" {
   inspect(text.contains("wasmoon.TableFill"), content="false")
   inspect(text.contains("call wasmoon.runtime.table_fill"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -441,7 +441,7 @@ test "lower linear explicit return without legacy bridge" {
   inspect(func.blocks.length(), content="1")
   inspect(text.contains("iadd"), content="true")
   inspect(text.contains("return"), content="true")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -458,7 +458,7 @@ test "lower return with dead tail without legacy bridge" {
   inspect(text.contains("return"), content="true")
   inspect(text.contains("iadd"), content="false")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -474,7 +474,7 @@ test "lower linear float arithmetic and drop without legacy bridge" {
   let text = func.print()
   inspect(func.blocks.length(), content="1")
   inspect(text.contains("fsub"), content="true")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -518,7 +518,7 @@ test "lower linear integer bitops comparisons and select natively" {
   inspect(text.contains("ishl"), content="true")
   inspect(text.contains("icmp.eq"), content="true")
   inspect(text.contains("select"), content="true")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -536,7 +536,7 @@ test "lower linear float compare and unary ops natively" {
   inspect(text.contains("fabs"), content="true")
   inspect(text.contains("fceil"), content="true")
   inspect(text.contains("fcmp.ge"), content="true")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -553,7 +553,7 @@ test "lower linear integer extensions and reduction natively" {
   inspect(text.contains("ireduce"), content="true")
   inspect(text.contains("sextend8"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -570,7 +570,7 @@ test "lower linear i64 extensions natively" {
   inspect(text.contains("uextend"), content="true")
   inspect(text.contains("sextend32"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -587,7 +587,7 @@ test "lower linear float promotion and demotion natively" {
   inspect(text.contains("fdemote"), content="true")
   inspect(text.contains("fpromote"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -604,7 +604,7 @@ test "lower linear numeric conversions natively" {
   inspect(text.contains("fcvt_to_sint"), content="true")
   inspect(text.contains("uint_to_fcvt"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -621,7 +621,7 @@ test "lower linear saturating conversion and reinterpret natively" {
   inspect(text.contains("fcvt_to_uint_sat"), content="true")
   inspect(text.contains("bitcast"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -638,7 +638,7 @@ test "lower pure if into native MilkIR select" {
   inspect(func.blocks.length(), content="1")
   inspect(text.contains("select"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -664,7 +664,7 @@ test "lower pure if expression bodies into native MilkIR select" {
   inspect(text.contains("ishl"), content="true")
   inspect(text.contains("select"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -705,8 +705,8 @@ test "lower pure if copysign and wide multiply expression bodies" {
   inspect(wide_func.print().contains("smulh"), content="true")
   inspect(wide_func.print().contains("select"), content="true")
   inspect(wide_func.print().contains("TODO(wasm_frontend)"), content="false")
-  inspect(float_func.verify(), content="()")
-  inspect(wide_func.verify(), content="()")
+  @wasm_milkir.verify_function(float_func)
+  @wasm_milkir.verify_function(wide_func)
 }
 
 ///|
@@ -717,7 +717,7 @@ test "lower trap without wasm_frontend skeleton fallback" {
   let text = func.print()
   inspect(text.contains("unreachable"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -756,7 +756,7 @@ test "lower direct calls as generic MilkIR calls" {
   let text = func.print()
   inspect(text.contains("call_ptr(3) -> 1"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -786,7 +786,7 @@ test "lower memory operations through native MilkIR memory ops" {
   inspect(text.contains("load.i32"), content="true")
   inspect(text.contains("store.i32"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -811,7 +811,7 @@ test "lower copysign through native MilkIR bit operations" {
   inspect(text.contains("band"), content="true")
   inspect(text.contains("bor"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -835,7 +835,7 @@ test "lower wide i64 multiply through native MilkIR high-half ops" {
   inspect(text.contains("umulh"), content="true")
   inspect(text.contains("smulh"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -865,7 +865,7 @@ test "lower narrow memory operations through native MilkIR memory ops" {
   inspect(text.contains("store16"), content="true")
   inspect(text.contains("load8_s.i32"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -915,7 +915,7 @@ test "lower memory grow size and bulk helpers as native helper calls" {
   inspect(text.contains("call wasmoon.runtime.memory_init"), content="true")
   inspect(text.contains("call wasmoon.runtime.data_drop"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -934,7 +934,7 @@ test "lower non-zero memory.size through native descriptor loads" {
   inspect(text.contains("load.i64"), content="true")
   inspect(text.contains("ushr"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -965,7 +965,7 @@ test "lower non-zero memory load store with explicit bounds check" {
   inspect(text.contains("load.i32"), content="true")
   inspect(text.contains("store.i32"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -992,7 +992,7 @@ test "lower memory64 load with overflow-safe bounds check" {
   inspect(text.contains("icmp.uge"), content="true")
   inspect(text.contains("icmp.ule"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -1025,7 +1025,7 @@ test "lower memory64 narrow load store with overflow-safe bounds check" {
   inspect(text.contains("load8_u.i32"), content="true")
   inspect(text.contains("store8"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -1050,7 +1050,7 @@ test "lower v128 load store through native memory path" {
   inspect(text.contains("store.v128"), content="true")
   inspect(text.contains("wasmoon.LoadMemBase"), content="false")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -1105,7 +1105,7 @@ test "lower table bulk helpers as native helper calls" {
   inspect(text.contains("call wasmoon.runtime.table_init"), content="true")
   inspect(text.contains("call wasmoon.runtime.elem_drop"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -1122,7 +1122,7 @@ test "lower reference null and is_null natively" {
   inspect(text.contains("iconst"), content="true")
   inspect(text.contains("icmp.eq"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -1142,7 +1142,7 @@ test "lower reference func non-null and eq natively" {
   inspect(text.contains("trap \"null reference\""), content="true")
   inspect(text.contains("icmp.eq"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -1160,7 +1160,7 @@ test "lower i31 refs through native linear fast path" {
   inspect(text.contains("uextend"), content="true")
   inspect(text.contains("trap \"null i31 reference\""), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|
@@ -1176,7 +1176,7 @@ test "lower ref conversion copies through native linear fast path" {
   let text = func.print()
   inspect(text.contains("copy"), content="true")
   inspect(text.contains("TODO(wasm_frontend)"), content="false")
-  inspect(func.verify(), content="()")
+  @wasm_milkir.verify_function(func)
 }
 
 ///|


### PR DESCRIPTION
## What

- Remove extension validator closures from MilkIR `Function` data.
- Require dialect adapters to pass their dialect name and validator explicitly at verification and lowering seams.
- Remove the ineffective extension-lowerer field and builder method from `LoweringConfig`; pass the lowerer only through dialect lowering APIs.
- Update the Wasm adapter, tests, generated interfaces, and documentation for the explicit adapter contract.

## Why

Validation and lowering behavior previously depended on function construction history. A producer could register a validator that later overrode the trusted adapter's behavior, and `LoweringConfig::with_extension_lowerer` exposed a path that core lowering rejected while dialect lowering replaced it internally.

## Impact

MilkIR functions are plain IR data again: generic verification checks core structure, while dialect semantics are owned by the consuming adapter. This changes the public dialect verification and lowering APIs so callers must supply the dialect validator explicitly.

## Checks

- `moon check --deny-warn --warn-list '+73'`
- `moon test --deny-warn --warn-list '+73'` (573 wasm-gc tests, 1329 native tests)
- `python3 scripts/audit_module_boundaries.py`
- `git diff --check`
