### PR TITLE
feat: verify MachV at compiler boundaries

### DIFF
--- a/modules/aarch64_target/aarch64_target_test.mbt
+++ b/modules/aarch64_target/aarch64_target_test.mbt
@@ -62,7 +62,7 @@ test "AArch64 wrapper accepts an explicit call convention" {
     custom_test_call_conv(),
   )
   inspect(lowered.params.length(), content="2")
-  inspect(lowered.results.length(), content="1")
+  inspect(lowered.result_kinds.length(), content="1")
 }
 
 ///|

--- a/modules/machv/README.mbt.md
+++ b/modules/machv/README.mbt.md
@@ -44,7 +44,7 @@ test "build a 64-bit add function" {
   inspect(
     func.print(),
     content=(
-      #|machv add64(v0:int, v1:int) {
+      #|machv add64(v0:int, v1:int) -> int {
       #|block0:
       #|    v2 = add v0, v1
       #|    ret v2
@@ -59,10 +59,10 @@ test "build a 64-bit add function" {
 Read the generated MachV from top to bottom:
 
 ```text
-machv add64(v0:int, v1:int) {  two integer-register parameters
-block0:                        execution starts in block0
-    v2 = add v0, v1           read v0 and v1, then define v2
-    ret v2                     return the value in v2
+machv add64(v0:int, v1:int) -> int {  two integer-register parameters and one result
+block0:                               execution starts in block0
+    v2 = add v0, v1                  read v0 and v1, then define v2
+    ret v2                            return the value in v2
 }
 ```
 
@@ -140,7 +140,7 @@ The order of `uses` and `defs` follows the operand contract of the opcode. For e
 ```text
 Add(true)     uses [lhs, rhs]       defs [result]
 Load(I64, 8)  uses [base]           defs [loaded]
-Store(I64, 8) uses [value, base]    defs []
+Store(I64, 8) uses [base, value]    defs []
 Move          uses [source]         defs [destination]
 ```
 
@@ -155,6 +155,7 @@ Most operands use `Any`, allowing register allocation to choose a location. `Fix
 test "attach a fixed-register constraint" {
   let builder = FunctionBuilder::FunctionBuilder("fixed_result")
   let src = builder.add_param(Int)
+  builder.add_result(I64)
   let dst = builder.new_vreg(Int)
   let required : PReg = { index: 1, class: Int }
 
@@ -217,6 +218,12 @@ The main terminators are:
 
 Every block passed to register allocation or emission needs a terminator.
 
+## Verification boundaries
+
+`Function::verify()` checks the target-independent MachV contract: CFG targets and edge arguments, function returns, constraint-array alignment, exhaustive opcode operand contracts, virtual-register definition uniqueness, use-before-definition, and dominance. `Function::verify_for_isa(isa)` additionally rejects physical registers that are illegal for the selected target. Register allocation uses `verify_for_regalloc_isa(isa)`, which also requires dense block IDs because its tables address blocks by numeric ID.
+
+`FunctionBuilder::finish()` calls `verify()` before returning. The lowering, register-allocation, and emission seams verify again because `Function`, `Block`, and `Inst` expose mutable arrays; callers may legally transform a function after construction, but they cannot bypass validation before a backend consumer processes it. Failures are returned as structured `VerifyError` values.
+
 ## Calls, ABI data, and stack state
 
 MachV records the machine-level information needed around calls:
@@ -231,7 +238,7 @@ Call targets can remain symbolic through MachV and machine-code emission. The em
 
 ## Construction rules
 
-`FunctionBuilder` records the instruction shape supplied by the caller; it does not infer an opcode's operands. A lowering implementation should maintain these rules:
+`FunctionBuilder` records the instruction shape supplied by the caller; it does not infer an opcode's operands. `finish()` verifies that shape. A lowering implementation should maintain these rules:
 
 1. Give every block exactly one terminator.
 2. Supply `uses` and `defs` in the order required by the opcode.
@@ -239,7 +246,7 @@ Call targets can remain symbolic through MachV and machine-code emission. The em
 4. Keep constraint arrays aligned with their corresponding operands.
 5. Use `Function::print()` in lowering tests so instruction and control-flow mistakes are easy to inspect.
 
-Downstream register-allocation and emission tests provide the strongest end-to-end check that a constructed function satisfies the selected target's requirements.
+Call `verify()` after target-independent transformations and `verify_for_isa(isa)` when physical registers or fixed constraints are present. Register allocation and emission also enforce these checks at their public entry points.
 
 ## Packages
 

--- a/modules/machv/builder.mbt
+++ b/modules/machv/builder.mbt
@@ -97,7 +97,10 @@ pub fn FunctionBuilder::terminate(
 }
 
 ///|
-pub fn FunctionBuilder::finish(self : FunctionBuilder) -> Function {
+pub fn FunctionBuilder::finish(
+  self : FunctionBuilder,
+) -> Function raise VerifyError {
+  self.func.verify()
   self.func
 }
 

--- a/modules/machv/machine_function.mbt
+++ b/modules/machv/machine_function.mbt
@@ -15,11 +15,20 @@ pub(all) enum ValueKind {
 } derive(Eq, Debug)
 
 ///|
+pub fn ValueKind::reg_class(self : ValueKind) -> @abi.RegClass {
+  match self {
+    I32 | I64 | Ptr => Int
+    F32 => Float32
+    F64 => Float64
+    V128 => Vector
+  }
+}
+
+///|
 /// MachV function - a complete machine-level function in virtual-register form.
 pub struct Function {
   name : String
   params : Array[@abi.VReg] // Function parameters
-  results : Array[@abi.RegClass] // Result types (for return value allocation)
   result_kinds : Array[ValueKind] // Full return kind info for multi-value returns
   blocks : Array[@block.Block]
   mut next_vreg_id : Int
@@ -76,7 +85,6 @@ pub fn Function::Function(name : String) -> Function {
   {
     name,
     params: [],
-    results: [],
     result_kinds: [],
     blocks: [],
     next_vreg_id: 0,
@@ -92,13 +100,12 @@ pub fn Function::Function(name : String) -> Function {
 /// Clone the base structure of a function for regalloc transformations.
 /// Copies: name, next_vreg_id, int_stack_params, max_outgoing_args_size,
 /// uses_context_cache_0_source
-/// Empty: params, results, result_kinds, blocks, param_pregs
+/// Empty: params, result_kinds, blocks, param_pregs
 /// Zero: num_spill_slots
 pub fn Function::clone_base(self : Function) -> Function {
   {
     name: self.name,
     params: [],
-    results: [],
     result_kinds: [],
     blocks: [],
     next_vreg_id: self.next_vreg_id,
@@ -170,11 +177,6 @@ pub fn Function::add_param(self : Function, class : @abi.RegClass) -> @abi.VReg 
 }
 
 ///|
-pub fn Function::add_result(self : Function, class : @abi.RegClass) -> Unit {
-  self.results.push(class)
-}
-
-///|
 /// Add a result kind with full kind information for multi-value returns
 pub fn Function::add_result_kind(self : Function, ty : ValueKind) -> Unit {
   self.result_kinds.push(ty)
@@ -185,7 +187,7 @@ fn Function::result_counts(self : Function) -> (Int, Int) {
   let mut int_count = 0
   let mut float_count = 0
   for ty in self.result_kinds {
-    if ty is (I32 | I64) {
+    if ty is (I32 | I64 | Ptr) {
       int_count = int_count + 1
     } else if ty is (F32 | F64 | V128) {
       float_count = float_count + 1
@@ -303,17 +305,17 @@ pub fn Function::print(self : Function) -> String {
   }
   result = result + ")"
   // Results
-  if self.results.length() > 0 {
+  if self.result_kinds.length() > 0 {
     result = result + " -> "
-    if self.results.length() == 1 {
-      result = result + self.results[0].to_string()
+    if self.result_kinds.length() == 1 {
+      result = result + self.result_kinds[0].reg_class().to_string()
     } else {
       result = result + "("
-      for i, r in self.results {
+      for i, kind in self.result_kinds {
         if i > 0 {
           result = result + ", "
         }
-        result = result + r.to_string()
+        result = result + kind.reg_class().to_string()
       }
       result = result + ")"
     }

--- a/modules/machv/machv_test.mbt
+++ b/modules/machv/machv_test.mbt
@@ -2,6 +2,7 @@
 test "build simple MachV function with FunctionBuilder" {
   let builder = FunctionBuilder::FunctionBuilder("copy")
   let src = builder.add_param(Int)
+  builder.add_result(I64)
   let dst = builder.new_vreg(Int)
   builder.append(Move, uses=[Virtual(src)], defs=[{ reg: Virtual(dst) }])
   |> ignore
@@ -42,7 +43,7 @@ test "print canonical MachV function" {
   inspect(
     builder.finish().print(),
     content=(
-      #|machv printed(v0:int) {
+      #|machv printed(v0:int) -> int {
       #|block0:
       #|    v1 = mov v0
       #|    ret v1

--- a/modules/machv/moon.pkg
+++ b/modules/machv/moon.pkg
@@ -2,4 +2,5 @@ import {
   "Milky2018/machv/abi",
   "Milky2018/machv/block",
   "Milky2018/machv/instr",
+  "Milky2018/machv/isa",
 }

--- a/modules/machv/pkg.generated.mbti
+++ b/modules/machv/pkg.generated.mbti
@@ -5,18 +5,34 @@ import {
   "Milky2018/machv/abi",
   "Milky2018/machv/block",
   "Milky2018/machv/instr",
+  "Milky2018/machv/isa",
   "moonbitlang/core/debug",
 }
 
 // Values
 
 // Errors
+pub suberror VerifyError {
+  EmptyFunction
+  MissingTerminator(block_id~ : Int)
+  DuplicateBlockId(block_id~ : Int)
+  InvalidBlockLayout(block_id~ : Int, expected_index~ : Int)
+  InvalidBlockTarget(block_id~ : Int)
+  ArityMismatch(message~ : String)
+  RegisterClassMismatch(message~ : String)
+  DuplicateVRegDefinition(vreg_id~ : Int)
+  UndefinedVReg(vreg_id~ : Int)
+  UseBeforeDefinition(vreg_id~ : Int)
+  NonDominatingUse(vreg_id~ : Int, defining_block~ : Int, use_block~ : Int)
+  InvalidInstruction(message~ : String)
+} derive(Eq, @debug.Debug)
+pub fn VerifyError::invalid_instruction(String) -> Self
+pub impl Show for VerifyError
 
 // Types and methods
 pub struct Function {
   name : String
   params : Array[@abi.VReg]
-  results : Array[@abi.RegClass]
   result_kinds : Array[ValueKind]
   blocks : Array[@block.Block]
   mut next_vreg_id : Int
@@ -29,7 +45,6 @@ pub struct Function {
 pub fn Function::Function(String) -> Self
 pub fn Function::add_param(Self, @abi.RegClass) -> @abi.VReg
 pub fn Function::add_param_preg(Self, @abi.PReg?) -> Unit
-pub fn Function::add_result(Self, @abi.RegClass) -> Unit
 pub fn Function::add_result_kind(Self, ValueKind) -> Unit
 pub fn Function::blocks(Self) -> Array[@block.Block]
 pub fn Function::calls_multi_value_function_for_call_conv(Self, @abi.CallConventionLayout) -> Bool
@@ -56,6 +71,10 @@ pub fn Function::should_reserve_context_cache_1(Self) -> Bool
 pub fn Function::update_max_outgoing_args_size(Self, Int) -> Unit
 pub fn Function::uses_context_cache_0_source(Self) -> Bool
 pub fn Function::uses_context_cache_1(Self) -> Bool
+pub fn Function::verify(Self) -> Unit raise VerifyError
+pub fn Function::verify_for_isa(Self, @isa.ISA) -> Unit raise VerifyError
+pub fn Function::verify_for_regalloc(Self) -> Unit raise VerifyError
+pub fn Function::verify_for_regalloc_isa(Self, @isa.ISA) -> Unit raise VerifyError
 pub impl Show for Function
 
 pub struct FunctionBuilder {
@@ -67,7 +86,7 @@ pub fn FunctionBuilder::add_param(Self, @abi.RegClass) -> @abi.VReg
 pub fn FunctionBuilder::add_result(Self, ValueKind) -> Unit
 pub fn FunctionBuilder::append(Self, @instr.Opcode, uses? : Array[@abi.Reg], defs? : Array[@abi.Writable], use_constraints? : Array[@abi.OperandConstraint], def_constraints? : Array[@abi.OperandConstraint]) -> Int
 pub fn FunctionBuilder::create_block(Self) -> Int
-pub fn FunctionBuilder::finish(Self) -> Function
+pub fn FunctionBuilder::finish(Self) -> Function raise VerifyError
 pub fn FunctionBuilder::new_vreg(Self, @abi.RegClass) -> @abi.VReg
 pub fn FunctionBuilder::switch_to_block(Self, Int) -> Unit
 pub fn FunctionBuilder::terminate(Self, @instr.Terminator) -> Unit
@@ -80,6 +99,7 @@ pub(all) enum ValueKind {
   V128
   Ptr
 } derive(Eq, @debug.Debug)
+pub fn ValueKind::reg_class(Self) -> @abi.RegClass
 
 // Type aliases
 pub using @block {type Block}

--- a/modules/machv/verify.mbt
+++ b/modules/machv/verify.mbt
@@ -1,0 +1,707 @@
+///|
+pub suberror VerifyError {
+  EmptyFunction
+  MissingTerminator(block_id~ : Int)
+  DuplicateBlockId(block_id~ : Int)
+  InvalidBlockLayout(block_id~ : Int, expected_index~ : Int)
+  InvalidBlockTarget(block_id~ : Int)
+  ArityMismatch(message~ : String)
+  RegisterClassMismatch(message~ : String)
+  DuplicateVRegDefinition(vreg_id~ : Int)
+  UndefinedVReg(vreg_id~ : Int)
+  UseBeforeDefinition(vreg_id~ : Int)
+  NonDominatingUse(vreg_id~ : Int, defining_block~ : Int, use_block~ : Int)
+  InvalidInstruction(message~ : String)
+} derive(Debug, Eq)
+
+///|
+priv enum VRegDefinition {
+  FunctionParameter(@abi.RegClass)
+  BlockParameter(@abi.RegClass, Int, Int)
+  InstructionResult(@abi.RegClass, Int, Int, Int)
+}
+
+///|
+priv struct ControlFlowGraph {
+  preds : Array[Array[Int]]
+  succs : Array[Array[Int]]
+}
+
+///|
+pub impl Show for VerifyError with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+pub fn VerifyError::invalid_instruction(message : String) -> VerifyError {
+  InvalidInstruction(message~)
+}
+
+///|
+fn reg_class(reg : @abi.Reg) -> @abi.RegClass {
+  match reg {
+    Virtual(vreg) => vreg.class
+    Physical(preg) => preg.class
+  }
+}
+
+///|
+fn writable_reg_class(writable : @abi.Writable) -> @abi.RegClass {
+  reg_class(writable.reg)
+}
+
+///|
+fn require_target(
+  blocks : Map[Int, @block.Block],
+  id : Int,
+) -> @block.Block raise VerifyError {
+  match blocks.get(id) {
+    Some(block) => block
+    None => raise InvalidBlockTarget(block_id=id)
+  }
+}
+
+///|
+fn require_same_class(
+  actual : @abi.RegClass,
+  expected : @abi.RegClass,
+  message : String,
+) -> Unit raise VerifyError {
+  if actual != expected {
+    raise RegisterClassMismatch(
+      message="\{message} has class \{actual}, expected \{expected}",
+    )
+  }
+}
+
+///|
+fn require_target_without_args(
+  blocks : Map[Int, @block.Block],
+  source_id : Int,
+  target_id : Int,
+) -> Unit raise VerifyError {
+  let target = require_target(blocks, target_id)
+  if !target.params.is_empty() {
+    raise ArityMismatch(
+      message="branch from block \{source_id} cannot pass \{target.params.length()} arguments required by block \{target_id}",
+    )
+  }
+}
+
+///|
+fn terminator_target_ids(term : @instr.Terminator) -> Array[Int] {
+  match term {
+    Jump(target, _) => [target]
+    Branch(_, then_id, else_id)
+    | BranchCmp(_, _, _, _, then_id, else_id)
+    | BranchZero(_, _, _, then_id, else_id)
+    | BranchCmpImm(_, _, _, _, then_id, else_id) => [then_id, else_id]
+    BrTable(_, targets, default_id) => {
+      let result = targets.copy()
+      result.push(default_id)
+      result
+    }
+    Return(_) | Trap(_) => []
+  }
+}
+
+///|
+fn ControlFlowGraph::build(func : Function) -> ControlFlowGraph {
+  let preds : Array[Array[Int]] = []
+  let succs : Array[Array[Int]] = []
+  for _ in func.blocks {
+    preds.push([])
+    succs.push([])
+  }
+  let block_indices : Map[Int, Int] = Map([])
+  for i, block in func.blocks {
+    block_indices.set(block.id, i)
+  }
+  for block_index, block in func.blocks {
+    if block.terminator is Some(term) {
+      for target_id in terminator_target_ids(term) {
+        if block_indices.get(target_id) is Some(target_index) {
+          succs[block_index].push(target_index)
+          preds[target_index].push(block_index)
+        }
+      }
+    }
+  }
+  { preds, succs }
+}
+
+///|
+fn ControlFlowGraph::postorder(self : ControlFlowGraph) -> Array[Int] {
+  let visited = Array::make(self.succs.length(), false)
+  let result : Array[Int] = []
+  if !self.succs.is_empty() {
+    let stack : Array[(Int, Int)] = [(0, 0)]
+    visited[0] = true
+    while !stack.is_empty() {
+      let top = stack.length() - 1
+      let (block, successor_index) = stack[top]
+      if successor_index < self.succs[block].length() {
+        stack[top] = (block, successor_index + 1)
+        let successor = self.succs[block][successor_index]
+        if !visited[successor] {
+          visited[successor] = true
+          stack.push((successor, 0))
+        }
+      } else {
+        stack.pop() |> ignore
+        result.push(block)
+      }
+    }
+  }
+  result
+}
+
+///|
+fn intersect_dominators(
+  idom : Array[Int],
+  rpo_number : Array[Int],
+  first_init : Int,
+  second_init : Int,
+) -> Int {
+  let mut first = first_init
+  let mut second = second_init
+  while first != second {
+    while rpo_number[first] > rpo_number[second] {
+      first = idom[first]
+    }
+    while rpo_number[second] > rpo_number[first] {
+      second = idom[second]
+    }
+  }
+  first
+}
+
+///|
+fn ControlFlowGraph::compute_dominators(self : ControlFlowGraph) -> Array[Int] {
+  let count = self.succs.length()
+  let idom = Array::make(count, -1)
+  if count == 0 {
+    return idom
+  }
+  idom[0] = 0
+  let rpo = self.postorder()
+  rpo.rev_in_place()
+  let rpo_number = Array::make(count, -1)
+  for i, block in rpo {
+    rpo_number[block] = i
+  }
+  let mut changed = true
+  while changed {
+    changed = false
+    for block in rpo {
+      if block == 0 {
+        continue
+      }
+      let mut new_idom = -1
+      for predecessor in self.preds[block] {
+        if idom[predecessor] != -1 {
+          new_idom = if new_idom == -1 {
+            predecessor
+          } else {
+            intersect_dominators(idom, rpo_number, new_idom, predecessor)
+          }
+        }
+      }
+      if new_idom != -1 && idom[block] != new_idom {
+        idom[block] = new_idom
+        changed = true
+      }
+    }
+  }
+  idom
+}
+
+///|
+fn dominates(idom : Array[Int], defining_block : Int, use_block : Int) -> Bool {
+  if defining_block == use_block {
+    return true
+  }
+  let mut current = use_block
+  while current != -1 && current != 0 {
+    current = idom[current]
+    if current == defining_block {
+      return true
+    }
+  }
+  defining_block == 0 && current == 0
+}
+
+///|
+fn record_definition(
+  vreg : @abi.VReg,
+  definition : VRegDefinition,
+  definitions : Array[VRegDefinition?],
+) -> Unit raise VerifyError {
+  if vreg.id < 0 || vreg.id >= definitions.length() {
+    raise InvalidInstruction(
+      message="definition uses virtual register id \{vreg.id} outside the function register range",
+    )
+  }
+  if definitions[vreg.id] is Some(_) {
+    raise DuplicateVRegDefinition(vreg_id=vreg.id)
+  }
+  definitions[vreg.id] = Some(definition)
+}
+
+///|
+fn definition_class(definition : VRegDefinition) -> @abi.RegClass {
+  match definition {
+    FunctionParameter(class)
+    | BlockParameter(class, _, _)
+    | InstructionResult(class, _, _, _) => class
+  }
+}
+
+///|
+fn verify_virtual_use(
+  vreg : @abi.VReg,
+  definitions : Array[VRegDefinition?],
+  use_block_index : Int,
+  use_block_id : Int,
+  use_position : Int,
+  idom : Array[Int],
+) -> Unit raise VerifyError {
+  if vreg.id < 0 || vreg.id >= definitions.length() {
+    raise UndefinedVReg(vreg_id=vreg.id)
+  }
+  match definitions[vreg.id] {
+    None => raise UndefinedVReg(vreg_id=vreg.id)
+    Some(definition) => {
+      require_same_class(
+        vreg.class,
+        definition_class(definition),
+        "virtual register \{vreg.id}",
+      )
+      match definition {
+        FunctionParameter(_) => ()
+        BlockParameter(_, defining_index, defining_id) =>
+          if !dominates(idom, defining_index, use_block_index) {
+            raise NonDominatingUse(
+              vreg_id=vreg.id,
+              defining_block=defining_id,
+              use_block=use_block_id,
+            )
+          }
+        InstructionResult(_, defining_index, defining_id, defining_position) =>
+          if defining_index == use_block_index {
+            if defining_position >= use_position {
+              raise UseBeforeDefinition(vreg_id=vreg.id)
+            }
+          } else if !dominates(idom, defining_index, use_block_index) {
+            raise NonDominatingUse(
+              vreg_id=vreg.id,
+              defining_block=defining_id,
+              use_block=use_block_id,
+            )
+          }
+      }
+    }
+  }
+}
+
+///|
+fn verify_reg_use(
+  reg : @abi.Reg,
+  definitions : Array[VRegDefinition?],
+  use_block_index : Int,
+  use_block_id : Int,
+  use_position : Int,
+  idom : Array[Int],
+) -> Unit raise VerifyError {
+  if reg is Virtual(vreg) {
+    verify_virtual_use(
+      vreg, definitions, use_block_index, use_block_id, use_position, idom,
+    )
+  }
+}
+
+///|
+fn verify_constraint(
+  reg : @abi.Reg,
+  constraint : @abi.OperandConstraint,
+  message : String,
+) -> Unit raise VerifyError {
+  if constraint is FixedReg(preg) {
+    require_same_class(reg_class(reg), preg.class, message)
+  }
+}
+
+///|
+fn verify_inst_structure(
+  inst : @instr.Inst,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  if inst.uses.length() != inst.use_constraints.length() {
+    raise InvalidInstruction(
+      message="instruction \{inst_index} in block \{block_id} has \{inst.uses.length()} uses but \{inst.use_constraints.length()} use constraints",
+    )
+  }
+  if inst.defs.length() != inst.def_constraints.length() {
+    raise InvalidInstruction(
+      message="instruction \{inst_index} in block \{block_id} has \{inst.defs.length()} defs but \{inst.def_constraints.length()} def constraints",
+    )
+  }
+  for i, reg in inst.uses {
+    verify_constraint(
+      reg,
+      inst.use_constraints[i],
+      "use constraint \{i} in block \{block_id}",
+    )
+  }
+  for i, writable in inst.defs {
+    verify_constraint(
+      writable.reg,
+      inst.def_constraints[i],
+      "def constraint \{i} in block \{block_id}",
+    )
+  }
+  verify_opcode_contract(inst, block_id, inst_index)
+}
+
+///|
+fn verify_terminator_uses(
+  term : @instr.Terminator,
+  definitions : Array[VRegDefinition?],
+  block_index : Int,
+  block_id : Int,
+  position : Int,
+  idom : Array[Int],
+) -> Unit raise VerifyError {
+  fn verify(
+    reg : @abi.Reg,
+    definitions : Array[VRegDefinition?],
+    block_index : Int,
+    block_id : Int,
+    position : Int,
+    idom : Array[Int],
+  ) -> Unit raise VerifyError {
+    verify_reg_use(reg, definitions, block_index, block_id, position, idom)
+  }
+
+  match term {
+    Jump(_, args) | Return(args) =>
+      for reg in args {
+        verify(reg, definitions, block_index, block_id, position, idom)
+      }
+    Branch(cond, _, _)
+    | BranchZero(cond, _, _, _, _)
+    | BranchCmpImm(cond, _, _, _, _, _)
+    | BrTable(cond, _, _) =>
+      verify(cond, definitions, block_index, block_id, position, idom)
+    BranchCmp(lhs, rhs, _, _, _, _) => {
+      verify(lhs, definitions, block_index, block_id, position, idom)
+      verify(rhs, definitions, block_index, block_id, position, idom)
+    }
+    Trap(_) => ()
+  }
+}
+
+///|
+fn Function::verify_terminator(
+  self : Function,
+  blocks : Map[Int, @block.Block],
+  block : @block.Block,
+  term : @instr.Terminator,
+) -> Unit raise VerifyError {
+  match term {
+    Jump(target_id, args) => {
+      let target = require_target(blocks, target_id)
+      if args.length() != target.params.length() {
+        raise ArityMismatch(
+          message="jump from block \{block.id} passes \{args.length()} arguments to block \{target_id} with \{target.params.length()} parameters",
+        )
+      }
+      for i, arg in args {
+        require_same_class(
+          reg_class(arg),
+          target.params[i].class,
+          "jump argument \{i} from block \{block.id}",
+        )
+      }
+    }
+    Branch(cond, then_id, else_id) => {
+      require_same_class(
+        reg_class(cond),
+        Int,
+        "branch condition in block \{block.id}",
+      )
+      require_target_without_args(blocks, block.id, then_id)
+      require_target_without_args(blocks, block.id, else_id)
+    }
+    BranchCmp(lhs, rhs, _, _, then_id, else_id) => {
+      require_same_class(
+        reg_class(rhs),
+        reg_class(lhs),
+        "branch comparison rhs in block \{block.id}",
+      )
+      require_target_without_args(blocks, block.id, then_id)
+      require_target_without_args(blocks, block.id, else_id)
+    }
+    BranchZero(reg, _, _, then_id, else_id) => {
+      require_same_class(
+        reg_class(reg),
+        Int,
+        "branch-zero operand in block \{block.id}",
+      )
+      require_target_without_args(blocks, block.id, then_id)
+      require_target_without_args(blocks, block.id, else_id)
+    }
+    BranchCmpImm(lhs, _, _, _, then_id, else_id) => {
+      require_same_class(
+        reg_class(lhs),
+        Int,
+        "branch-immediate operand in block \{block.id}",
+      )
+      require_target_without_args(blocks, block.id, then_id)
+      require_target_without_args(blocks, block.id, else_id)
+    }
+    Return(values) => {
+      if values.length() != self.result_kinds.length() {
+        raise ArityMismatch(
+          message="return in block \{block.id} has \{values.length()} values, expected \{self.result_kinds.length()}",
+        )
+      }
+      for i, value in values {
+        require_same_class(
+          reg_class(value),
+          self.result_kinds[i].reg_class(),
+          "return value \{i} in block \{block.id}",
+        )
+      }
+    }
+    Trap(_) => ()
+    BrTable(index, targets, default_id) => {
+      require_same_class(
+        reg_class(index),
+        Int,
+        "br_table index in block \{block.id}",
+      )
+      for target_id in targets {
+        require_target_without_args(blocks, block.id, target_id)
+      }
+      require_target_without_args(blocks, block.id, default_id)
+    }
+  }
+}
+
+///|
+pub fn Function::verify(self : Function) -> Unit raise VerifyError {
+  if self.blocks.is_empty() {
+    raise EmptyFunction
+  }
+  let blocks : Map[Int, @block.Block] = Map([])
+  for block in self.blocks {
+    if block.id < 0 {
+      raise InvalidBlockTarget(block_id=block.id)
+    }
+    if blocks.get(block.id) is Some(_) {
+      raise DuplicateBlockId(block_id=block.id)
+    }
+    blocks.set(block.id, block)
+  }
+  for block in self.blocks {
+    match block.terminator {
+      None => raise MissingTerminator(block_id=block.id)
+      Some(term) => self.verify_terminator(blocks, block, term)
+    }
+  }
+  let definitions : Array[VRegDefinition?] = Array::make(
+    self.next_vreg_id,
+    None,
+  )
+  for param in self.params {
+    record_definition(param, FunctionParameter(param.class), definitions)
+  }
+  for block_index, block in self.blocks {
+    for param in block.params {
+      record_definition(
+        param,
+        BlockParameter(param.class, block_index, block.id),
+        definitions,
+      )
+    }
+    for inst_index, inst in block.insts {
+      verify_inst_structure(inst, block.id, inst_index)
+      for writable in inst.defs {
+        if writable.reg is Virtual(vreg) {
+          record_definition(
+            vreg,
+            InstructionResult(
+              writable_reg_class(writable),
+              block_index,
+              block.id,
+              inst_index,
+            ),
+            definitions,
+          )
+        }
+      }
+    }
+  }
+  let idom = ControlFlowGraph::build(self).compute_dominators()
+  for block_index, block in self.blocks {
+    for inst_index, inst in block.insts {
+      for reg in inst.uses {
+        verify_reg_use(
+          reg,
+          definitions,
+          block_index,
+          block.id,
+          inst_index,
+          idom,
+        )
+      }
+    }
+    if block.terminator is Some(term) {
+      verify_terminator_uses(
+        term,
+        definitions,
+        block_index,
+        block.id,
+        block.insts.length(),
+        idom,
+      )
+    }
+  }
+}
+
+///|
+fn verify_physical_register(
+  preg : @abi.PReg,
+  isa : @isa.ISA,
+  location : String,
+) -> Unit raise VerifyError {
+  let valid = match (isa, preg.class) {
+    (AArch64, Int) => preg.index >= 0 && preg.index < 32
+    (AArch64, Float32 | Float64 | Vector) => preg.index >= 0 && preg.index < 32
+    (AMD64, Int) =>
+      preg.index >= 0 && preg.index < 16 && preg.index != 4 && preg.index != 5
+    (AMD64, Float32 | Float64 | Vector) => preg.index >= 0 && preg.index < 16
+  }
+  if !valid {
+    let isa_name = match isa {
+      AArch64 => "aarch64"
+      AMD64 => "amd64"
+    }
+    raise InvalidInstruction(
+      message="invalid physical register \{preg} for \{isa_name} at \{location}",
+    )
+  }
+}
+
+///|
+fn verify_reg_for_isa(
+  reg : @abi.Reg,
+  isa : @isa.ISA,
+  location : String,
+) -> Unit raise VerifyError {
+  if reg is Physical(preg) {
+    verify_physical_register(preg, isa, location)
+  }
+}
+
+///|
+fn Function::verify_isa_registers(
+  self : Function,
+  isa : @isa.ISA,
+) -> Unit raise VerifyError {
+  for i, preg in self.param_pregs {
+    if preg is Some(reg) {
+      verify_physical_register(reg, isa, "param_pregs[\{i}]")
+    }
+  }
+  for block in self.blocks {
+    for inst_index, inst in block.insts {
+      for i, reg in inst.uses {
+        verify_reg_for_isa(
+          reg,
+          isa,
+          "block \{block.id} instruction \{inst_index} use \{i}",
+        )
+      }
+      for i, writable in inst.defs {
+        verify_reg_for_isa(
+          writable.reg,
+          isa,
+          "block \{block.id} instruction \{inst_index} def \{i}",
+        )
+      }
+      for i, constraint in inst.use_constraints {
+        if constraint is FixedReg(preg) {
+          verify_physical_register(
+            preg,
+            isa,
+            "block \{block.id} instruction \{inst_index} use constraint \{i}",
+          )
+        }
+      }
+      for i, constraint in inst.def_constraints {
+        if constraint is FixedReg(preg) {
+          verify_physical_register(
+            preg,
+            isa,
+            "block \{block.id} instruction \{inst_index} def constraint \{i}",
+          )
+        }
+      }
+    }
+    if block.terminator is Some(term) {
+      match term {
+        Jump(_, regs) | Return(regs) =>
+          for i, reg in regs {
+            verify_reg_for_isa(
+              reg,
+              isa,
+              "block \{block.id} terminator use \{i}",
+            )
+          }
+        Branch(reg, _, _)
+        | BranchZero(reg, _, _, _, _)
+        | BranchCmpImm(reg, _, _, _, _, _)
+        | BrTable(reg, _, _) =>
+          verify_reg_for_isa(reg, isa, "block \{block.id} terminator use 0")
+        BranchCmp(lhs, rhs, _, _, _, _) => {
+          verify_reg_for_isa(lhs, isa, "block \{block.id} terminator use 0")
+          verify_reg_for_isa(rhs, isa, "block \{block.id} terminator use 1")
+        }
+        Trap(_) => ()
+      }
+    }
+  }
+}
+
+///|
+pub fn Function::verify_for_isa(
+  self : Function,
+  isa : @isa.ISA,
+) -> Unit raise VerifyError {
+  self.verify()
+  self.verify_isa_registers(isa)
+}
+
+///|
+/// Verify invariants required by the register-allocation data structures,
+/// which address blocks by dense numeric ID.
+pub fn Function::verify_for_regalloc(self : Function) -> Unit raise VerifyError {
+  self.verify()
+  for index, block in self.blocks {
+    if block.id != index {
+      raise InvalidBlockLayout(block_id=block.id, expected_index=index)
+    }
+  }
+}
+
+///|
+pub fn Function::verify_for_regalloc_isa(
+  self : Function,
+  isa : @isa.ISA,
+) -> Unit raise VerifyError {
+  self.verify_for_regalloc()
+  self.verify_isa_registers(isa)
+}

--- a/modules/machv/verify_opcode.mbt
+++ b/modules/machv/verify_opcode.mbt
@@ -1,0 +1,619 @@
+///|
+fn mem_type_class(ty : @instr.MemType) -> @abi.RegClass {
+  match ty {
+    I32 | I64 => Int
+    F32 => Float32
+    F64 => Float64
+    V128 => Vector
+  }
+}
+
+///|
+fn float_class(is_f32 : Bool) -> @abi.RegClass {
+  if is_f32 {
+    Float32
+  } else {
+    Float64
+  }
+}
+
+///|
+fn require_inst_arity(
+  inst : @instr.Inst,
+  uses : Int,
+  defs : Int,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  if inst.uses.length() != uses || inst.defs.length() != defs {
+    raise InvalidInstruction(
+      message="instruction \{inst_index} in block \{block_id} (\{inst.opcode}) has \{inst.uses.length()} uses and \{inst.defs.length()} defs, expected \{uses} uses and \{defs} defs",
+    )
+  }
+}
+
+///|
+fn require_use_class(
+  inst : @instr.Inst,
+  index : Int,
+  expected : @abi.RegClass,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  require_same_class(
+    reg_class(inst.uses[index]),
+    expected,
+    "use \{index} of instruction \{inst_index} in block \{block_id}",
+  )
+}
+
+///|
+fn require_def_class(
+  inst : @instr.Inst,
+  index : Int,
+  expected : @abi.RegClass,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  require_same_class(
+    writable_reg_class(inst.defs[index]),
+    expected,
+    "def \{index} of instruction \{inst_index} in block \{block_id}",
+  )
+}
+
+///|
+fn require_all_uses(
+  inst : @instr.Inst,
+  expected : @abi.RegClass,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  for i in 0..<inst.uses.length() {
+    require_use_class(inst, i, expected, block_id, inst_index)
+  }
+}
+
+///|
+fn require_all_defs(
+  inst : @instr.Inst,
+  expected : @abi.RegClass,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  for i in 0..<inst.defs.length() {
+    require_def_class(inst, i, expected, block_id, inst_index)
+  }
+}
+
+///|
+fn verify_fixed_contract(
+  inst : @instr.Inst,
+  uses : Int,
+  defs : Int,
+  use_class : @abi.RegClass,
+  def_class : @abi.RegClass,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  require_inst_arity(inst, uses, defs, block_id, inst_index)
+  require_all_uses(inst, use_class, block_id, inst_index)
+  require_all_defs(inst, def_class, block_id, inst_index)
+}
+
+///|
+fn verify_same_class_contract(
+  inst : @instr.Inst,
+  uses : Int,
+  defs : Int,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  require_inst_arity(inst, uses, defs, block_id, inst_index)
+  if uses > 0 {
+    let expected = reg_class(inst.uses[0])
+    require_all_uses(inst, expected, block_id, inst_index)
+    require_all_defs(inst, expected, block_id, inst_index)
+  }
+}
+
+///|
+fn verify_call_contract(
+  inst : @instr.Inst,
+  result_classes : Array[@abi.RegClass],
+  has_pointer_use : Bool,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  if has_pointer_use && inst.uses.is_empty() {
+    raise InvalidInstruction(
+      message="pointer call instruction \{inst_index} in block \{block_id} has no callee operand",
+    )
+  }
+  if has_pointer_use {
+    require_use_class(inst, 0, Int, block_id, inst_index)
+  }
+  if inst.defs.length() < result_classes.length() {
+    raise InvalidInstruction(
+      message="call instruction \{inst_index} in block \{block_id} has \{inst.defs.length()} defs for \{result_classes.length()} results",
+    )
+  }
+  for i, class in result_classes {
+    require_def_class(inst, i, class, block_id, inst_index)
+  }
+  for i in result_classes.length()..<inst.defs.length() {
+    if inst.defs[i].reg is Virtual(_) {
+      raise InvalidInstruction(
+        message="call instruction \{inst_index} in block \{block_id} has a virtual clobber def at index \{i}",
+      )
+    }
+  }
+}
+
+///|
+fn verify_result_with_clobbers(
+  inst : @instr.Inst,
+  uses : Int,
+  use_class : @abi.RegClass,
+  result_class : @abi.RegClass,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  if inst.uses.length() != uses || inst.defs.is_empty() {
+    raise InvalidInstruction(
+      message="instruction \{inst_index} in block \{block_id} (\{inst.opcode}) must have \{uses} uses and at least one def",
+    )
+  }
+  require_all_uses(inst, use_class, block_id, inst_index)
+  require_def_class(inst, 0, result_class, block_id, inst_index)
+  for i in 1..<inst.defs.length() {
+    if inst.defs[i].reg is Virtual(_) {
+      raise InvalidInstruction(
+        message="instruction \{inst_index} in block \{block_id} has a virtual clobber def at index \{i}",
+      )
+    }
+  }
+}
+
+///|
+fn verify_opcode_contract(
+  inst : @instr.Inst,
+  block_id : Int,
+  inst_index : Int,
+) -> Unit raise VerifyError {
+  match inst.opcode {
+    Add(_)
+    | Sub(_)
+    | Mul(_)
+    | SDiv(_)
+    | UDiv(_)
+    | And(_)
+    | Or(_)
+    | Xor(_)
+    | Shl(_)
+    | AShr(_)
+    | LShr(_)
+    | Rotr(_)
+    | AndNot(_)
+    | OrNot(_)
+    | XorNot(_)
+    | ExtrImm(_, _) =>
+      verify_fixed_contract(inst, 2, 1, Int, Int, block_id, inst_index)
+    SRem(_) | URem(_) | Umulh | Smulh =>
+      verify_result_with_clobbers(inst, 2, Int, Int, block_id, inst_index)
+    AddImm(_, _)
+    | SubImm(_, _)
+    | AndImm(_, _)
+    | OrImm(_, _)
+    | XorImm(_, _)
+    | ShlImm(_, _)
+    | AShrImm(_, _)
+    | LShrImm(_, _)
+    | RotrImm(_, _)
+    | Not(_)
+    | Clz(_)
+    | Popcnt(_)
+    | Rbit(_)
+    | Extend(_)
+    | Truncate =>
+      verify_fixed_contract(inst, 1, 1, Int, Int, block_id, inst_index)
+    FAdd(is_f32)
+    | FSub(is_f32)
+    | FMul(is_f32)
+    | FDiv(is_f32)
+    | FMin(is_f32)
+    | FMax(is_f32)
+    | FpuMaxnm(is_f32)
+    | FpuMinnm(is_f32) => {
+      let class = float_class(is_f32)
+      verify_fixed_contract(inst, 2, 1, class, class, block_id, inst_index)
+    }
+    FSqrt(is_f32)
+    | FAbs(is_f32)
+    | FNeg(is_f32)
+    | FCeil(is_f32)
+    | FFloor(is_f32)
+    | FTrunc(is_f32)
+    | FNearest(is_f32) => {
+      let class = float_class(is_f32)
+      verify_fixed_contract(inst, 1, 1, class, class, block_id, inst_index)
+    }
+    Load(ty, _) | LoadPtr(ty, _) => {
+      require_inst_arity(inst, 1, 1, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      require_def_class(inst, 0, mem_type_class(ty), block_id, inst_index)
+    }
+    Store(ty, _) | StorePtr(ty, _) => {
+      require_inst_arity(inst, 2, 0, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      require_use_class(inst, 1, mem_type_class(ty), block_id, inst_index)
+    }
+    Load8S(_)
+    | Load8U(_)
+    | Load16S(_)
+    | Load16U(_)
+    | Load32S(_)
+    | Load32U(_)
+    | LoadPtrNarrow(_, _, _) =>
+      verify_fixed_contract(inst, 1, 1, Int, Int, block_id, inst_index)
+    Move => verify_same_class_contract(inst, 1, 1, block_id, inst_index)
+    LoadConst(_) =>
+      verify_fixed_contract(inst, 0, 1, Int, Int, block_id, inst_index)
+    LoadConstF32(_) =>
+      verify_fixed_contract(inst, 0, 1, Float32, Float32, block_id, inst_index)
+    LoadConstF64(_) =>
+      verify_fixed_contract(inst, 0, 1, Float64, Float64, block_id, inst_index)
+    Cmp(_, _) =>
+      verify_fixed_contract(inst, 2, 1, Int, Int, block_id, inst_index)
+    IntCmp(_) =>
+      verify_fixed_contract(inst, 2, 0, Int, Int, block_id, inst_index)
+    FCmp(_) => {
+      require_inst_arity(inst, 2, 1, block_id, inst_index)
+      let class = reg_class(inst.uses[0])
+      if class is Int || class is Vector {
+        raise RegisterClassMismatch(
+          message="float comparison in block \{block_id} has non-float operands",
+        )
+      }
+      require_use_class(inst, 1, class, block_id, inst_index)
+      require_def_class(inst, 0, Int, block_id, inst_index)
+    }
+    IntToFloat(kind) => {
+      let result_class : @abi.RegClass = match kind {
+        I32SToF32 | I32UToF32 | I64SToF32 | I64UToF32 => Float32
+        I32SToF64 | I32UToF64 | I64SToF64 | I64UToF64 => Float64
+      }
+      verify_fixed_contract(inst, 1, 1, Int, result_class, block_id, inst_index)
+    }
+    FPromote =>
+      verify_fixed_contract(inst, 1, 1, Float32, Float64, block_id, inst_index)
+    FDemote =>
+      verify_fixed_contract(inst, 1, 1, Float64, Float32, block_id, inst_index)
+    Bitcast => {
+      require_inst_arity(inst, 1, 1, block_id, inst_index)
+      let source = reg_class(inst.uses[0])
+      let result = writable_reg_class(inst.defs[0])
+      if source is Vector || result is Vector {
+        require_same_class(result, source, "vector bitcast result")
+      }
+    }
+    Select => {
+      require_inst_arity(inst, 3, 1, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      let class = reg_class(inst.uses[1])
+      require_use_class(inst, 2, class, block_id, inst_index)
+      require_def_class(inst, 0, class, block_id, inst_index)
+    }
+    SelectCmp(_, _) => {
+      require_inst_arity(inst, 4, 1, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      require_use_class(inst, 1, Int, block_id, inst_index)
+      let class = reg_class(inst.uses[2])
+      require_use_class(inst, 3, class, block_id, inst_index)
+      require_def_class(inst, 0, class, block_id, inst_index)
+    }
+    Nop | TrapIf(_, _) | AdjustSP(_) =>
+      require_inst_arity(inst, 0, 0, block_id, inst_index)
+    TrapIfUgt(_) | TrapIfUge(_) | TrapIfDivOverflow(_, _) =>
+      verify_fixed_contract(inst, 2, 0, Int, Int, block_id, inst_index)
+    FpuCmp(is_f32) => {
+      let class = float_class(is_f32)
+      verify_fixed_contract(inst, 2, 0, class, class, block_id, inst_index)
+    }
+    TrapIfZero(_, _) =>
+      verify_fixed_contract(inst, 1, 0, Int, Int, block_id, inst_index)
+    FcvtToInt(is_f32, _, _) =>
+      verify_fixed_contract(
+        inst,
+        1,
+        1,
+        float_class(is_f32),
+        Int,
+        block_id,
+        inst_index,
+      )
+    FpuSel(is_f32, _) => {
+      let class = float_class(is_f32)
+      verify_fixed_contract(inst, 2, 1, class, class, block_id, inst_index)
+    }
+    AddShifted(_, _)
+    | AddExtend(_, _)
+    | SubExtend(_, _)
+    | SubShifted(_, _)
+    | AndShifted(_, _)
+    | OrShifted(_, _)
+    | XorShifted(_, _)
+    | AddShifted32(_, _)
+    | SubShifted32(_, _)
+    | AndShifted32(_, _)
+    | OrShifted32(_, _)
+    | XorShifted32(_, _)
+    | Umull
+    | Smull => verify_fixed_contract(inst, 2, 1, Int, Int, block_id, inst_index)
+    Madd | Msub | Madd32 | Msub32 =>
+      verify_fixed_contract(inst, 3, 1, Int, Int, block_id, inst_index)
+    Mneg | Mneg32 =>
+      verify_fixed_contract(inst, 2, 1, Int, Int, block_id, inst_index)
+    ReturnCallIndirect(stack_arg_bytes, num_results) => {
+      if stack_arg_bytes < 0 || num_results < 0 {
+        raise InvalidInstruction(
+          message="indirect tail call in block \{block_id} has negative call metadata",
+        )
+      }
+      if inst.uses.is_empty() {
+        raise InvalidInstruction(
+          message="indirect tail call in block \{block_id} has no callee operand",
+        )
+      }
+      require_use_class(inst, 0, Int, block_id, inst_index)
+    }
+    CallExternalIfI32NeImm(_, _) => {
+      if inst.uses.length() != 1 {
+        raise InvalidInstruction(
+          message="conditional external call in block \{block_id} must have one operand",
+        )
+      }
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      for writable in inst.defs {
+        if writable.reg is Virtual(_) {
+          raise InvalidInstruction(
+            message="conditional external call in block \{block_id} has a virtual clobber",
+          )
+        }
+      }
+    }
+    StackLoad(_) => require_inst_arity(inst, 0, 1, block_id, inst_index)
+    StackStore(_) | StoreToStack(_) =>
+      require_inst_arity(inst, 1, 0, block_id, inst_index)
+    LoadStackParam(_, class) =>
+      verify_fixed_contract(inst, 0, 1, class, class, block_id, inst_index)
+    LoadPtrRegOffset(ty, _, _, _) => {
+      require_inst_arity(inst, 2, 1, block_id, inst_index)
+      require_all_uses(inst, Int, block_id, inst_index)
+      require_def_class(inst, 0, mem_type_class(ty), block_id, inst_index)
+    }
+    LoadPtrNarrowRegOffset(bits, _, _, _, _) => {
+      if bits != 8 && bits != 16 && bits != 32 {
+        raise InvalidInstruction(
+          message="narrow pointer load has invalid width \{bits}",
+        )
+      }
+      verify_fixed_contract(inst, 2, 1, Int, Int, block_id, inst_index)
+    }
+    StorePtrRegOffset(ty, _, _, _) => {
+      require_inst_arity(inst, 3, 0, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      require_use_class(inst, 1, Int, block_id, inst_index)
+      require_use_class(inst, 2, mem_type_class(ty), block_id, inst_index)
+    }
+    StorePtrNarrowRegOffset(bits, _, _, _) => {
+      if bits != 8 && bits != 16 && bits != 32 {
+        raise InvalidInstruction(
+          message="narrow pointer store has invalid width \{bits}",
+        )
+      }
+      verify_fixed_contract(inst, 3, 0, Int, Int, block_id, inst_index)
+    }
+    StorePtrNarrow(bits, _) => {
+      if bits != 8 && bits != 16 && bits != 32 {
+        raise InvalidInstruction(
+          message="narrow pointer store has invalid width \{bits}",
+        )
+      }
+      verify_fixed_contract(inst, 2, 0, Int, Int, block_id, inst_index)
+    }
+    LoadExternalFuncAddr(_) | LoadCodeAddr(_) | LoadSP =>
+      verify_fixed_contract(inst, 0, 1, Int, Int, block_id, inst_index)
+    LoadSafepointId(root_count) => {
+      if root_count < 0 {
+        raise InvalidInstruction(
+          message="safepoint root count cannot be negative",
+        )
+      }
+      verify_fixed_contract(inst, 0, 1, Int, Int, block_id, inst_index)
+    }
+    CallPtr(num_args, result_classes, clobber_class) => {
+      if num_args < 0 {
+        raise InvalidInstruction(
+          message="pointer call argument count cannot be negative",
+        )
+      }
+      let extra_uses = if clobber_class is Internal { 2 } else { 1 }
+      if inst.uses.length() > num_args + extra_uses {
+        raise InvalidInstruction(
+          message="pointer call in block \{block_id} has \{inst.uses.length()} uses for \{num_args} arguments",
+        )
+      }
+      verify_call_contract(inst, result_classes, true, block_id, inst_index)
+    }
+    CallDirect(_, num_args, result_classes, clobber_class)
+    | CallExternal(_, num_args, result_classes, clobber_class) => {
+      if num_args < 0 {
+        raise InvalidInstruction(
+          message="direct call argument count cannot be negative",
+        )
+      }
+      let extra_uses = if clobber_class is Internal { 1 } else { 0 }
+      if inst.uses.length() > num_args + extra_uses {
+        raise InvalidInstruction(
+          message="direct call in block \{block_id} has \{inst.uses.length()} uses for \{num_args} arguments",
+        )
+      }
+      verify_call_contract(inst, result_classes, false, block_id, inst_index)
+    }
+    LoadConstV128(_) =>
+      verify_fixed_contract(inst, 0, 1, Vector, Vector, block_id, inst_index)
+    SIMDSplat(_) => {
+      require_inst_arity(inst, 1, 1, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      require_def_class(inst, 0, Vector, block_id, inst_index)
+    }
+    SIMDSplatF(is_f32) =>
+      verify_fixed_contract(
+        inst,
+        1,
+        1,
+        float_class(is_f32),
+        Vector,
+        block_id,
+        inst_index,
+      )
+    SIMDExtractU(_, _) | SIMDExtractS(_, _) =>
+      verify_fixed_contract(inst, 1, 1, Vector, Int, block_id, inst_index)
+    SIMDExtractF(is_f32, _) =>
+      verify_fixed_contract(
+        inst,
+        1,
+        1,
+        Vector,
+        float_class(is_f32),
+        block_id,
+        inst_index,
+      )
+    SIMDInsert(_, _) => {
+      require_inst_arity(inst, 2, 1, block_id, inst_index)
+      require_use_class(inst, 0, Vector, block_id, inst_index)
+      require_use_class(inst, 1, Int, block_id, inst_index)
+      require_def_class(inst, 0, Vector, block_id, inst_index)
+    }
+    SIMDInsertF(is_f32, _) => {
+      require_inst_arity(inst, 2, 1, block_id, inst_index)
+      require_use_class(inst, 0, Vector, block_id, inst_index)
+      require_use_class(inst, 1, float_class(is_f32), block_id, inst_index)
+      require_def_class(inst, 0, Vector, block_id, inst_index)
+    }
+    SIMDShuffle(_) =>
+      verify_fixed_contract(inst, 2, 3, Vector, Vector, block_id, inst_index)
+    SIMDSwizzle
+    | SIMDAnd
+    | SIMDBic
+    | SIMDOr
+    | SIMDXor
+    | SIMDAdd(_)
+    | SIMDSub(_)
+    | SIMDMul(_)
+    | SIMDSqadd(_)
+    | SIMDUqadd(_)
+    | SIMDSqsub(_)
+    | SIMDUqsub(_)
+    | SIMDSmin(_)
+    | SIMDUmin(_)
+    | SIMDSmax(_)
+    | SIMDUmax(_)
+    | SIMDUrhadd(_)
+    | SIMDShiftByVec(_, _)
+    | SIMDCmp(_, _)
+    | SIMDNarrow(_, _)
+    | SIMDExtMulLow(_, _)
+    | SIMDExtMulHigh(_, _)
+    | SIMDDot
+    | SIMDQ15MulrSat
+    | SIMDFAdd(_)
+    | SIMDFSub(_)
+    | SIMDFMul(_)
+    | SIMDFDiv(_)
+    | SIMDFMin(_)
+    | SIMDFMax(_)
+    | SIMDFPMin(_)
+    | SIMDFPMax(_)
+    | SIMDFCmp(_, _) =>
+      verify_fixed_contract(inst, 2, 1, Vector, Vector, block_id, inst_index)
+    SIMDNot
+    | SIMDAbs(_)
+    | SIMDNeg(_)
+    | SIMDCnt
+    | SIMDExtendLow(_, _)
+    | SIMDExtendHigh(_, _)
+    | SIMDExtAddPairwise(_, _)
+    | SIMDFAbs(_)
+    | SIMDFNeg(_)
+    | SIMDFSqrt(_)
+    | SIMDFCeil(_)
+    | SIMDFFloor(_)
+    | SIMDFTrunc(_)
+    | SIMDFNearest(_)
+    | SIMDFCvtToIntS(_)
+    | SIMDFCvtToIntU(_)
+    | SIMDIntToFloatS(_)
+    | SIMDIntToFloatU(_)
+    | SIMDTruncSatF64ToI32SZero
+    | SIMDTruncSatF64ToI32UZero
+    | SIMDConvertLowI32ToF64S
+    | SIMDConvertLowI32ToF64U
+    | SIMDDemoteF64ToF32Zero
+    | SIMDPromoteLowF32ToF64 =>
+      verify_fixed_contract(inst, 1, 1, Vector, Vector, block_id, inst_index)
+    SIMDBsl | SIMDFMla(_) | SIMDFMls(_) =>
+      verify_fixed_contract(inst, 3, 1, Vector, Vector, block_id, inst_index)
+    SIMDAnyTrue => {
+      require_inst_arity(inst, 1, 2, block_id, inst_index)
+      require_use_class(inst, 0, Vector, block_id, inst_index)
+      require_def_class(inst, 0, Int, block_id, inst_index)
+      require_def_class(inst, 1, Vector, block_id, inst_index)
+    }
+    SIMDAllTrue(lane) => {
+      let defs = if lane is D64 { 1 } else { 2 }
+      require_inst_arity(inst, 1, defs, block_id, inst_index)
+      require_use_class(inst, 0, Vector, block_id, inst_index)
+      require_def_class(inst, 0, Int, block_id, inst_index)
+      if defs == 2 {
+        require_def_class(inst, 1, Vector, block_id, inst_index)
+      }
+    }
+    SIMDBitmask(lane) => {
+      let defs = if lane is B8 { 4 } else { 1 }
+      require_inst_arity(inst, 1, defs, block_id, inst_index)
+      require_use_class(inst, 0, Vector, block_id, inst_index)
+      require_def_class(inst, 0, Int, block_id, inst_index)
+      for i in 1..<defs {
+        require_def_class(inst, i, Vector, block_id, inst_index)
+      }
+    }
+    SIMDBroadcastShift(_, _) => {
+      require_inst_arity(inst, 1, 2, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      require_def_class(inst, 0, Int, block_id, inst_index)
+      require_def_class(inst, 1, Vector, block_id, inst_index)
+    }
+    SIMDLoad(_)
+    | SIMDLoadSplat(_, _)
+    | SIMDLoadExtend(_, _, _)
+    | SIMDLoadZero(_, _) =>
+      verify_fixed_contract(inst, 1, 1, Int, Vector, block_id, inst_index)
+    SIMDStore(_) | SIMDStoreLane(_, _, _) => {
+      require_inst_arity(inst, 2, 0, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      require_use_class(inst, 1, Vector, block_id, inst_index)
+    }
+    SIMDLoadLane(_, _, _) => {
+      require_inst_arity(inst, 2, 1, block_id, inst_index)
+      require_use_class(inst, 0, Int, block_id, inst_index)
+      require_use_class(inst, 1, Vector, block_id, inst_index)
+      require_def_class(inst, 0, Vector, block_id, inst_index)
+    }
+    SIMDRelaxedDot8to16 =>
+      verify_fixed_contract(inst, 2, 2, Vector, Vector, block_id, inst_index)
+    SIMDRelaxedDot8to32Add =>
+      verify_fixed_contract(inst, 3, 2, Vector, Vector, block_id, inst_index)
+  }
+}

--- a/modules/machv/verify_test.mbt
+++ b/modules/machv/verify_test.mbt
@@ -1,0 +1,408 @@
+///|
+test "public verifier rejects a missing terminator" {
+  let func = @machv.Function::Function("missing_terminator")
+  func.new_block() |> ignore
+  try func.verify() catch {
+    err => inspect(err, content="MissingTerminator(block_id=0)")
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "public verifier rejects an empty function" {
+  let func = @machv.Function::Function("empty")
+  try func.verify() catch {
+    err => inspect(err, content="EmptyFunction")
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "public builder finish rejects a missing terminator" {
+  let builder = @machv.FunctionBuilder::FunctionBuilder("unfinished")
+  try builder.finish() catch {
+    err => inspect(err, content="MissingTerminator(block_id=0)")
+  } noraise {
+    _ => fail("expected MachV builder finish to fail")
+  }
+}
+
+///|
+test "verifier rejects an invalid jump target" {
+  let func = @machv.Function::Function("invalid_target")
+  let entry = func.new_block()
+  entry.set_terminator(Jump(7, []))
+  try func.verify() catch {
+    err => inspect(err, content="InvalidBlockTarget(block_id=7)")
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks jump argument arity" {
+  let func = @machv.Function::Function("jump_arity")
+  let entry = func.new_block()
+  let target = func.new_block()
+  target.params.push(func.new_vreg(Int))
+  entry.set_terminator(Jump(target.id, []))
+  target.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|ArityMismatch(message="jump from block 0 passes 0 arguments to block 1 with 1 parameters")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks jump argument register classes" {
+  let func = @machv.Function::Function("jump_class")
+  let entry = func.new_block()
+  let target = func.new_block()
+  let argument = func.add_param(Int)
+  target.params.push(func.new_vreg(Float64))
+  entry.set_terminator(Jump(target.id, [Virtual(argument)]))
+  target.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|RegisterClassMismatch(message="jump argument 0 from block 0 has class int, expected double")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier rejects parameterized targets for branches without arguments" {
+  let func = @machv.Function::Function("branch_parameter")
+  let entry = func.new_block()
+  let target = func.new_block()
+  let fallback = func.new_block()
+  let condition = func.add_param(Int)
+  target.params.push(func.new_vreg(Int))
+  entry.set_terminator(Branch(Virtual(condition), target.id, fallback.id))
+  target.set_terminator(Return([]))
+  fallback.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|ArityMismatch(message="branch from block 0 cannot pass 1 arguments required by block 1")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks return arity" {
+  let func = @machv.Function::Function("return_arity")
+  func.add_result_kind(I64)
+  func.new_block().set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|ArityMismatch(message="return in block 0 has 0 values, expected 1")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks return register classes" {
+  let func = @machv.Function::Function("return_class")
+  func.add_result_kind(F64)
+  let value = func.add_param(Int)
+  func.new_block().set_terminator(Return([Virtual(value)]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|RegisterClassMismatch(message="return value 0 in block 0 has class int, expected double")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier rejects undefined virtual registers" {
+  let func = @machv.Function::Function("undefined_vreg")
+  func.add_result_kind(I64)
+  func.new_block().set_terminator(Return([Virtual({ id: 99, class: Int })]))
+  try func.verify() catch {
+    err => inspect(err, content="UndefinedVReg(vreg_id=99)")
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier rejects duplicate virtual register definitions" {
+  let func = @machv.Function::Function("duplicate_definition")
+  let block = func.new_block()
+  let value = func.new_vreg(Int)
+  let first = @machv.Inst::Inst(LoadConst(1L))
+  first.add_def({ reg: Virtual(value) })
+  block.add_inst(first)
+  let second = @machv.Inst::Inst(LoadConst(2L))
+  second.add_def({ reg: Virtual(value) })
+  block.add_inst(second)
+  block.set_terminator(Return([]))
+  try func.verify() catch {
+    err => inspect(err, content="DuplicateVRegDefinition(vreg_id=0)")
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier rejects use before definition" {
+  let func = @machv.Function::Function("use_before_definition")
+  let block = func.new_block()
+  let source = func.new_vreg(Int)
+  let result = func.new_vreg(Int)
+  let copy = @machv.Inst::Inst(Move)
+  copy.add_use(Virtual(source))
+  copy.add_def({ reg: Virtual(result) })
+  block.add_inst(copy)
+  let constant = @machv.Inst::Inst(LoadConst(1L))
+  constant.add_def({ reg: Virtual(source) })
+  block.add_inst(constant)
+  block.set_terminator(Return([]))
+  try func.verify() catch {
+    err => inspect(err, content="UseBeforeDefinition(vreg_id=0)")
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier rejects non-dominating definitions" {
+  let func = @machv.Function::Function("non_dominating_definition")
+  let entry = func.new_block()
+  let then_block = func.new_block()
+  let else_block = func.new_block()
+  let cond = func.add_param(Int)
+  let value = func.new_vreg(Int)
+  let copy = func.new_vreg(Int)
+  entry.set_terminator(Branch(Virtual(cond), then_block.id, else_block.id))
+  let constant = @machv.Inst::Inst(LoadConst(1L))
+  constant.add_def({ reg: Virtual(value) })
+  then_block.add_inst(constant)
+  then_block.set_terminator(Return([]))
+  let copy_inst = @machv.Inst::Inst(Move)
+  copy_inst.add_use(Virtual(value))
+  copy_inst.add_def({ reg: Virtual(copy) })
+  else_block.add_inst(copy_inst)
+  else_block.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|NonDominatingUse(vreg_id=1, defining_block=1, use_block=2)
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks operand constraint arrays" {
+  let func = @machv.Function::Function("constraint_arity")
+  let block = func.new_block()
+  let value = func.new_vreg(Int)
+  let inst = @machv.Inst::Inst(LoadConst(1L))
+  inst.add_def({ reg: Virtual(value) })
+  inst.def_constraints.clear()
+  block.add_inst(inst)
+  block.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|InvalidInstruction(message="instruction 0 in block 0 has 1 defs but 0 def constraints")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier rejects duplicate block ids through mutable block arrays" {
+  let func = @machv.Function::Function("duplicate_blocks")
+  let block = func.new_block()
+  block.set_terminator(Return([]))
+  func.get_blocks().push(block)
+  try func.verify() catch {
+    err => inspect(err, content="DuplicateBlockId(block_id=0)")
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks opcode operand arity" {
+  let func = @machv.Function::Function("move_arity")
+  let block = func.new_block()
+  let result = func.new_vreg(Int)
+  let inst = @machv.Inst::Inst(Move)
+  inst.add_def({ reg: Virtual(result) })
+  block.add_inst(inst)
+  block.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|InvalidInstruction(message="instruction 0 in block 0 (mov) has 0 uses and 1 defs, expected 1 uses and 1 defs")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks scalar opcode register classes" {
+  let func = @machv.Function::Function("add_classes")
+  let block = func.new_block()
+  let lhs = func.add_param(Float64)
+  let rhs = func.add_param(Float64)
+  let result = func.new_vreg(Float64)
+  let inst = @machv.Inst::Inst(Add(true))
+  inst.add_use(Virtual(lhs))
+  inst.add_use(Virtual(rhs))
+  inst.add_def({ reg: Virtual(result) })
+  block.add_inst(inst)
+  block.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|RegisterClassMismatch(message="use 0 of instruction 0 in block 0 has class double, expected int")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks call result classes" {
+  let func = @machv.Function::Function("call_result_class")
+  let block = func.new_block()
+  let callee = func.add_param(Int)
+  let result = func.new_vreg(Int)
+  let inst = @machv.Inst::Inst(CallPtr(0, [Float64], Foreign))
+  inst.add_use(Virtual(callee))
+  inst.add_def({ reg: Virtual(result) })
+  block.add_inst(inst)
+  block.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|RegisterClassMismatch(message="def 0 of instruction 0 in block 0 has class int, expected double")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks call argument metadata" {
+  let func = @machv.Function::Function("call_argument_count")
+  let block = func.new_block()
+  let callee = func.add_param(Int)
+  let argument = func.add_param(Int)
+  let inst = @machv.Inst::Inst(CallPtr(0, [], Foreign))
+  inst.add_use(Virtual(callee))
+  inst.add_use(Virtual(argument))
+  block.add_inst(inst)
+  block.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|InvalidInstruction(message="pointer call in block 0 has 2 uses for 0 arguments")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "verifier checks vector-memory opcode classes" {
+  let func = @machv.Function::Function("vector_load_class")
+  let block = func.new_block()
+  let base = func.add_param(Int)
+  let result = func.new_vreg(Int)
+  let inst = @machv.Inst::Inst(SIMDLoad(0))
+  inst.add_use(Virtual(base))
+  inst.add_def({ reg: Virtual(result) })
+  block.add_inst(inst)
+  block.set_terminator(Return([]))
+  try func.verify() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|RegisterClassMismatch(message="def 0 of instruction 0 in block 0 has class int, expected vector")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV verification to fail")
+  }
+}
+
+///|
+test "ISA verifier rejects out-of-range physical registers" {
+  let func = @machv.Function::Function("invalid_amd64_register")
+  let block = func.new_block()
+  let inst = @machv.Inst::Inst(Move)
+  inst.add_use(Physical({ index: 20, class: Int }))
+  inst.add_def({ reg: Physical({ index: 0, class: Int }) })
+  block.add_inst(inst)
+  block.set_terminator(Return([]))
+  try func.verify_for_isa(AMD64) catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|InvalidInstruction(message="invalid physical register x20 for amd64 at block 0 instruction 0 use 0")
+        ),
+      )
+  } noraise {
+    _ => fail("expected MachV ISA verification to fail")
+  }
+}

--- a/modules/machv_emit/pkg.generated.mbti
+++ b/modules/machv_emit/pkg.generated.mbti
@@ -11,9 +11,9 @@ import {
 }
 
 // Values
-pub fn emit_function(@machv.Function, isa? : @isa.ISA, debug_func_idx? : Int?, force_frame_setup? : Bool, embedding_abi? : @abi.EmbeddingABI?, record_disasm? : Bool) -> MachineCode
+pub fn emit_function(@machv.Function, isa? : @isa.ISA, debug_func_idx? : Int?, force_frame_setup? : Bool, embedding_abi? : @abi.EmbeddingABI?, record_disasm? : Bool) -> MachineCode raise @machv.VerifyError
 
-pub fn emit_function_with_regalloc(@machv.Function, @machv_regalloc.Output, isa? : @isa.ISA, debug_func_idx? : Int?, force_frame_setup? : Bool, embedding_abi? : @abi.EmbeddingABI?, record_disasm? : Bool) -> MachineCode
+pub fn emit_function_with_regalloc(@machv.Function, @machv_regalloc.Output, isa? : @isa.ISA, debug_func_idx? : Int?, force_frame_setup? : Bool, embedding_abi? : @abi.EmbeddingABI?, record_disasm? : Bool) -> MachineCode raise @machv.VerifyError
 
 pub fn fits_signed_i32(Int) -> Bool
 

--- a/modules/machv_emit/prelude.mbt
+++ b/modules/machv_emit/prelude.mbt
@@ -790,10 +790,12 @@ pub fn emit_function(
   force_frame_setup? : Bool = false,
   embedding_abi? : @abi.EmbeddingABI? = None,
   record_disasm? : Bool = true,
-) -> MachineCode {
+) -> MachineCode raise @machv.VerifyError {
+  func.verify_for_isa(isa)
   // Optimize block layout for better branch prediction
   // Loop rotation makes back edges fall through, reducing taken branches
   let func = @layout.optimize_layout(func)
+  func.verify_for_isa(isa)
   let mc = MachineCode::MachineCode(isa~, record_disasm~)
   let embedding_abi = require_embedding_abi(embedding_abi)
   let call_conv_layout = embedding_abi.call_conv
@@ -2076,10 +2078,13 @@ pub fn emit_function_with_regalloc(
   force_frame_setup? : Bool = false,
   embedding_abi? : @abi.EmbeddingABI? = None,
   record_disasm? : Bool = true,
-) -> MachineCode {
+) -> MachineCode raise @machv.VerifyError {
+  func.verify_for_isa(isa)
+  output.validate_for_isa(isa)
   // Regalloc output carries edge copies as edits keyed by original blocks.
   // Reorder blocks, but do not thread jumps across edge-copy blocks.
   let func = @layout.optimize_layout_preserving_edges(func)
+  func.verify_for_isa(isa)
   let mc = MachineCode::MachineCode(isa~, record_disasm~)
   let is_amd64 = isa is AMD64
   let embedding_abi = require_embedding_abi(embedding_abi)

--- a/modules/machv_emit/verify_test.mbt
+++ b/modules/machv_emit/verify_test.mbt
@@ -1,0 +1,10 @@
+///|
+test "emitter rejects invalid MachV before layout and encoding" {
+  let func = @machv.Function::Function("invalid_emit_input")
+  func.new_block() |> ignore
+  try @machv_emit.emit_function(func) catch {
+    err => inspect(err, content="MissingTerminator(block_id=0)")
+  } noraise {
+    _ => fail("expected emitter input verification to fail")
+  }
+}

--- a/modules/machv_regalloc/README.mbt.md
+++ b/modules/machv_regalloc/README.mbt.md
@@ -44,6 +44,7 @@ fn example_abi() -> @abi.EmbeddingABI {
 test "allocate a MachV copy" {
   let builder = @machv.FunctionBuilder::FunctionBuilder("copy")
   let src = builder.add_param(Int)
+  builder.add_result(I64)
   let dst = builder.new_vreg(Int)
   builder.append(Move, uses=[Virtual(src)], defs=[{ reg: Virtual(dst) }])
   |> ignore
@@ -68,6 +69,7 @@ preferred path for emitters that materialize moves while encoding instructions.
 test "read operand locations from regalloc output" {
   let builder = @machv.FunctionBuilder::FunctionBuilder("rewrite")
   let src = builder.add_param(Int)
+  builder.add_result(I64)
   let dst = builder.new_vreg(Int)
   builder.append(Move, uses=[Virtual(src)], defs=[{ reg: Virtual(dst) }])
   |> ignore

--- a/modules/machv_regalloc/machv_regalloc_test.mbt
+++ b/modules/machv_regalloc/machv_regalloc_test.mbt
@@ -21,9 +21,10 @@ fn test_embedding_abi() -> @abi.EmbeddingABI {
 }
 
 ///|
-fn copy_function() -> @machv.Function {
+fn copy_function() -> @machv.Function raise @machv.VerifyError {
   let builder = @machv.FunctionBuilder::FunctionBuilder("copy")
   let src = builder.add_param(Int)
+  builder.add_result(I64)
   let dst = builder.new_vreg(Int)
   builder.append(Move, uses=[Virtual(src)], defs=[{ reg: Virtual(dst) }])
   |> ignore
@@ -60,6 +61,7 @@ test "output path keeps MachV virtual-register IR and reports allocations" {
 test "fixed constraints are consumed by canonical MachV regalloc" {
   let builder = @machv.FunctionBuilder::FunctionBuilder("fixed")
   let src = builder.add_param(Int)
+  builder.add_result(I64)
   let dst = builder.new_vreg(Int)
   let fixed : @abi.PReg = { index: 1, class: Int }
   builder.append(Move, uses=[Virtual(src)], defs=[{ reg: Virtual(dst) }], def_constraints=[
@@ -73,4 +75,46 @@ test "fixed constraints are consumed by canonical MachV regalloc" {
     embedding_abi=Some(test_embedding_abi()),
   )
   inspect(output.inst_def_loc(0, 0, false, 0), content="x1")
+}
+
+///|
+test "regalloc rejects invalid MachV before analysis" {
+  let func = @machv.Function::Function("invalid_regalloc_input")
+  func.new_block() |> ignore
+  try allocate_registers_backtracking_with_isa(func, AArch64) catch {
+    err => inspect(err, content="MissingTerminator(block_id=0)")
+  } noraise {
+    _ => fail("expected regalloc input verification to fail")
+  }
+}
+
+///|
+test "regalloc rejects non-canonical block id layout" {
+  let func = @machv.Function::Function("reordered_blocks")
+  func.new_block().set_terminator(Return([]))
+  func.new_block().set_terminator(Return([]))
+  func.get_blocks().rev_in_place()
+  try allocate_registers_backtracking_with_isa(func, AArch64) catch {
+    err =>
+      inspect(err, content="InvalidBlockLayout(block_id=1, expected_index=0)")
+  } noraise {
+    _ => fail("expected regalloc input verification to fail")
+  }
+}
+
+///|
+test "regalloc output verifier checks AArch64 physical registers" {
+  let output = Output::Output()
+  output.push_param_loc(Reg({ index: 32, class: Int }))
+  try output.validate_for_isa(AArch64) catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|InvalidInstruction(message="aarch64 regalloc output contains invalid preg x32 at param_locs[0]")
+        ),
+      )
+  } noraise {
+    _ => fail("expected regalloc output verification to fail")
+  }
 }

--- a/modules/machv_regalloc/output.mbt
+++ b/modules/machv_regalloc/output.mbt
@@ -339,10 +339,10 @@ pub fn Output::spill_reload_stats(self : Output) -> (Int, Int, Int, Int) {
 ///
 /// This is a fail-fast guard: silent truncation in x86 encoders can clobber rsp/rbp
 /// if an out-of-range preg leaks into emission (e.g. x20 -> rsp).
-pub fn Output::validate_for_isa(self : Output, isa : @isa.ISA) -> Unit {
-  if !(isa is AMD64) {
-    return
-  }
+pub fn Output::validate_for_isa(
+  self : Output,
+  isa : @isa.ISA,
+) -> Unit raise @machv.VerifyError {
   fn alloc_context(self : Output, alloc_idx : Int) -> String {
     for range in self.operand_ranges {
       let (block_id, inst_idx, is_terminator, range_start, def_count, use_count) = range
@@ -361,32 +361,29 @@ pub fn Output::validate_for_isa(self : Output, isa : @isa.ISA) -> Unit {
     "unknown"
   }
 
-  fn validate_preg(p : @abi.PReg, ctx_desc_fn : () -> String) -> Unit {
-    match p.class {
-      Int => {
-        guard p.index >= 0 && p.index < 16 else {
-          abort(
-            "amd64 regalloc output contains invalid Int preg \{p} at \{ctx_desc_fn()}",
-          )
-        }
-        // rsp/rbp are never allocatable as value registers.
-        guard p.index != 4 && p.index != 5 else {
-          abort(
-            "amd64 regalloc output contains reserved Int preg \{p} at \{ctx_desc_fn()}",
-          )
-        }
-      }
-      Float32 | Float64 | Vector => {
-        guard p.index >= 0 && p.index < 16 else {
-          abort(
-            "amd64 regalloc output contains invalid FP/Vec preg \{p} at \{ctx_desc_fn()}",
-          )
-        }
-      }
+  fn validate_preg(
+    p : @abi.PReg,
+    ctx_desc_fn : () -> String,
+  ) -> Unit raise @machv.VerifyError {
+    let valid = match (isa, p.class) {
+      (AArch64, Int) => p.index >= 0 && p.index < 32
+      (AArch64, Float32 | Float64 | Vector) => p.index >= 0 && p.index < 32
+      (AMD64, Int) =>
+        p.index >= 0 && p.index < 16 && p.index != 4 && p.index != 5
+      (AMD64, Float32 | Float64 | Vector) => p.index >= 0 && p.index < 16
+    }
+    if !valid {
+      let isa_name = if isa is AArch64 { "aarch64" } else { "amd64" }
+      raise @machv.VerifyError::invalid_instruction(
+        "\{isa_name} regalloc output contains invalid preg \{p} at \{ctx_desc_fn()}",
+      )
     }
   }
 
-  fn validate_loc(loc : Loc, ctx_desc_fn : () -> String) -> Unit {
+  fn validate_loc(
+    loc : Loc,
+    ctx_desc_fn : () -> String,
+  ) -> Unit raise @machv.VerifyError {
     if loc is Reg(p) {
       validate_preg(p, ctx_desc_fn)
     }

--- a/modules/machv_regalloc/pkg.generated.mbti
+++ b/modules/machv_regalloc/pkg.generated.mbti
@@ -12,15 +12,15 @@ import {
 }
 
 // Values
-pub fn allocate_registers_backtracking(@machv.Function, embedding_abi? : @abi.EmbeddingABI?) -> @machv.Function
+pub fn allocate_registers_backtracking(@machv.Function, embedding_abi? : @abi.EmbeddingABI?) -> @machv.Function raise @machv.VerifyError
 
-pub fn allocate_registers_backtracking_output(@machv.Function, embedding_abi? : @abi.EmbeddingABI?) -> (@machv.Function, Output)
+pub fn allocate_registers_backtracking_output(@machv.Function, embedding_abi? : @abi.EmbeddingABI?) -> (@machv.Function, Output) raise @machv.VerifyError
 
-pub fn allocate_registers_backtracking_output_with_isa(@machv.Function, @isa.ISA, embedding_abi? : @abi.EmbeddingABI?) -> (@machv.Function, Output)
+pub fn allocate_registers_backtracking_output_with_isa(@machv.Function, @isa.ISA, embedding_abi? : @abi.EmbeddingABI?) -> (@machv.Function, Output) raise @machv.VerifyError
 
-pub fn allocate_registers_backtracking_with_isa(@machv.Function, @isa.ISA, embedding_abi? : @abi.EmbeddingABI?) -> @machv.Function
+pub fn allocate_registers_backtracking_with_isa(@machv.Function, @isa.ISA, embedding_abi? : @abi.EmbeddingABI?) -> @machv.Function raise @machv.VerifyError
 
-pub fn apply_allocation(@machv.Function, RegAllocResult, @isa.ISA, @abi.EmbeddingABI) -> @machv.Function
+pub fn apply_allocation(@machv.Function, RegAllocResult, @isa.ISA, @abi.EmbeddingABI) -> @machv.Function raise @machv.VerifyError
 
 pub fn build_bundles_with_merging(@machv.Function, LiveRangeSet) -> BundleSet
 
@@ -30,9 +30,9 @@ pub fn build_live_ranges(@machv.Function, LivenessResult) -> LiveRangeSet
 
 pub fn build_stack_layout_aarch64(RegAllocResult, @machv.Function) -> AArch64StackFrame
 
-pub fn compute_liveness(@machv.Function) -> LivenessResult
+pub fn compute_liveness(@machv.Function) -> LivenessResult raise @machv.VerifyError
 
-pub fn compute_liveness_for_regalloc(@machv.Function) -> LivenessResult
+pub fn compute_liveness_for_regalloc(@machv.Function) -> LivenessResult raise @machv.VerifyError
 
 pub fn compute_loop_depths(@machv.Function) -> Array[Int]
 
@@ -42,7 +42,7 @@ pub fn debug_liveness(LivenessResult) -> String
 
 pub fn eliminate_dead_code(@machv.Function) -> @machv.Function
 
-pub fn get_alloc_stats(@machv.Function, isa? : @isa.ISA, embedding_abi? : @abi.EmbeddingABI?) -> AllocStats
+pub fn get_alloc_stats(@machv.Function, isa? : @isa.ISA, embedding_abi? : @abi.EmbeddingABI?) -> AllocStats raise @machv.VerifyError
 
 pub fn process_constraints(@machv.Function, RegAllocResult) -> Unit
 
@@ -186,7 +186,7 @@ pub fn Output::sort_edits(Self) -> Unit
 pub fn Output::spill_reload_stats(Self) -> (Int, Int, Int, Int)
 pub fn Output::summary(Self) -> String
 pub fn Output::uses_preg_index_any(Self, Int, Bool) -> Bool
-pub fn Output::validate_for_isa(Self, @isa.ISA) -> Unit
+pub fn Output::validate_for_isa(Self, @isa.ISA) -> Unit raise @machv.VerifyError
 
 pub struct ProgPoint {
   block : Int

--- a/modules/machv_regalloc/regalloc_analysis.mbt
+++ b/modules/machv_regalloc/regalloc_analysis.mbt
@@ -500,13 +500,19 @@ fn compute_liveness_with_options(
 
 ///|
 /// Compute full liveness information including interval maps.
-pub fn compute_liveness(func : @machv.Function) -> LivenessResult {
+pub fn compute_liveness(
+  func : @machv.Function,
+) -> LivenessResult raise @machv.VerifyError {
+  func.verify_for_regalloc()
   compute_liveness_with_options(func, true, true)
 }
 
 ///|
 /// Compute liveness for regalloc hot path (no interval map construction).
-pub fn compute_liveness_for_regalloc(func : @machv.Function) -> LivenessResult {
+pub fn compute_liveness_for_regalloc(
+  func : @machv.Function,
+) -> LivenessResult raise @machv.VerifyError {
+  func.verify_for_regalloc()
   compute_liveness_with_options(func, false, false)
 }
 

--- a/modules/machv_regalloc/regalloc_apply.mbt
+++ b/modules/machv_regalloc/regalloc_apply.mbt
@@ -20,7 +20,8 @@ pub fn apply_allocation(
   alloc : RegAllocResult,
   isa : @isa.ISA,
   embedding_abi : @abi.EmbeddingABI,
-) -> @machv.Function {
+) -> @machv.Function raise @machv.VerifyError {
+  func.verify_for_regalloc_isa(isa)
   let new_func = func.clone_base()
   new_func.set_num_spill_slots(alloc.num_spill_slots)
   let block_id_to_index : Map[Int, Int] = Map([])
@@ -161,7 +162,7 @@ pub fn apply_allocation(
   }
 
   // Keep reload-coalescing pass disabled by default for Cranelift alignment.
-  let liveness = compute_liveness_for_regalloc(func)
+  let liveness = compute_liveness_with_options(func, false, false)
   let enable_reload_coalescing = false
   let reload_intervals : Map[(Int, Int), ReloadInterval] = if enable_reload_coalescing {
     let intervals = compute_reload_intervals(func, alloc)
@@ -295,11 +296,6 @@ pub fn apply_allocation(
         }
       }
     }
-  }
-
-  // Copy results
-  for r in func.results {
-    new_func.results.push(r)
   }
 
   // Copy result types for multi-value return support
@@ -887,7 +883,9 @@ pub fn apply_allocation(
       "unconsumed inst_edits entries: consumed=\{inst_edits_cursor} total=\{alloc.inst_edits.length()}",
     )
   }
-  eliminate_trivial_moves(new_func)
+  let result = eliminate_trivial_moves(new_func)
+  result.verify_for_regalloc_isa(isa)
+  result
 }
 
 ///|
@@ -909,9 +907,6 @@ fn eliminate_trivial_moves(func : @machv.Function) -> @machv.Function {
   }
   for preg in func.param_pregs {
     new_func.param_pregs.push(preg)
-  }
-  for result in func.results {
-    new_func.results.push(result)
   }
   for ty in func.result_kinds {
     new_func.result_kinds.push(ty)

--- a/modules/machv_regalloc/regalloc_misc.mbt
+++ b/modules/machv_regalloc/regalloc_misc.mbt
@@ -168,12 +168,9 @@ pub fn eliminate_dead_code(func : @machv.Function) -> @machv.Function {
   // Step 2: Build new function without dead instructions
   let new_func = func.clone_base()
 
-  // Copy params and results
+  // Copy params and result types
   for param in func.params {
     new_func.params.push(param)
-  }
-  for result in func.results {
-    new_func.results.push(result)
   }
   // Copy result types for multi-value return support
   for ty in func.result_kinds {
@@ -321,7 +318,7 @@ fn build_reg_pools(
 pub fn allocate_registers_backtracking(
   func : @machv.Function,
   embedding_abi? : @abi.EmbeddingABI? = None,
-) -> @machv.Function {
+) -> @machv.Function raise @machv.VerifyError {
   allocate_registers_backtracking_with_isa(func, AArch64, embedding_abi~)
 }
 
@@ -331,12 +328,14 @@ pub fn allocate_registers_backtracking_with_isa(
   func : @machv.Function,
   isa : @isa.ISA,
   embedding_abi? : @abi.EmbeddingABI? = None,
-) -> @machv.Function {
+) -> @machv.Function raise @machv.VerifyError {
+  func.verify_for_regalloc_isa(isa)
   // Keep Cranelift-style cheap rematerialization before allocation to shorten
   // cross-block live ranges for constants/function pointers.
   let func = rematerialize_long_distance_constants(func)
   let func = rematerialize_cross_block_constants(func)
   let func = eliminate_dead_code(func)
+  func.verify_for_regalloc_isa(isa)
   let embedding_abi = require_embedding_abi(embedding_abi)
 
   // Build register pools
@@ -349,7 +348,7 @@ pub fn allocate_registers_backtracking_with_isa(
   ) = build_reg_pools(isa, func, embedding_abi)
 
   // Compute liveness (Phase 1)
-  let liveness = compute_liveness_for_regalloc(func)
+  let liveness = compute_liveness_with_options(func, false, false)
   let algorithm = selected_regalloc_algorithm()
 
   // Delegate allocator-core decisions to regalloc through the MachV adapter.
@@ -383,7 +382,7 @@ pub fn allocate_registers_backtracking_with_isa(
 pub fn allocate_registers_backtracking_output(
   func : @machv.Function,
   embedding_abi? : @abi.EmbeddingABI? = None,
-) -> (@machv.Function, Output) {
+) -> (@machv.Function, Output) raise @machv.VerifyError {
   allocate_registers_backtracking_output_with_isa(func, AArch64, embedding_abi~)
 }
 
@@ -394,12 +393,14 @@ pub fn allocate_registers_backtracking_output_with_isa(
   func : @machv.Function,
   isa : @isa.ISA,
   embedding_abi? : @abi.EmbeddingABI? = None,
-) -> (@machv.Function, Output) {
+) -> (@machv.Function, Output) raise @machv.VerifyError {
+  func.verify_for_regalloc_isa(isa)
   // Keep Cranelift-style cheap rematerialization before allocation to shorten
   // cross-block live ranges for constants/function pointers.
   let func = rematerialize_long_distance_constants(func)
   let func = rematerialize_cross_block_constants(func)
   let func = eliminate_dead_code(func)
+  func.verify_for_regalloc_isa(isa)
   let embedding_abi = require_embedding_abi(embedding_abi)
 
   // Build register pools.
@@ -414,7 +415,7 @@ pub fn allocate_registers_backtracking_output_with_isa(
   // Compute liveness (Phase 1).
   let perf_on = perf_enabled()
   let tick_liveness = if perf_on { Some(perf_tick_now()) } else { None }
-  let liveness = compute_liveness_for_regalloc(func)
+  let liveness = compute_liveness_with_options(func, false, false)
   let algorithm = selected_regalloc_algorithm()
   if tick_liveness is Some(tick) {
     perf_record_regalloc_phase_us(
@@ -448,9 +449,7 @@ pub fn allocate_registers_backtracking_output_with_isa(
   if tick_output is Some(tick) {
     perf_record_regalloc_phase_us("phase_build_output", perf_elapsed_us(tick))
   }
-  if regalloc_validation_enabled() {
-    output.validate_for_isa(isa)
-  }
+  output.validate_for_isa(isa)
   (func, output)
 }
 
@@ -509,7 +508,8 @@ pub fn get_alloc_stats(
   func : @machv.Function,
   isa? : @isa.ISA = AArch64,
   embedding_abi? : @abi.EmbeddingABI? = None,
-) -> AllocStats {
+) -> AllocStats raise @machv.VerifyError {
+  func.verify_for_regalloc_isa(isa)
   let func = eliminate_dead_code(func)
   let func = rematerialize_cross_block_constants(func)
   let func = eliminate_dead_code(func)
@@ -521,7 +521,7 @@ pub fn get_alloc_stats(
     callee_saved_int_regs,
     callee_saved_float_regs,
   ) = build_reg_pools(isa, func, embedding_abi)
-  let liveness = compute_liveness(func)
+  let liveness = compute_liveness_with_options(func, true, true)
 
   // Count vregs
   let num_vregs = liveness.intervals.length()

--- a/modules/milkir/pkg.generated.mbti
+++ b/modules/milkir/pkg.generated.mbti
@@ -35,6 +35,7 @@ pub suberror VerifyError {
   TypeMismatch(message~ : String)
   UnverifiableInstruction(message~ : String)
 } derive(Eq, @debug.Debug)
+pub fn VerifyError::unverifiable_instruction(String) -> Self
 pub impl Show for VerifyError
 
 // Types and methods

--- a/modules/milkir/verify.mbt
+++ b/modules/milkir/verify.mbt
@@ -31,6 +31,13 @@ pub impl Show for VerifyError with fn output(self, logger) {
 }
 
 ///|
+/// Construct a structured error for a consumer seam that cannot validate or
+/// lower an otherwise well-formed MilkIR function.
+pub fn VerifyError::unverifiable_instruction(message : String) -> VerifyError {
+  UnverifiableInstruction(message~)
+}
+
+///|
 pub fn Function::verify(self : Function) -> Unit raise VerifyError {
   if self.owner.val.construction_error is Some(error) {
     raise error

--- a/modules/milkir_machv/lower/lower.mbt
+++ b/modules/milkir_machv/lower/lower.mbt
@@ -1703,7 +1703,7 @@ fn lower_function_with_config_unchecked(
     @block.Block,
     @milkir.ExtOp,
   ) -> ExtensionLowerResult)?,
-) -> @machv.Function {
+) -> @machv.Function raise @milkir.VerifyError {
   // Keep this optional for call sites that already ran full IR optimization.
   if config.run_ir_opt {
     @milkir.optimize_with_level(ir_func, @milkir.OptLevel::from_int(0))
@@ -1806,8 +1806,6 @@ fn lower_function_with_config_unchecked(
 
   // Phase 3: Lower result types
   for ty in ir_func.results {
-    let class = ir_type_to_reg_class(ty)
-    ctx.machv_func.add_result(class)
     ctx.machv_func.add_result_kind(ir_type_to_value_kind(ty))
   }
 
@@ -1845,6 +1843,12 @@ fn lower_function_with_config_unchecked(
   // lowering site to set it correctly.
   if ctx.isa is AMD64 {
     fixup_amd64_shift_count_constraints(ctx.machv_func)
+  }
+  ctx.machv_func.verify() catch {
+    error =>
+      raise @milkir.VerifyError::unverifiable_instruction(
+        "invalid MachV produced by lowering: \{error}",
+      )
   }
   ctx.machv_func
 }
@@ -2584,16 +2588,36 @@ fn lower_terminator(
       }
       block.set_terminator(Jump(target_id, regs))
     }
-    Branch(cond, true_target, _true_args, false_target, _false_args) =>
-      // TODO(milkir): MachV MachV currently has no edge-argument branch
-      // terminator. Lower branch arguments through explicit block-param copies.
+    Branch(cond, true_target, true_args, false_target, false_args) => {
+      fn lower_edge(
+        ctx : LoweringContext,
+        source : @block.Block,
+        target : Int,
+        args : Array[@milkir.Value],
+      ) -> Int {
+        let target_id = ctx.get_block_id(target)
+        if args.is_empty() {
+          return target_id
+        }
+        let edge = ctx.machv_func.new_block()
+        let regs : Array[@abi.Reg] = []
+        for arg in args {
+          regs.push(Virtual(ctx.get_vreg_for_use(arg, source)))
+        }
+        edge.set_terminator(Jump(target_id, regs))
+        edge.id
+      }
+
+      let true_edge = lower_edge(ctx, block, true_target, true_args)
+      let false_edge = lower_edge(ctx, block, false_target, false_args)
       block.set_terminator(
         Branch(
           Virtual(ctx.get_vreg_for_use(cond, block)),
-          ctx.get_block_id(true_target),
-          ctx.get_block_id(false_target),
+          true_edge,
+          false_edge,
         ),
       )
+    }
     Brz(cond, then_block, else_block) => {
       let then_id = ctx.get_block_id(then_block)
       let else_id = ctx.get_block_id(else_block)

--- a/modules/milkir_machv/validation_seam_test.mbt
+++ b/modules/milkir_machv/validation_seam_test.mbt
@@ -65,3 +65,62 @@ test "dialect lowering applies its explicit adapter verifier" {
     _ => fail("expected dialect lowering to apply adapter validation")
   }
 }
+
+///|
+test "conditional edge arguments lower through explicit jump blocks" {
+  let signature = @milkir.Signature::Signature([], [I64])
+  let func = @milkir.Function::with_signature("branch_edges", signature)
+  let cond = func.new_value(I32)
+  let true_value = func.new_value(I64)
+  let false_value = func.new_value(I64)
+  let true_param = func.new_value(I64)
+  let false_param = func.new_value(I64)
+  let entry = func.new_block([])
+  let then_block = func.new_block([true_param])
+  let else_block = func.new_block([false_param])
+  entry.append_inst(func.new_inst(Scalar(IntConst(1L)), [], [cond]))
+  entry.append_inst(func.new_inst(Scalar(IntConst(42L)), [], [true_value]))
+  entry.append_inst(func.new_inst(Scalar(IntConst(7L)), [], [false_value]))
+  entry.set_terminator(
+    Branch(cond, then_block.id, [true_value], else_block.id, [false_value]),
+  )
+  then_block.set_terminator(Return([true_param]))
+  else_block.set_terminator(Return([false_param]))
+  let call_conv : @abi.CallConventionLayout = {
+    context_arg: { index: 27, class: Int },
+    user_arg_gprs: [],
+    arg_fprs: [],
+    ret_gprs: [{ index: 0, class: Int }],
+    ret_fprs: [],
+  }
+  let embedding_abi = @abi.EmbeddingABI::EmbeddingABI(
+    call_conv,
+    reserve_context_role=false,
+  )
+  let lowered = @lower.lower_function(
+    func,
+    run_ir_opt=false,
+    embedding_abi=Some(embedding_abi),
+  )
+  inspect(
+    lowered.print(),
+    content=(
+      #|machv branch_edges() -> int {
+      #|block0:
+      #|    v2 = ldi 1
+      #|    v3 = ldi 42
+      #|    v4 = ldi 7
+      #|    branch v2, block3, block4
+      #|block1(v0:int):
+      #|    ret v0
+      #|block2(v1:int):
+      #|    ret v1
+      #|block3:
+      #|    jump block1 (v3)
+      #|block4:
+      #|    jump block2 (v4)
+      #|}
+      #|
+    ),
+  )
+}

--- a/modules/wasmoon/cmd/wasmoon/commands/run.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/run.mbt
@@ -1711,7 +1711,21 @@ pub fn compile_module_to_jit(
       machv_func,
       isa,
       embedding_abi=Some(embedding_abi),
-    )
+    ) catch {
+      err => {
+        emit_compile_progress(
+          on_progress,
+          Failed,
+          progress_start,
+          total_compile_funcs,
+          compiled_count,
+          func_idx=Some(func_idx),
+          func_name=Some(func_name),
+          message=Some(err.to_string()),
+        )
+        return None
+      }
+    }
     if regalloc_tick is Some(tick) {
       @perf.record_stage_us("regalloc", @perf.elapsed_us(tick))
       let (spills, reloads, reg_moves, spill_to_spill) = ra_output.spill_reload_stats()
@@ -1745,7 +1759,21 @@ pub fn compile_module_to_jit(
       force_frame_setup=enable_dwarf,
       embedding_abi=Some(embedding_abi),
       record_disasm=debug_db is Some(_),
-    )
+    ) catch {
+      err => {
+        emit_compile_progress(
+          on_progress,
+          Failed,
+          progress_start,
+          total_compile_funcs,
+          compiled_count,
+          func_idx=Some(func_idx),
+          func_name=Some(func_name),
+          message=Some(err.to_string()),
+        )
+        return None
+      }
+    }
     if emit_tick is Some(tick) {
       @perf.record_stage_us("emit", @perf.elapsed_us(tick))
     }

--- a/modules/wasmoon/jit/ffi_jit.mbt
+++ b/modules/wasmoon/jit/ffi_jit.mbt
@@ -312,7 +312,9 @@ fn JITContext::call_multi_return(
         result_codes_arr,
         @wasmoon_jit.wasm_calling_convention(isa~),
         isa~,
-      )
+      ) catch {
+        err => raise JITTrap("entry trampoline verification failed: \{err}")
+      }
       let code_ints = mc.get_bytes()
       let trampoline = @wasmoon_jit.ExecCode::try_alloc(code_ints)
       match trampoline {

--- a/modules/wasmoon/jit/jit_runtime.mbt
+++ b/modules/wasmoon/jit/jit_runtime.mbt
@@ -28,6 +28,12 @@ pub suberror JITModuleLoadError {
     func_name~ : String,
     code_size~ : Int
   )
+  ImportTrampolineCompilationFailed(
+    import_idx~ : Int,
+    module_name~ : String,
+    func_name~ : String,
+    message~ : String
+  )
   FunctionCodeAllocationFailed(
     func_idx~ : Int,
     func_name~ : String,
@@ -259,7 +265,15 @@ pub fn JITModule::load_with_imports(
                 @wasmoon_jit.runtime_hostcall_symbol(),
                 @wasmoon_jit.wasm_calling_convention(isa~),
                 isa~,
-              )
+              ) catch {
+                err =>
+                  raise ImportTrampolineCompilationFailed(
+                    import_idx=i,
+                    module_name=imp.module_name,
+                    func_name=imp.func_name,
+                    message=err.to_string(),
+                  )
+              }
               let code_ints = mc.get_bytes()
               let exec = @wasmoon_jit.ExecCode::try_alloc(code_ints)
               match exec {

--- a/modules/wasmoon/jit/pkg.generated.mbti
+++ b/modules/wasmoon/jit/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub suberror JITModuleLoadError {
   ContextAllocationFailed(total_funcs~ : Int)
   UnsupportedImport(import_idx~ : Int, module_name~ : String, func_name~ : String)
   ImportTrampolineAllocationFailed(import_idx~ : Int, module_name~ : String, func_name~ : String, code_size~ : Int)
+  ImportTrampolineCompilationFailed(import_idx~ : Int, module_name~ : String, func_name~ : String, message~ : String)
   FunctionCodeAllocationFailed(func_idx~ : Int, func_name~ : String, code_size~ : Int)
 } derive(@debug.Debug)
 pub impl Show for JITModuleLoadError

--- a/modules/wasmoon/pkg.generated.mbti
+++ b/modules/wasmoon/pkg.generated.mbti
@@ -14,7 +14,7 @@ import {
 }
 
 // Values
-pub fn compiler_infrastructure_assembly() -> CompilerInfrastructureAssembly
+pub fn compiler_infrastructure_assembly() -> CompilerInfrastructureAssembly raise WasmCompilerPipelineError
 
 pub fn plan_wasm_function_with_compiler_infra(@embedding.EmbeddingEnvironment, @types.Module, Int, @machv_emit.EmitTarget, opt_level? : Int) -> @wasmoon_jit.JitIntegrationPlan raise WasmCompilerPipelineError
 

--- a/modules/wasmoon/runtime_assembly.mbt
+++ b/modules/wasmoon/runtime_assembly.mbt
@@ -116,7 +116,7 @@ pub fn runtime_assembly() -> RuntimeAssembly {
 }
 
 ///|
-pub fn compiler_infrastructure_assembly() -> CompilerInfrastructureAssembly {
+pub fn compiler_infrastructure_assembly() -> CompilerInfrastructureAssembly raise WasmCompilerPipelineError {
   let signature = @milkir.Signature::Signature([], [])
   let milk = @milkir.Function::with_signature(
     "wasmoon_runtime_probe", signature,
@@ -132,16 +132,21 @@ pub fn compiler_infrastructure_assembly() -> CompilerInfrastructureAssembly {
   let (allocated_function, output) = @machv_regalloc.allocate_registers_backtracking_output(
     machv_function,
     embedding_abi=Some(embedding_abi),
-  )
+  ) catch {
+    err => raise WasmCompilerPipelineFailure(message=to_repr(err).to_string())
+  }
+  let code_object = @machv_emit.emit_function_with_regalloc(
+    allocated_function,
+    output,
+    embedding_abi=Some(embedding_abi),
+  ) catch {
+    err => raise WasmCompilerPipelineFailure(message=to_repr(err).to_string())
+  }
   {
     signature,
     machv_function,
     allocated_function,
-    code_object: @machv_emit.emit_function_with_regalloc(
-      allocated_function,
-      output,
-      embedding_abi=Some(embedding_abi),
-    ),
+    code_object,
     x64_abi: @x64_target.abi_policy(),
     aarch64_abi: @aarch64_target.abi_policy(),
     jit_glue: @wasmoon_jit.default_native_glue(),

--- a/modules/wasmoon/testsuite/compare.mbt
+++ b/modules/wasmoon/testsuite/compare.mbt
@@ -388,9 +388,22 @@ fn run_jit_with_opt_level(
     let linker = @runtime.Linker::Linker()
     let store = linker.get_store()
     let instance = @executor.instantiate_with_linker(linker, "test", mod_)
-    guard @commands.compile_module_to_jit(mod_, false, false, opt_level, false)
+    let mut compile_error : String? = None
+    guard @commands.compile_module_to_jit(
+        mod_,
+        false,
+        false,
+        opt_level,
+        false,
+        on_progress=fn(event) {
+          if event.stage is Failed {
+            compile_error = event.message
+          }
+          None
+        },
+      )
       is Some((precompiled, debug_db)) else {
-      return Err("JIT compile returned unsupported")
+      return Err(compile_error.unwrap_or("JIT compile returned unsupported"))
     }
     let func_signatures = @wast.build_func_signatures(mod_)
     let external_imports = @wast.build_external_imports_for_jit(

--- a/modules/wasmoon_jit/entry_trampoline_emit.mbt
+++ b/modules/wasmoon_jit/entry_trampoline_emit.mbt
@@ -35,7 +35,7 @@ pub fn emit_entry_trampoline(
   result_types : Array[Int],
   call_conv_layout : @abi.CallConventionLayout,
   isa? : @isa.ISA = AArch64,
-) -> @machv_emit.MachineCode {
+) -> @machv_emit.MachineCode raise JitPipelineError {
   // Generate trampoline as IR using FunctionBuilder
   let ir_func = generate_trampoline_ir(param_types, result_types)
   let embedding_abi = @abi.EmbeddingABI::EmbeddingABI(
@@ -54,10 +54,14 @@ pub fn emit_entry_trampoline(
     machv_func,
     isa,
     embedding_abi=Some(embedding_abi),
-  )
+  ) catch {
+    err => raise PipelineFailure(message=to_repr(err).to_string())
+  }
 
   // Emit machine code
-  @machv_emit.emit_function(allocated, isa~, embedding_abi=Some(embedding_abi))
+  @machv_emit.emit_function(allocated, isa~, embedding_abi=Some(embedding_abi)) catch {
+    err => raise PipelineFailure(message=to_repr(err).to_string())
+  }
 }
 
 ///|

--- a/modules/wasmoon_jit/hostcall_trampoline.mbt
+++ b/modules/wasmoon_jit/hostcall_trampoline.mbt
@@ -72,7 +72,7 @@ pub fn emit_hostcall_import_trampoline(
   hostcall_symbol : @instr.ExternalName,
   call_conv_layout : @abi.CallConventionLayout,
   isa? : @isa.ISA = AArch64,
-) -> @machv_emit.MachineCode {
+) -> @machv_emit.MachineCode raise JitPipelineError {
   let func = @machv.Function::Function("host_import_trampoline")
   let roles = wasm_embedding_reg_roles(isa~)
 
@@ -134,7 +134,6 @@ pub fn emit_hostcall_import_trampoline(
 
   // Results.
   for ty in result_types {
-    func.add_result(value_type_to_reg_class(ty))
     func.add_result_kind(value_type_to_value_kind(ty))
   }
 
@@ -325,6 +324,10 @@ pub fn emit_hostcall_import_trampoline(
     func,
     isa,
     embedding_abi=Some(embedding_abi),
-  )
-  @machv_emit.emit_function(allocated, isa~, embedding_abi=Some(embedding_abi))
+  ) catch {
+    err => raise PipelineFailure(message=to_repr(err).to_string())
+  }
+  @machv_emit.emit_function(allocated, isa~, embedding_abi=Some(embedding_abi)) catch {
+    err => raise PipelineFailure(message=to_repr(err).to_string())
+  }
 }

--- a/modules/wasmoon_jit/native_glue.mbt
+++ b/modules/wasmoon_jit/native_glue.mbt
@@ -120,19 +120,22 @@ pub fn plan_integration_for_target(
   machv_func : @machv.Function,
   regalloc_output : @machv_regalloc.Output,
   target : @machv_emit.EmitTarget,
-) -> JitIntegrationPlan {
+) -> JitIntegrationPlan raise JitPipelineError {
   let isa = emit_target_to_isa(target)
   let embedding_abi = wasm_embedding_abi_for_isa(isa)
+  let object = @machv_emit.emit_function_with_regalloc(
+    machv_func,
+    regalloc_output,
+    isa~,
+    embedding_abi=Some(embedding_abi),
+  ) catch {
+    err => raise PipelineFailure(message=err.to_string())
+  }
   {
     entry_symbol: func.name,
     target,
     native_glue: default_native_glue(),
-    object: @machv_emit.emit_function_with_regalloc(
-      machv_func,
-      regalloc_output,
-      isa~,
-      embedding_abi=Some(embedding_abi),
-    ),
+    object,
   }
 }
 
@@ -204,7 +207,9 @@ pub fn plan_milkir_integration_for_target(
     machv_func,
     isa,
     embedding_abi=Some(embedding_abi),
-  )
+  ) catch {
+    err => raise PipelineFailure(message=err.to_string())
+  }
   plan_integration_for_target(func, allocated_func, output, target)
 }
 
@@ -230,6 +235,8 @@ pub fn plan_wasm_body_milkir_integration_for_target(
     machv_func,
     isa,
     embedding_abi=Some(embedding_abi),
-  )
+  ) catch {
+    err => raise PipelineFailure(message=err.to_string())
+  }
   plan_integration_for_target(func, allocated_func, output, target)
 }

--- a/modules/wasmoon_jit/pkg.generated.mbti
+++ b/modules/wasmoon_jit/pkg.generated.mbti
@@ -100,9 +100,9 @@ pub fn direct_call_idx_memory_fill_mem0() -> Int
 
 pub fn embedding_context_layout() -> @abi.EmbeddingContextLayout
 
-pub fn emit_entry_trampoline(Array[Int], Array[Int], @abi.CallConventionLayout, isa? : @isa.ISA) -> @machv_emit.MachineCode
+pub fn emit_entry_trampoline(Array[Int], Array[Int], @abi.CallConventionLayout, isa? : @isa.ISA) -> @machv_emit.MachineCode raise JitPipelineError
 
-pub fn emit_hostcall_import_trampoline(Array[@types.ValueType], Array[@types.ValueType], Int, @instr.ExternalName, @abi.CallConventionLayout, isa? : @isa.ISA) -> @machv_emit.MachineCode
+pub fn emit_hostcall_import_trampoline(Array[@types.ValueType], Array[@types.ValueType], Int, @instr.ExternalName, @abi.CallConventionLayout, isa? : @isa.ISA) -> @machv_emit.MachineCode raise JitPipelineError
 
 pub fn emit_target_to_isa(@machv_emit.EmitTarget) -> @isa.ISA
 
@@ -404,7 +404,7 @@ pub fn plan_entry_trampoline_for_target(Array[@types.ValueType], Array[@types.Va
 
 pub fn plan_hostcall_import_trampoline_layout(Array[@types.ValueType], Array[@types.ValueType], Int, Int) -> HostcallImportTrampolineLayout
 
-pub fn plan_integration_for_target(@milkir.Function, @machv.Function, @machv_regalloc.Output, @machv_emit.EmitTarget) -> JitIntegrationPlan
+pub fn plan_integration_for_target(@milkir.Function, @machv.Function, @machv_regalloc.Output, @machv_emit.EmitTarget) -> JitIntegrationPlan raise JitPipelineError
 
 pub fn plan_milkir_integration_for_target(@milkir.Function, @machv_emit.EmitTarget) -> JitIntegrationPlan raise JitPipelineError
 

--- a/modules/x64_target/x64_target_test.mbt
+++ b/modules/x64_target/x64_target_test.mbt
@@ -68,7 +68,7 @@ test "x64 wrapper accepts an explicit call convention" {
     custom_test_call_conv(),
   )
   inspect(lowered.params.length(), content="2")
-  inspect(lowered.results.length(), content="1")
+  inspect(lowered.result_kinds.length(), content="1")
 }
 
 ///|


### PR DESCRIPTION
## What

- Add structured MachV verification for CFG shape, block arguments, return contracts, virtual-register definitions and dominance, operand constraints, and exhaustive opcode contracts.
- Add ISA-aware physical-register validation for MachV and register-allocation output.
- Make `FunctionBuilder::finish()` verify the function before returning it.
- Revalidate MachV at lowering, register-allocation, layout, and emission boundaries where mutable IR may have changed.
- Preserve MilkIR branch edge arguments by lowering them through explicit edge blocks.
- Add verifier regression tests and update the MachV contract documentation and generated interfaces.

## Why

MachV previously had no verifier: builders returned unchecked functions, and malformed machine IR could reach register allocation or emission. Failures therefore surfaced late as aborts, encoder corruption, or incorrect code rather than structured diagnostics at the boundary that introduced the invalid IR.

## Impact

Compiler stages now fail fast with `MachV::VerifyError` when handed malformed IR. Public builder, regalloc, and emission entry points can raise structured verification errors, so downstream callers must propagate or handle them.

## Checks

- `moon check --deny-warn --warn-list '+73'`
- `moon test --deny-warn --warn-list '+73'` (598 wasm-gc tests, 1330 native tests)
- `python3 scripts/audit_module_boundaries.py`
- `moon fmt --check`
- `git diff --check origin/main...HEAD`
