### PR TITLE
Release all modules with patch versions

### DIFF
--- a/modules/aarch64_target/moon.mod
+++ b/modules/aarch64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/aarch64_target"
 
-version = "0.3.1"
+version = "0.3.2"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "aarch64", "compiler", "codegen", "jit" ]
 description = "AArch64 target pipeline from semantic MachV to native code"
 
 import {
-  "Milky2018/milkir@0.3.1",
-  "Milky2018/machv@0.5.1",
-  "Milky2018/machv_regalloc@0.3.1",
-  "Milky2018/milkir_machv@0.4.1",
+  "Milky2018/milkir@0.3.2",
+  "Milky2018/machv@0.5.2",
+  "Milky2018/machv_regalloc@0.3.2",
+  "Milky2018/milkir_machv@0.4.2",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/machv/moon.mod
+++ b/modules/machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv"
 
-version = "0.5.1"
+version = "0.5.2"
 
 readme = "README.mbt.md"
 

--- a/modules/machv_regalloc/moon.mod
+++ b/modules/machv_regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv_regalloc"
 
-version = "0.3.1"
+version = "0.3.2"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "Target VCode adapter for the reusable register allocator"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/machv@0.5.1",
-  "Milky2018/regalloc@0.4.0",
+  "Milky2018/machv@0.5.2",
+  "Milky2018/regalloc@0.4.1",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/milkir/moon.mod
+++ b/modules/milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir"
 
-version = "0.3.1"
+version = "0.3.2"
 
 readme = "README.mbt.md"
 

--- a/modules/milkir_machv/moon.mod
+++ b/modules/milkir_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir_machv"
 
-version = "0.4.1"
+version = "0.4.2"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "MilkIR-to-MachV lowering"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/milkir@0.3.1",
-  "Milky2018/machv@0.5.1",
+  "Milky2018/milkir@0.3.2",
+  "Milky2018/machv@0.5.2",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/regalloc/moon.mod
+++ b/modules/regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/regalloc"
 
-version = "0.4.0"
+version = "0.4.1"
 
 readme = "README.mbt.md"
 

--- a/modules/wasm_core/moon.mod
+++ b/modules/wasm_core/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_core"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.mbt.md"
 

--- a/modules/wasm_machv/moon.mod
+++ b/modules/wasm_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_machv"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "wasm", "webassembly", "milkir", "machv", "lowering" ]
 description = "WebAssembly MilkIR dialect adapter for target-neutral MachV"
 
 import {
-  "Milky2018/wasm_milkir@0.3.1",
-  "Milky2018/milkir@0.3.1",
-  "Milky2018/machv@0.5.1",
-  "Milky2018/milkir_machv@0.4.1",
+  "Milky2018/wasm_milkir@0.3.2",
+  "Milky2018/milkir@0.3.2",
+  "Milky2018/machv@0.5.2",
+  "Milky2018/milkir_machv@0.4.2",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasm_milkir/moon.mod
+++ b/modules/wasm_milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_milkir"
 
-version = "0.3.1"
+version = "0.3.2"
 
 readme = "README.mbt.md"
 
@@ -13,7 +13,7 @@ keywords = [ "wasm", "webassembly", "milkir", "compiler", "dialect" ]
 description = "WebAssembly dialect adapter for MilkIR extension operations"
 
 import {
-  "Milky2018/milkir@0.3.1",
+  "Milky2018/milkir@0.3.2",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasmoon/moon.mod
+++ b/modules/wasmoon/moon.mod
@@ -1,19 +1,19 @@
 name = "Milky2018/wasmoon"
 
-version = "0.9.1"
+version = "0.9.2"
 
 import {
   "moonbitlang/x@0.4.38",
   "TheWaWaR/clap@0.2.6",
-  "Milky2018/wasm_core@0.2.0",
-  "Milky2018/wasm_milkir@0.3.1",
-  "Milky2018/milkir@0.3.1",
-  "Milky2018/machv@0.5.1",
-  "Milky2018/milkir_machv@0.4.1",
-  "Milky2018/machv_regalloc@0.3.1",
-  "Milky2018/x64_target@0.2.1",
-  "Milky2018/aarch64_target@0.3.1",
-  "Milky2018/wasmoon_jit@0.4.1",
+  "Milky2018/wasm_core@0.2.1",
+  "Milky2018/wasm_milkir@0.3.2",
+  "Milky2018/milkir@0.3.2",
+  "Milky2018/machv@0.5.2",
+  "Milky2018/milkir_machv@0.4.2",
+  "Milky2018/machv_regalloc@0.3.2",
+  "Milky2018/x64_target@0.2.2",
+  "Milky2018/aarch64_target@0.3.2",
+  "Milky2018/wasmoon_jit@0.4.2",
 }
 
 readme = "README.mbt.md"

--- a/modules/wasmoon_jit/moon.mod
+++ b/modules/wasmoon_jit/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasmoon_jit"
 
-version = "0.4.1"
+version = "0.4.2"
 
 readme = "README.mbt.md"
 
@@ -14,15 +14,15 @@ description = "Wasmoon-specific JIT integration and native runtime glue"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/wasm_core@0.2.0",
-  "Milky2018/wasm_milkir@0.3.1",
-  "Milky2018/wasm_machv@0.2.1",
-  "Milky2018/milkir@0.3.1",
-  "Milky2018/machv@0.5.1",
-  "Milky2018/milkir_machv@0.4.1",
-  "Milky2018/machv_regalloc@0.3.1",
-  "Milky2018/aarch64_target@0.3.1",
-  "Milky2018/x64_target@0.2.1",
+  "Milky2018/wasm_core@0.2.1",
+  "Milky2018/wasm_milkir@0.3.2",
+  "Milky2018/wasm_machv@0.2.2",
+  "Milky2018/milkir@0.3.2",
+  "Milky2018/machv@0.5.2",
+  "Milky2018/milkir_machv@0.4.2",
+  "Milky2018/machv_regalloc@0.3.2",
+  "Milky2018/aarch64_target@0.3.2",
+  "Milky2018/x64_target@0.2.2",
 }
 
 preferred_target = "native"

--- a/modules/x64_target/moon.mod
+++ b/modules/x64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/x64_target"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "x64", "x86-64", "compiler", "codegen" ]
 description = "x64 target pipeline from semantic MachV to native code"
 
 import {
-  "Milky2018/milkir@0.3.1",
-  "Milky2018/machv@0.5.1",
-  "Milky2018/machv_regalloc@0.3.1",
-  "Milky2018/milkir_machv@0.4.1",
+  "Milky2018/milkir@0.3.2",
+  "Milky2018/machv@0.5.2",
+  "Milky2018/machv_regalloc@0.3.2",
+  "Milky2018/milkir_machv@0.4.2",
 }
 
 preferred_target = "wasm-gc"


### PR DESCRIPTION
## Summary

Raise every publishable workspace module by one patch version and update all
internal dependency pins to the matching releases.

## Released versions

- `Milky2018/wasm_core@0.2.1`
- `Milky2018/milkir@0.3.2`
- `Milky2018/machv@0.5.2`
- `Milky2018/regalloc@0.4.1`
- `Milky2018/wasm_milkir@0.3.2`
- `Milky2018/milkir_machv@0.4.2`
- `Milky2018/machv_regalloc@0.3.2`
- `Milky2018/wasm_machv@0.2.2`
- `Milky2018/x64_target@0.2.2`
- `Milky2018/aarch64_target@0.3.2`
- `Milky2018/wasmoon_jit@0.4.2`
- `Milky2018/wasmoon@0.9.2`

All modules were published in dependency order. Every registry upload returned
`Server status: 200 OK`, and every extracted release archive passed the
publisher's independent `moon check`.

## Validation

- internal version graph and dependency pins validated against the workspace
- `moon info`
- `moon fmt`
- `moon check --target all --warn-list +73`
- `moon test --target native`: 2321/2321
- `python3 scripts/audit_module_boundaries.py`
- `moon package --list` for all 12 modules
- `git diff --check`
