### PR TITLE
Add component JIT execution and explicit async continuations

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -244,7 +244,7 @@ jobs:
         run: exit 1
 
   component-model:
-    name: Component Model (${{ matrix.suite }}, ${{ matrix.os }})
+    name: Component Model (${{ matrix.suite }}, ${{ matrix.engine }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -256,6 +256,9 @@ jobs:
           - stable-0.2
           - async-0.3
           - future-gated
+        engine:
+          - jit
+          - interpreter
     steps:
       - uses: actions/checkout@v4
 
@@ -296,9 +299,14 @@ jobs:
       - name: run ${{ matrix.suite }} suite
         timeout-minutes: 10
         run: |
+          args=()
+          if [ "${{ matrix.engine }}" = "interpreter" ]; then
+            args+=(--no-jit)
+          fi
           python3 scripts/run_component_wast.py \
             --suite "${{ matrix.suite }}" \
-            --dump-failures
+            --dump-failures \
+            "${args[@]}"
 
   build-ubuntu-sanitizer:
     runs-on: ubuntu-latest

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,6 +89,34 @@ At O3, MilkIR may unroll only canonical constant-trip natural loops after checke
 
 The top-level `wasmoon/wasm_frontend` package is the product API boundary. Product callers do not import `wasmoon/wasm_frontend/ir` directly.
 
+### Component Core Execution
+
+The component linker owns a `CoreExecutionEngine` seam rather than calling the
+core interpreter directly. After a core module is instantiated, the engine
+registers the shared module instance and chooses one of three execution modes
+for each entry:
+
+- `Synchronous` uses native JIT code when the function and its imported call
+  graph can enter native code safely.
+- `Interpreted` executes non-suspending functions whose imports or tables can
+  re-enter component adapters. This conservative path prevents unsupported
+  nested native activation while preserving synchronous semantics.
+- `Suspendable` enters the interpreter through an explicit continuation seam.
+  Yield and wait operations return captured operand-stack, frame, local, label,
+  and structured-control state. Resumption continues at the suspended host-call
+  boundary; it does not replay the function from its first instruction.
+
+The default `component` and `component-test` commands enable the JIT engine.
+`--no-jit` selects the interpreter engine for differential testing.
+
+Component async execution uses one cooperative host event loop. MoonBit
+processes and component tasks are logical scheduling units, not operating-system
+threads. A task may return `Yield` or wait on a waitable set; the scheduler then
+runs another ready task and resumes the stored continuation when an event is
+available. Embedding-provided host futures expose non-blocking `poll` and
+`cancel` operations, while the host event-loop hook is responsible for waiting
+for external I/O or timer readiness without blocking guest execution.
+
 ## IR and ABI Boundaries
 
 MilkIR uses SSA values and block parameters rather than WebAssembly operand-stack state. Its core opcode contract consists of five semantic families: scalar, memory, call, vector, and typed extension operations. WebAssembly-specific operations are represented through the `wasm_milkir` dialect or lowered into ordinary MilkIR operations by the frontend. Source-only fields such as WebAssembly SIMD memory indices, alignment hints, and immediate offsets are consumed before core IR construction.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,6 +50,13 @@ The command must export the pinned `wasi:cli/run` interface from either
 Preview 2 `0.2.11` or Preview 3 `0.3.0-rc-2025-09-16`. Components are
 validated before instantiation.
 
+Core functions use JIT compilation by default when their component call graph
+can enter native code safely. Use `--no-jit` to force interpreter execution:
+
+```bash
+./wasmoon component command.component.wasm --run --no-jit
+```
+
 Filesystem and network authority are denied by default. Grant only the
 capabilities the command requires:
 
@@ -63,6 +70,21 @@ capabilities the command requires:
 
 `--network` accepts `deny`, `loopback`, or `all`. Standard input, output, and
 error are inherited by command execution.
+
+### Run Component Model Tests
+
+```bash
+./wasmoon component-test component-tests.json
+```
+
+The component test harness also enables JIT execution by default. Pass
+`--no-jit` to run the same script through the interpreter. The pinned upstream
+suites expose the same switch:
+
+```bash
+python3 scripts/run_component_wast.py --suite stable-0.2
+python3 scripts/run_component_wast.py --suite stable-0.2 --no-jit
+```
 
 ### Explore Compilation
 

--- a/docs/component-model-plan.md
+++ b/docs/component-model-plan.md
@@ -1,89 +1,68 @@
-# Component Model Plan (MVP)
+# Component Model Architecture
 
-This document proposes a staged plan to add WebAssembly Component Model support
-in Wasmoon while keeping the existing core Wasm pipeline intact.
+Wasmoon layers the WebAssembly Component Model above its validated core Wasm
+runtime. Component parsing, validation, linking, canonical ABI adaptation, and
+WASI component hosts remain product-owned code; embedded core modules reuse the
+same runtime objects, interpreter, and native compiler as ordinary core Wasm.
 
-## Goals
+## Package Boundaries
 
-- Parse and validate component binaries and text format inputs.
-- Instantiate components that embed or reference core Wasm modules.
-- Support canonical ABI adapters (lift/lower) for basic value types.
-- Provide a CLI surface for running and testing component inputs.
+- `wasmoon/component`: component binary model and parser.
+- `wasmoon/validator/component_model`: component validation.
+- `wasmoon/component/runtime_impl`: linker, instantiation, canonical ABI,
+  resources, tasks, streams, futures, and host adapters.
+- `wasmoon/wasi_component`: WASI Preview 2 and Preview 3 component hosts.
+- `wasmoon/cmd/wasmoon`: command execution and component-spec test harness.
 
-## Non-goals (for MVP)
+Component execution does not add product dependencies to reusable compiler
+modules. The component runtime selects a core execution engine through an
+adapter owned by Wasmoon.
 
-- Full async/futures support.
-- Resource types beyond basic handles.
-- Complete WIT package manager integration.
-- Advanced optimization of adapters or cross-component inlining.
+## Core Execution Contract
 
-## Architecture Alignment
+Each instantiated core module is registered with a `CoreExecutionEngine`.
+Component function references retain that engine and declare whether a call may
+suspend and whether native entry is safe.
 
-Component model will be layered above the existing core Wasm pipeline:
+Synchronous, native-eligible core calls use the JIT by default. Calls that may
+re-enter canonical adapters through imports or indirect tables use the
+interpreter conservatively. Suspendable calls always use the continuation-aware
+interpreter because native machine stacks are not guest continuations.
 
+The interpreter returns either completed results or a typed suspension with an
+owned continuation. A continuation captures the exact operand stack, locals,
+frames, labels, and remaining structured control flow. It can be resumed once
+or cancelled; resumption retries only the suspended host-call boundary.
+
+## Async Host Contract
+
+The component scheduler is a cooperative, single-threaded event loop. Component
+tasks and MoonBit processes are logical tasks; Wasmoon does not require or
+model operating-system threads.
+
+Host async functions return pollable futures. Polling must be non-blocking.
+When no guest task can progress, the embedding-provided host event-loop hook
+waits for external I/O or timer readiness. Waitable-set events wake the owning
+task, and the scheduler resumes its stored continuation. Cancellation releases
+the continuation and calls the host future's cancellation hook.
+
+No replay cursor or cached host result is part of this protocol. Effects before
+a suspension point execute once, and events are consumed once after resumption.
+
+## Validation
+
+The pinned component-model snapshot is divided into stable 0.2, current 0.3
+async, and future-gated suites. Each suite can run with the default JIT adapter
+or with `--no-jit`:
+
+```bash
+python3 scripts/run_component_wast.py --suite stable-0.2
+python3 scripts/run_component_wast.py --suite stable-0.2 --no-jit
+python3 scripts/run_component_wast.py --suite async-0.3
+python3 scripts/run_component_wast.py --suite async-0.3 --no-jit
+python3 scripts/run_component_wast.py --suite future-gated
+python3 scripts/run_component_wast.py --suite future-gated --no-jit
 ```
-component parser -> component validator -> component runtime/linker
-                                 |               |
-                                 v               v
-                           core wasm parser  runtime/executor/JIT
-```
 
-Key idea: component instantiation produces core Wasm modules and adapters that
-reuse the existing runtime and execution stacks.
-
-## Proposed Packages (high-level)
-
-- `component/`: AST + IR for component definitions.
-- `component_parser/`: binary + text parsing for component model.
-- `component_validator/`: type checking, aliasing rules, canonical ABI rules.
-- `component_runtime/`: linker/instantiator, adapter dispatch, host bindings.
-- `component_types/`: canonicalized type system and WIT mapping.
-
-(Exact package names to be finalized after first parser prototype.)
-
-## Staged Plan
-
-### Phase 0: Scope + CLI Surface
-
-- Add a design doc (this file) and an initial CLI flag plan.
-- Decide on file detection: explicit subcommand vs. auto-detect.
-- Decide on where component code lives in the repo tree.
-
-### Phase 1: Parsing + IR
-
-- Implement component AST and binary parser for core component sections:
-  - type, import/export, alias, component/module, instance, canon, start.
-- Add WIT parsing for a minimal subset required by canonical ABI mapping.
-- Provide a round-trip dump utility for debugging.
-
-### Phase 2: Validation
-
-- Validate type correctness for component definitions and instantiation.
-- Validate canonical ABI lifting/lowering constraints.
-- Validate alias/import/export/instance dependency ordering.
-
-### Phase 3: Runtime + Linker
-
-- Instantiate component graphs, resolve imports/exports, build core modules.
-- Implement canonical ABI adapters (lift/lower) for basic types.
-- Bridge adapters to core Wasm functions and host bindings.
-- Ensure compatibility with interpreter and JIT call paths.
-
-### Phase 4: CLI + Tests
-
-- Add `wasmoon component <command>` (exact names TBD).
-- Add fixtures and spec tests (component-model WAST/WIT sources).
-- Add targeted regression tests for canonical ABI conversions.
-
-## Open Questions
-
-- Binary component format detection (magic/version) vs. explicit CLI flag.
-- WIT parsing strategy: minimal in-tree parser vs. external generator.
-- Host binding model: map to existing WASI import style or new interface.
-- JIT interaction: whether to JIT adapters or keep them in interpreter.
-
-## Success Criteria (MVP)
-
-- Load and instantiate component binaries with nested core modules.
-- Execute an exported component function that uses lift/lower.
-- Run a small suite of component spec tests in CI.
+Known unsupported specification features are recorded in
+`docs/component/unsupported-matrix.md`.

--- a/issues/ISS-280.md
+++ b/issues/ISS-280.md
@@ -1,0 +1,55 @@
+# ISS-280: Add JIT component execution and explicit async continuations
+
+## Metadata
+- Type: epic
+- Status: closed
+- Priority: 1
+- Labels: component-model, jit, async, runtime, migration
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+Component core modules currently execute only through the recursive interpreter.
+Sync-style async execution traps out of the interpreter and restarts the core
+function from its entry, using per-task cursor maps and cached canonical results
+to suppress repeated effects. This prevents general component JIT execution and
+does not represent the suspended Wasm computation.
+
+## Design
+Introduce one component-owned core execution seam. Synchronous calls may use a
+native JIT adapter. Calls that may suspend use a resumable interpreter and
+return an explicit continuation together with a typed suspension reason. A
+single-threaded host event loop owns ready/waiting queues and resumes
+continuations. Do not introduce OS threads, native stack snapshots, or replay
+caches.
+
+## Acceptance Criteria
+- [x] Synchronous component core functions execute through the configured JIT.
+- [x] Suspendable core functions preserve frames, locals, operand stack, labels,
+      instruction positions, and instance context in an explicit continuation.
+- [x] Host readiness resumes the exact continuation without re-entering the
+      function from its entry.
+- [x] Replay cursors and canonical-result caches are removed.
+- [x] Stable 0.2, async 0.3, future-gated, WASI component, WAST, and MoonBit
+      quality gates pass.
+
+## Relationships
+- Depends on: ISS-281, ISS-282, ISS-283, ISS-284, ISS-285
+- Parent: none
+- Related: ISS-269, ISS-271
+- Discovered from: none
+
+## Notes
+- 2026-07-28: Native JIT stacks are deliberately not made suspendable. The
+  engine selects the resumable interpreter before entering code that may reach
+  a suspending canonical import.
+
+## Close Notes
+
+Completed the engine seam, component JIT adapter, explicit interpreter
+continuations, cooperative host event loop, and replay-state removal tracked by
+ISS-281 through ISS-285. Verified 2,378 MoonBit tests, all 258 core WAST files
+in both interpreter and JIT modes, and all pinned component suites in both
+engine modes. CI now preserves the same dual-engine component matrix.

--- a/issues/ISS-281.md
+++ b/issues/ISS-281.md
@@ -1,0 +1,46 @@
+# ISS-281: Introduce the component core execution engine seam
+
+## Metadata
+- Type: task
+- Status: closed
+- Priority: 1
+- Labels: component-model, jit, runtime, architecture
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+`runtime_impl` directly instantiates and invokes core Wasm through `executor`.
+There is no seam at which an embedding can prepare a JIT instance, choose an
+execution mode, or observe a structured suspension.
+
+## Design
+Define a small component-owned execution engine interface covering core-instance
+registration and function invocation. Keep the default interpreter adapter.
+The call interface distinguishes synchronous and suspendable invocations and
+returns a typed execution outcome rather than communicating suspension through
+global variables.
+
+## Acceptance Criteria
+- [x] `ComponentLinker` accepts an execution engine and defaults to interpreter.
+- [x] Every core instance is registered once after successful instantiation.
+- [x] All core calls cross the same engine seam.
+- [x] Engine errors are surfaced as structured component runtime errors.
+- [x] Focused black-box tests cover registration, selection, return, and trap.
+
+## Relationships
+- Depends on: none
+- Parent: ISS-280
+- Related: ISS-282
+- Discovered from: ISS-280
+
+## Notes
+- 2026-07-28: Work started.
+
+## Close Notes
+
+Implemented `CoreExecutionEngine`, typed execution modes and outcomes, and
+linker-owned core-instance registration. Component runtime tests verify the
+engine seam and synchronous mode selection. Verified with `moon test --target
+native` and all pinned component suites in JIT and interpreter modes.

--- a/issues/ISS-282.md
+++ b/issues/ISS-282.md
@@ -1,0 +1,51 @@
+# ISS-282: Make the core interpreter explicitly resumable
+
+## Metadata
+- Type: feature
+- Status: closed
+- Priority: 1
+- Labels: executor, continuation, async, component-model
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+The interpreter uses MoonBit recursion for Wasm calls and structured control.
+When a canonical host function requests suspension, unwinding destroys the
+actual execution position and forces component execution to restart.
+
+## Design
+Add a resumable instruction-pointer machine for suspendable invocations. Its
+continuation owns explicit call and control frames, locals, operand stack,
+labels, current module instance, and next instruction positions. Keep the
+existing synchronous interpreter interface as a completed-run wrapper over the
+same semantics where practical.
+
+## Acceptance Criteria
+- [x] A host function can return `Pending` without unwinding or discarding Wasm
+      execution state.
+- [x] Resuming continues after the suspension point exactly once.
+- [x] Nested calls, blocks, loops, branches, tail calls, traps, exceptions, and
+      cancellation preserve existing interpreter behavior.
+- [x] A regression test proves effects before suspension are not repeated.
+- [x] WAST interpreter tests pass.
+
+## Relationships
+- Depends on: ISS-281
+- Parent: ISS-280
+- Related: ISS-283
+- Discovered from: ISS-280
+
+## Notes
+- 2026-07-28: Compiler-generated MoonBit async continuations cannot be invoked
+  from the current synchronous host-function type, so this must be an explicit
+  executor state machine rather than an exception wrapper.
+
+## Close Notes
+
+Added `ExecutionContinuation` with captured executor state and composed
+structured-control resume actions. Regression tests cover once-only effects,
+nested calls and blocks, repeated loop suspensions, and iterative ordinary
+loops. Both interpreter and JIT passed all 258 core WAST files (62,563
+assertions per mode).

--- a/issues/ISS-283.md
+++ b/issues/ISS-283.md
@@ -1,0 +1,49 @@
+# ISS-283: Drive component continuations from the host event loop
+
+## Metadata
+- Type: feature
+- Status: closed
+- Priority: 1
+- Labels: component-model, async, event-loop, wasi
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+The current scheduler repeatedly invokes core functions and polls cached
+canonical calls. Host event-loop integration is a blocking Boolean callback,
+not an owner of concrete ready and waiting computations.
+
+## Design
+Represent component tasks as ready, waiting, completed, cancelled, or trapped,
+with an optional core continuation. Canonical yield and wait operations return
+typed suspension reasons. The single-threaded host event loop registers
+readiness, wakes tasks, and resumes continuations. Logical Component Model
+threads remain cooperatively scheduled tasks and are not MoonBit or OS threads.
+
+## Acceptance Criteria
+- [x] Yield queues the current continuation once.
+- [x] Wait associates the continuation with the exact waitable set.
+- [x] Host futures, streams, pollables, timers, and logical threads wake tasks
+      through one ready queue.
+- [x] Cancellation disposes the continuation and resources exactly once.
+- [x] Deadlock is reported only when no ready task and no host event source can
+      make progress.
+
+## Relationships
+- Depends on: ISS-282
+- Parent: ISS-280
+- Related: ISS-274, ISS-277
+- Discovered from: ISS-280
+
+## Notes
+- 2026-07-28: Scheduling is single-threaded and cooperative.
+
+## Close Notes
+
+Component tasks now retain typed core continuations and use one fair,
+single-threaded scheduler for yield, waitable readiness, host futures, streams,
+and logical guest threads. Dormant calls release dynamic entry guards and
+reacquire them on resume; cancellation and deadlock paths dispose continuations.
+The async 0.3 and future-gated suites pass in both engine modes.

--- a/issues/ISS-284.md
+++ b/issues/ISS-284.md
@@ -1,0 +1,44 @@
+# ISS-284: Remove component async replay state
+
+## Metadata
+- Type: task
+- Status: closed
+- Priority: 1
+- Labels: component-model, async, cleanup, correctness
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+`AsyncState` contains yield, wait, call, stream, callback, and nested-lower
+cursor maps whose only purpose is to make entry-point replay appear idempotent.
+The state is large, fragile, and can hide repeated guest effects.
+
+## Design
+After all suspendable paths use explicit continuations, delete replay cursors,
+cached canonical results, replay-specific cleanup, and reset loops. Canonical
+operations execute once and publish only their real protocol state.
+
+## Acceptance Criteria
+- [x] No replay cursor or per-ordinal canonical-result cache remains.
+- [x] No async path restarts a core function after suspension.
+- [x] Tests assert exact once-only host and guest effects around suspension.
+- [x] Component async matrices pass without replay compatibility code.
+
+## Relationships
+- Depends on: ISS-283
+- Parent: ISS-280
+- Related: none
+- Discovered from: ISS-280
+
+## Notes
+- 2026-07-28: Removal is intentionally last so each cache can be deleted only
+  after its continuation-backed caller is live.
+
+## Close Notes
+
+Removed yield, wait, call, stream, callback, and nested-lower replay cursors and
+per-ordinal result caches. Canonical operations now consume protocol state once
+after resuming the exact captured host-call boundary. Source audit and the
+dual-engine async matrices verify the replay mechanism is gone.

--- a/issues/ISS-285.md
+++ b/issues/ISS-285.md
@@ -1,0 +1,51 @@
+# ISS-285: Add the component JIT adapter and execution gates
+
+## Metadata
+- Type: feature
+- Status: closed
+- Priority: 1
+- Labels: component-model, jit, cli, tests
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+The CLI and component test runner always construct an interpreter-only
+`ComponentLinker`, even though the repository already has a complete native JIT
+compiler and runtime for core Wasm modules.
+
+## Design
+Build a Wasmoon-owned JIT adapter for the component execution seam. Compile and
+register each core module instance, reuse descriptor-backed memories, synchronize
+globals and tables at engine transitions, and dispatch arbitrary canonical host
+imports through the existing hostcall bridge. Use JIT only for synchronous
+invocations; suspendable invocations select the continuation interpreter before
+entry.
+
+## Acceptance Criteria
+- [x] Component CLI execution uses JIT by default and exposes an interpreter
+      opt-out.
+- [x] The component conformance runner can execute both engine modes.
+- [x] Memory, globals, tables, references, imports, traps, and multi-value calls
+      agree with interpreter results.
+- [x] Tests prove async-capable calls never enter a non-resumable JIT frame.
+- [x] CI includes component JIT smoke and differential coverage.
+
+## Relationships
+- Depends on: ISS-281
+- Parent: ISS-280
+- Related: ISS-269
+- Discovered from: ISS-280
+
+## Notes
+- 2026-07-28: JIT compilation is not itself a continuation mechanism.
+
+## Close Notes
+
+Added the Wasmoon-owned component JIT adapter, default CLI JIT selection,
+`--no-jit` opt-outs, hostcall state synchronization, and conservative
+eligibility propagation for suspending or adapter-reentrant calls. The CI
+component matrix now runs all three pinned suites with both JIT and interpreter.
+Local results were 982 stable, 153 async, and 439 future-gated commands in each
+mode.

--- a/issues/README.md
+++ b/issues/README.md
@@ -295,6 +295,12 @@ graph TD
   ISS_277["ISS-277: Implement the current Preview 3 async WASI interfaces"]
   ISS_278["ISS-278: Integrate component commands and WASI conformance gates"]
   ISS_279["ISS-279: Generate WASI component contracts from pinned official WIT"]
+  ISS_280["ISS-280: Add JIT component execution and explicit async continuations"]
+  ISS_281["ISS-281: Introduce the component core execution engine seam"]
+  ISS_282["ISS-282: Make the core interpreter explicitly resumable"]
+  ISS_283["ISS-283: Drive component continuations from the host event loop"]
+  ISS_284["ISS-284: Remove component async replay state"]
+  ISS_285["ISS-285: Add the component JIT adapter and execution gates"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005
@@ -584,6 +590,15 @@ graph TD
   ISS_276 --> ISS_278
   ISS_277 --> ISS_278
   ISS_272 --> ISS_279
+  ISS_281 --> ISS_280
+  ISS_282 --> ISS_280
+  ISS_283 --> ISS_280
+  ISS_284 --> ISS_280
+  ISS_285 --> ISS_280
+  ISS_281 --> ISS_282
+  ISS_282 --> ISS_283
+  ISS_283 --> ISS_284
+  ISS_281 --> ISS_285
 ```
 
 ## Warnings

--- a/modules/wasmoon/README.mbt.md
+++ b/modules/wasmoon/README.mbt.md
@@ -120,10 +120,12 @@ wasmoon component path/to/component.wasm --validate
 wasmoon component path/to/command.component.wasm --run \
   --dir /srv/data::/data \
   --network loopback
+wasmoon component path/to/command.component.wasm --run --no-jit
 wasmoon component --help
 
 # component-test
 wasmoon component-test path/to/component-tests.json
+wasmoon component-test path/to/component-tests.json --no-jit
 wasmoon component-test --help
 
 # wat
@@ -214,8 +216,11 @@ cargo install wasm-tools --version 1.254.0 --locked
 python3 scripts/run_all_wast.py --dir spec --rec
 python3 scripts/check_component_snapshot.py
 python3 scripts/run_component_wast.py --suite stable-0.2
+python3 scripts/run_component_wast.py --suite stable-0.2 --no-jit
 python3 scripts/run_component_wast.py --suite async-0.3
+python3 scripts/run_component_wast.py --suite async-0.3 --no-jit
 python3 scripts/run_component_wast.py --suite future-gated
+python3 scripts/run_component_wast.py --suite future-gated --no-jit
 ```
 
 ## Library Usage

--- a/modules/wasmoon/cmd/wasmoon/commands/component_cmd.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/component_cmd.mbt
@@ -376,6 +376,7 @@ pub fn run_wasi_component_command(
   network : String,
   wit_names : Bool,
   error_format : ComponentErrorFormat,
+  use_jit? : Bool = true,
 ) -> Int {
   let parsed = run_component_command_eval(file_path, true, wit_names)
   guard parsed.parsed is Some(component) else {
@@ -390,7 +391,13 @@ pub fn run_wasi_component_command(
       )
   }
   defer ctx.close()
-  let linker = @runtime_impl.ComponentLinker()
+  let linker = if use_jit {
+    @runtime_impl.ComponentLinker::with_core_execution_engine(
+      component_jit_execution_engine(),
+    )
+  } else {
+    ComponentLinker()
+  }
   let host = @wasi_component.WasiComponentHost(linker, ctx)
   (try {
     host.add_preview2_cli_clocks_random()

--- a/modules/wasmoon/cmd/wasmoon/commands/component_jit.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/component_jit.mbt
@@ -1,0 +1,54 @@
+///|
+/// Build the Wasmoon-owned native adapter for component core execution.
+///
+/// Suspendable calls are selected before native entry and remain on the
+/// resumable interpreter path. A JIT stack is never treated as a continuation.
+fn component_jit_execution_engine() -> @runtime_impl.CoreExecutionEngine {
+  let contexts : Map[Int, @wast.JITModuleContext] = Map([])
+  let interpreter = @runtime_impl.interpreter_core_execution_engine()
+  CoreExecutionEngine(
+    fn(store, module_, instance) raise @runtime_impl.ComponentRuntimeError {
+      match try_compile_jit(module_, instance, store) {
+        Ok(context) => contexts.set(instance.store_idx, context)
+        Err(message) =>
+          raise CanonCallError("component JIT compilation failed: \{message}")
+      }
+    },
+    fn(
+      store,
+      instance,
+      func_idx,
+      args,
+      mode,
+    ) raise @runtime_impl.ComponentRuntimeError {
+      if mode != Synchronous {
+        return interpreter.invoke(store, instance, func_idx, args, mode)
+      }
+      guard contexts.get(instance.store_idx) is Some(context) else {
+        raise CanonCallError(
+          "component JIT context is missing for core instance \{instance.store_idx}",
+        )
+      }
+      let results = context.call_core_func(store, instance, func_idx, args) catch {
+        FunctionUnavailable(_) =>
+          // Re-exported imports do not have local machine code in this module.
+          @executor.call_func_by_index(store, instance, func_idx, args) catch {
+            error => raise CanonCallError(error.to_string())
+          }
+        Exit(code) => raise HostExit(code)
+        Trap(message) =>
+          if message.contains("unreachable") {
+            raise CanonCallError(
+              "wasm trap: wasm `unreachable` instruction executed",
+            )
+          } else {
+            raise CanonCallError("wasm trap: \{message}")
+          }
+        error =>
+          raise CanonCallError("component JIT invocation failed: \{error}")
+      }
+      Returned(results)
+    },
+    prepare_store=fn(store) { store.enable_c_heap() },
+  )
+}

--- a/modules/wasmoon/cmd/wasmoon/commands/component_script.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/component_script.mbt
@@ -852,6 +852,7 @@ fn run_component_script_impl(
   path : String,
   error_format : ComponentErrorFormat,
   print_output : Bool,
+  use_jit : Bool,
 ) -> Int {
   let contents = @fs.read_file_to_string(path) catch {
     IOError(e) => {
@@ -914,7 +915,13 @@ fn run_component_script_impl(
     }
   }
   let result = ScriptResult::ScriptResult()
-  let linker = @runtime_impl.ComponentLinker::ComponentLinker()
+  let linker = if use_jit {
+    @runtime_impl.ComponentLinker::with_core_execution_engine(
+      component_jit_execution_engine(),
+    )
+  } else {
+    ComponentLinker()
+  }
   let store = linker.get_store()
   let return_two = make_const_u32_func(2)
   let return_three = make_const_u32_func(3)
@@ -1491,14 +1498,16 @@ fn run_component_script_impl(
 pub fn run_component_script(
   path : String,
   error_format : ComponentErrorFormat,
+  use_jit? : Bool = true,
 ) -> Int {
-  run_component_script_impl(path, error_format, false)
+  run_component_script_impl(path, error_format, false, use_jit)
 }
 
 ///|
 pub fn run_component_script_cli(
   path : String,
   error_format : ComponentErrorFormat,
+  use_jit? : Bool = true,
 ) -> Int {
-  run_component_script_impl(path, error_format, true)
+  run_component_script_impl(path, error_format, true, use_jit)
 }

--- a/modules/wasmoon/cmd/wasmoon/commands/pkg.generated.mbti
+++ b/modules/wasmoon/cmd/wasmoon/commands/pkg.generated.mbti
@@ -20,9 +20,9 @@ pub fn func_to_wat(String, @types.FuncType, Array[@types.ValueType], Array[@type
 
 pub fn run_component_command(String, Bool, Bool, Bool, ComponentErrorFormat) -> Int
 
-pub fn run_component_script(String, ComponentErrorFormat) -> Int
+pub fn run_component_script(String, ComponentErrorFormat, use_jit? : Bool) -> Int
 
-pub fn run_component_script_cli(String, ComponentErrorFormat) -> Int
+pub fn run_component_script_cli(String, ComponentErrorFormat, use_jit? : Bool) -> Int
 
 pub fn run_config(String) -> Unit
 
@@ -34,7 +34,7 @@ pub fn run_settings() -> Unit
 
 pub fn run_testsuite(String, Bool, Bool) -> Unit
 
-pub fn run_wasi_component_command(String, Array[String], Array[String], Array[String], String, Bool, ComponentErrorFormat) -> Int
+pub fn run_wasi_component_command(String, Array[String], Array[String], Array[String], String, Bool, ComponentErrorFormat, use_jit? : Bool) -> Int
 
 pub fn run_wasm(String, String?, Array[String], Array[String], Array[String], Array[String], Array[String], Array[String], Bool, Bool, Bool, Int, Bool) -> Unit
 

--- a/modules/wasmoon/cmd/wasmoon/commands/wast.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/wast.mbt
@@ -492,8 +492,6 @@ fn try_compile_jit(
           wast_jit_compiled_functions.val = wast_jit_compiled_functions.val +
             compiled_local_funcs
           @wast.register_instance_funcrefs_for_jit(jm, instance)
-          // Enable arbitrary host function imports via JIT -> hostcall bridge.
-          @wast.install_jit_hostcall_dispatcher(jm, store, instance)
           // Allocate independent WASM stack with guard page. Native JIT
           // execution and hostcall bridges use this stack, so keep it aligned
           // with `wasmoon run`.
@@ -580,6 +578,26 @@ fn try_compile_jit(
             jm, globals_ptr, global_addrs_copy, table_addrs_copy, func_addrs_copy,
             func_type_indices_copy, canonical_type_indices_copy, module_types_copy,
             module_rec_groups_copy, use_subtype_indirect_check,
+          )
+          // Cross an explicit state-coherence boundary around imported host or
+          // interpreter calls made from native component code.
+          @wast.install_jit_hostcall_dispatcher(
+            jm,
+            store,
+            instance,
+            before_dispatch=fn() {
+              @wast.sync_jit_globals_to_store(jit_ctx, store)
+              @wast.sync_jit_tables_to_store(jit_ctx, store)
+            },
+            after_dispatch=fn() {
+              @wast.sync_store_globals_to_jit(jit_ctx, store)
+              @wast.sync_tables_to_jit(
+                instance,
+                store,
+                jm,
+                use_subtype_indirect_check~,
+              )
+            },
           )
           Ok(jit_ctx)
         }

--- a/modules/wasmoon/cmd/wasmoon/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon/main.mbt
@@ -106,6 +106,9 @@ fn main {
           "run": @clap.Arg::flag(
             help="Run a pinned WASI Preview 2 or Preview 3 command component",
           ),
+          "no-jit": @clap.Arg::flag(
+            help="Disable JIT compilation for synchronous component core functions",
+          ),
           "arg": @clap.Arg::named(
             nargs=Any,
             help="Command arguments passed after the component path",
@@ -141,6 +144,9 @@ fn main {
             nargs=AtMost(1),
             choices=error_format_choices,
             help="component-test output format: text (default) or json",
+          ),
+          "no-jit": @clap.Arg::flag(
+            help="Use the core interpreter for all component test calls",
           ),
         },
       ),
@@ -304,6 +310,10 @@ fn main {
                   None => Text
                 }
                 let status = if run {
+                  let use_jit = match sub.flags.get("no-jit") {
+                    Some(true) => false
+                    _ => true
+                  }
                   @commands.run_wasi_component_command(
                     positional[0],
                     match sub.args.get("arg") {
@@ -324,6 +334,7 @@ fn main {
                     },
                     wit_names,
                     error_format,
+                    use_jit~,
                   )
                 } else {
                   @commands.run_component_command(
@@ -356,6 +367,7 @@ fn main {
                 let status = @commands.run_component_script_cli(
                   positional[0],
                   error_format,
+                  use_jit=!sub.args.contains("no-jit"),
                 )
                 if status != 0 {
                   @sys.exit(status)

--- a/modules/wasmoon/component/runtime_impl/async_runtime.mbt
+++ b/modules/wasmoon/component/runtime_impl/async_runtime.mbt
@@ -56,6 +56,69 @@ fn transfer_results_if_needed(
 }
 
 ///|
+/// Drive one suspended core invocation on the component host event loop.
+///
+/// This resumes the captured interpreter state; it never re-enters the
+/// function from its first instruction.
+fn drive_core_to_completion(
+  async_state : AsyncState,
+  store : @runtime.Store,
+  initial : CoreExecutionOutcome,
+) -> Array[@types.Value] raise ComponentRuntimeError {
+  let mut outcome = initial
+  while true {
+    match outcome {
+      Returned(results) => return results
+      Suspended(reason, continuation) => {
+        match reason {
+          Yield =>
+            if !progress_one_subtask(async_state, store) {
+              continuation.cancel()
+              raise CanonCallError(
+                "wasm trap: deadlock detected: event loop cannot make further progress",
+              )
+            }
+          Wait(waitable_set) =>
+            while !waitable_set_has_event(async_state, waitable_set) {
+              if !progress_one_subtask(async_state, store) {
+                continuation.cancel()
+                raise CanonCallError(
+                  "wasm trap: deadlock detected: event loop cannot make further progress",
+                )
+              }
+            }
+        }
+        if reason is Wait(_) {
+          // Deliver one fair scheduler round before resuming the waiter. A
+          // single readiness event can make a peer task runnable (for example,
+          // a zero-length stream rendezvous enabling the real write).
+          let turns = runnable_subtask_count(async_state)
+          for _ in 0..<turns {
+            if !progress_one_subtask(async_state, store) {
+              break
+            }
+          }
+        }
+        outcome = continuation.continue_execution()
+      }
+    }
+  }
+  raise CanonCallError("unreachable")
+}
+
+///|
+fn runnable_subtask_count(async_state : AsyncState) -> Int {
+  let mut count = 0
+  for entry in async_state.subtasks {
+    let (_task_id, subtask) = entry
+    if subtask.phase[0] == Started {
+      count = count + 1
+    }
+  }
+  count
+}
+
+///|
 fn await_component_func(
   func : ComponentFunc,
   args : Array[ComponentValue],
@@ -144,100 +207,57 @@ fn await_component_func(
         match cb_opt {
           None =>
             if async_abi {
-              // Sync-style async ABI: the core function may suspend (thread.yield / waitable-set.wait).
-              while true {
-                if async_state.yield_cursor_stack.length() > 0 {
-                  async_state.yield_cursor_stack[async_state.yield_cursor_stack.length() -
-                  1] = 0
-                }
-                if async_state.wait_cursor_stack.length() > 0 {
-                  async_state.wait_cursor_stack[async_state.wait_cursor_stack.length() -
-                  1] = 0
-                }
-                if async_state.call_cursor_stack.length() > 0 {
-                  async_state.call_cursor_stack[async_state.call_cursor_stack.length() -
-                  1] = 0
-                }
-                if async_state.stream_cursor_stack.length() > 0 {
-                  async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-                  1] = 0
-                }
-                let core_results = call_core_func_guarded(
+              let core_results = drive_core_to_completion(
+                async_state,
+                store,
+                call_core_func_guarded_outcome(
                   store, may_enter, core_func, core_args,
-                ) catch {
-                  AsyncSuspendYield => {
-                    if !progress_one_subtask(async_state, store) {
-                      raise CanonCallError(
-                        "wasm trap: deadlock detected: event loop cannot make further progress",
-                      )
-                    }
-                    continue
-                  }
-                  AsyncSuspendWait(ws) => {
-                    while !waitable_set_has_event(async_state, ws) {
-                      if !progress_one_subtask(async_state, store) {
-                        raise CanonCallError(
-                          "wasm trap: deadlock detected: event loop cannot make further progress",
-                        )
-                      }
-                    }
-                    // Once the awaited set has an event, allow other ready tasks to make a bit
-                    // more progress before restarting the core function. This matches Wasmtime's
-                    // event-loop behavior where delivering one event can synchronously enable
-                    // progress in other tasks (e.g. zero-length stream rendezvous).
-                    let mut spins = 0
-                    while spins < 32 && progress_one_subtask(async_state, store) {
-                      spins = spins + 1
-                    }
-                    continue
-                  }
-                  e => raise e
-                }
-                // Prefer results published via `canon task.return` (used by many component-spec/async
-                // tests), but fall back to interpreting the core function's direct results.
-                let vals = match take_task_result(async_state, task_id) {
-                  Some(v) => v
-                  None =>
-                    core_results_to_component(
-                      core_results, func_type, types, resources, store, callee_table,
-                    )
-                }
-                match func_type.result {
-                  Some(rty) =>
-                    if vals.length() > 0 {
-                      validate_lifted_stream_future(
-                        rty,
-                        vals[0],
-                        types,
-                        async_state,
-                        callee_table.id,
-                      )
-                    } else {
-                      ()
-                    }
-                  None => ()
-                }
-                let out_vals = transfer_results_if_needed(
-                  vals,
-                  func_type.result,
-                  types,
-                  async_state,
-                  callee_table.id,
-                  caller_table.id,
-                )
-                // Mirror task.return bookkeeping so other parts can uniformly query results.
-                async_state.task_returned.set(task_id, true)
-                set_task_result(async_state, task_id, caller_table.id, out_vals)
-                pop_task(async_state)
-                drop_task_thread(async_state, task_id)
-                remove_task_meta(async_state, task_id)
-                return out_vals
+                ),
+              )
+              // Prefer results published via `canon task.return` (used by many
+              // async-ABI functions), but fall back to direct core results.
+              let vals = match take_task_result(async_state, task_id) {
+                Some(values) => values
+                None =>
+                  core_results_to_component(
+                    core_results, func_type, types, resources, store, callee_table,
+                  )
               }
-              raise CanonCallError("unreachable")
+              match func_type.result {
+                Some(result_type) =>
+                  if vals.length() > 0 {
+                    validate_lifted_stream_future(
+                      result_type,
+                      vals[0],
+                      types,
+                      async_state,
+                      callee_table.id,
+                    )
+                  }
+                None => ()
+              }
+              let out_vals = transfer_results_if_needed(
+                vals,
+                func_type.result,
+                types,
+                async_state,
+                callee_table.id,
+                caller_table.id,
+              )
+              async_state.task_returned.set(task_id, true)
+              set_task_result(async_state, task_id, caller_table.id, out_vals)
+              pop_task(async_state)
+              drop_task_thread(async_state, task_id)
+              remove_task_meta(async_state, task_id)
+              return out_vals
             } else {
               // Sync-style async: the core function returns results directly (no task.return).
-              let core_results = call_core_func_guarded(
-                store, may_enter, core_func, core_args,
+              let core_results = drive_core_to_completion(
+                async_state,
+                store,
+                call_core_func_guarded_outcome(
+                  store, may_enter, core_func, core_args,
+                ),
               )
               let vals = core_results_to_component(
                 core_results, func_type, types, resources, store, callee_table,
@@ -271,8 +291,12 @@ fn await_component_func(
               out_vals
             }
           Some(cb) => {
-            let core_results = call_core_func_guarded(
-              store, may_enter, core_func, core_args,
+            let core_results = drive_core_to_completion(
+              async_state,
+              store,
+              call_core_func_guarded_outcome(
+                store, may_enter, core_func, core_args,
+              ),
             )
             let mut code = match core_results {
               [I32(n)] => n
@@ -287,16 +311,17 @@ fn await_component_func(
               } else if tag == 1 {
                 // YIELD
                 progress_one_subtask(async_state, store) |> ignore
-                async_state.stream_results_cb.remove(
-                  current_task_id(async_state),
-                )
                 async_state.in_async_callback[0] = true
                 preset_canon_debug_message("async.callback.yield(ev=NONE)")
-                let r = call_core_func_guarded(store, may_enter, cb, [
-                  I32(0),
-                  I32(0),
-                  I32(0),
-                ]) catch {
+                let r = drive_core_to_completion(
+                  async_state,
+                  store,
+                  call_core_func_guarded_outcome(store, may_enter, cb, [
+                    I32(0),
+                    I32(0),
+                    I32(0),
+                  ]),
+                ) catch {
                   e => {
                     async_state.in_async_callback[0] = false
                     raise e
@@ -316,9 +341,6 @@ fn await_component_func(
                 }
                 let ws_key = handle_key(callee_table.id, payload)
                 let ev = wait_for_event(async_state, store, ws_key)
-                async_state.stream_results_cb.remove(
-                  current_task_id(async_state),
-                )
                 async_state.in_async_callback[0] = true
                 fn subtask_mem_dbg(ev : WaitEvent) -> String {
                   if ev.code != 1 || ev.payload != 2 {
@@ -344,11 +366,15 @@ fn await_component_func(
                 preset_canon_debug_message(
                   "async.callback.wait(ev code=\{ev.code} index=\{ev.index} payload=\{ev.payload})\{subtask_mem_dbg(ev)}",
                 )
-                let r = call_core_func_guarded(store, may_enter, cb, [
-                  I32(ev.code),
-                  I32(ev.index),
-                  I32(ev.payload),
-                ]) catch {
+                let r = drive_core_to_completion(
+                  async_state,
+                  store,
+                  call_core_func_guarded_outcome(store, may_enter, cb, [
+                    I32(ev.code),
+                    I32(ev.index),
+                    I32(ev.payload),
+                  ]),
+                ) catch {
                   e => {
                     async_state.in_async_callback[0] = false
                     raise e
@@ -450,6 +476,16 @@ fn step_task_once(
   caller_table : ResourceTable,
   async_state : AsyncState,
 ) -> TaskStep raise ComponentRuntimeError {
+  step_task_once_impl(task, store, caller_table, async_state)
+}
+
+///|
+fn step_task_once_impl(
+  task : CallbackTask,
+  store : @runtime.Store,
+  caller_table : ResourceTable,
+  async_state : AsyncState,
+) -> TaskStep raise ComponentRuntimeError {
   fn task_owner_component_id() -> Int {
     match task.func {
       Host(_, _, _) => caller_table.id
@@ -476,6 +512,37 @@ fn step_task_once(
       set.waiters[0] = set.waiters[0] + 1
     }
     task.waiting_set[0] = ws_opt
+  }
+
+  fn poll_core(
+    invoke : () -> CoreExecutionOutcome raise ComponentRuntimeError,
+  ) -> TaskCorePoll raise ComponentRuntimeError {
+    let outcome = match task.continuation[0] {
+      Some(continuation) => {
+        task.continuation[0] = None
+        continuation.continue_execution()
+      }
+      None => invoke()
+    }
+    match outcome {
+      Returned(results) => {
+        set_waiting(None)
+        CoreReady(results)
+      }
+      Suspended(reason, continuation) => {
+        task.continuation[0] = Some(continuation)
+        match reason {
+          Yield => {
+            set_waiting(None)
+            CorePending(Progressed)
+          }
+          Wait(waitable_set) => {
+            set_waiting(Some(waitable_set))
+            CorePending(Blocked)
+          }
+        }
+      }
+    }
   }
 
   match task.func {
@@ -567,57 +634,20 @@ fn step_task_once(
             }
           None => ()
         }
-        if !task.started[0] {
-          task.started[0] = true
-          let core_results = call_core_func_guarded(
-            store, may_enter, core_func, core_args,
-          ) catch {
-            AsyncSuspendYield => {
-              // Cooperative suspension (e.g. sync-lowering an async callee).
-              task.started[0] = false
-              set_waiting(None)
-              // Replay from the top: reset restartable cursors for this task invocation.
-              if async_state.yield_cursor_stack.length() > 0 {
-                async_state.yield_cursor_stack[async_state.yield_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.wait_cursor_stack.length() > 0 {
-                async_state.wait_cursor_stack[async_state.wait_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.call_cursor_stack.length() > 0 {
-                async_state.call_cursor_stack[async_state.call_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.stream_cursor_stack.length() > 0 {
-                async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-                1] = 0
-              }
-              return Progressed
-            }
-            AsyncSuspendWait(ws) => {
-              task.started[0] = false
-              set_waiting(Some(ws))
-              if async_state.yield_cursor_stack.length() > 0 {
-                async_state.yield_cursor_stack[async_state.yield_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.wait_cursor_stack.length() > 0 {
-                async_state.wait_cursor_stack[async_state.wait_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.call_cursor_stack.length() > 0 {
-                async_state.call_cursor_stack[async_state.call_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.stream_cursor_stack.length() > 0 {
-                async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-                1] = 0
-              }
-              return Blocked
-            }
-            e => raise e
+        if !task.started[0] || task.continuation[0] is Some(_) {
+          let polled = poll_core(fn() raise ComponentRuntimeError {
+            call_core_func_guarded_outcome(
+              store, may_enter, core_func, core_args,
+            )
+          })
+          let core_results = match polled {
+            CoreReady(results) => results
+            CorePending(step) => return step
           }
+          // Automatic backpressure is released only after the initial call
+          // actually returns a callback code. Merely entering and suspending
+          // that call does not count as started.
+          task.started[0] = true
           let code = match core_results {
             [I32(n)] => n
             _ => raise CanonCallError("type mismatch")
@@ -646,10 +676,15 @@ fn step_task_once(
           } else {
             [I32(0), I32(0), I32(0)]
           }
-          async_state.stream_results_cb.remove(current_task_id(async_state))
           async_state.in_async_callback[0] = true
-          let r = call_core_func_guarded(store, may_enter, cb, args)
+          let polled = poll_core(fn() raise ComponentRuntimeError {
+            call_core_func_guarded_outcome(store, may_enter, cb, args)
+          })
           async_state.in_async_callback[0] = false
+          let r = match polled {
+            CoreReady(results) => results
+            CorePending(step) => return step
+          }
           let code = match r {
             [I32(n)] => n
             _ => raise CanonCallError("type mismatch")
@@ -672,14 +707,19 @@ fn step_task_once(
           if task.cancelled[0] {
             task.cancelled[0] = false
             set_waiting(None)
-            async_state.stream_results_cb.remove(current_task_id(async_state))
             async_state.in_async_callback[0] = true
-            let r = call_core_func_guarded(store, may_enter, cb, [
-              I32(6),
-              I32(0),
-              I32(0),
-            ])
+            let polled = poll_core(fn() raise ComponentRuntimeError {
+              call_core_func_guarded_outcome(store, may_enter, cb, [
+                I32(6),
+                I32(0),
+                I32(0),
+              ])
+            })
             async_state.in_async_callback[0] = false
+            let r = match polled {
+              CoreReady(results) => results
+              CorePending(step) => return step
+            }
             let code = match r {
               [I32(n)] => n
               _ => raise CanonCallError("type mismatch")
@@ -705,14 +745,19 @@ fn step_task_once(
           acknowledge_waitable_event(async_state, ev)
           // Leaving the waiting state to process one event.
           set_waiting(None)
-          async_state.stream_results_cb.remove(current_task_id(async_state))
           async_state.in_async_callback[0] = true
-          let r = call_core_func_guarded(store, may_enter, cb, [
-            I32(ev.code),
-            I32(ev.index),
-            I32(ev.payload),
-          ])
+          let polled = poll_core(fn() raise ComponentRuntimeError {
+            call_core_func_guarded_outcome(store, may_enter, cb, [
+              I32(ev.code),
+              I32(ev.index),
+              I32(ev.payload),
+            ])
+          })
           async_state.in_async_callback[0] = false
+          let r = match polled {
+            CoreReady(results) => results
+            CorePending(step) => return step
+          }
           let code = match r {
             [I32(n)] => n
             _ => raise CanonCallError("type mismatch")
@@ -736,64 +781,67 @@ fn step_task_once(
         // If previously blocked on a waitable-set, only resume once an event exists.
         match task.waiting_set[0] {
           Some(ws) =>
-            if !waitable_set_has_event(async_state, ws) {
+            if !waitable_set_has_event(async_state, ws) &&
+              !task.cancelled[0] &&
+              !(async_state.task_cancelled.get(current_task_id(async_state))
+              is Some(true)) {
               return Blocked
             }
           None => ()
         }
-        // Re-run from the top; intrinsics will replay completed suspension points.
-        try {
-          let core_results = call_core_func_guarded(
-            store, may_enter, core_func, core_args,
-          )
-          let task_id = current_task_id(async_state)
-          // Prefer results published via `canon task.return` (many async-abi
-          // functions return `[]` from core and communicate via task.return),
-          // but fall back to direct core results.
-          match async_state.task_results.get(task_id) {
-            Some(_vals) => async_state.task_returned.set(task_id, true)
-            None => {
-              let vals = core_results_to_component(
-                core_results, func_type, types, resources, store, callee_table,
-              )
-              match func_type.result {
-                Some(rty) =>
-                  if vals.length() > 0 {
-                    validate_lifted_stream_future(
-                      rty,
-                      vals[0],
-                      types,
-                      async_state,
-                      callee_table.id,
-                    )
-                  } else {
-                    ()
-                  }
-                None => ()
-              }
-              async_state.task_returned.set(task_id, true)
-              set_task_result(async_state, task_id, callee_table.id, vals)
-            }
-          }
-          Done
-        } catch {
-          AsyncSuspendYield => {
+        let polled = poll_core(fn() raise ComponentRuntimeError {
+          call_core_func_guarded_outcome(store, may_enter, core_func, core_args)
+        })
+        let core_results = match polled {
+          CoreReady(results) => results
+          CorePending(step) => {
             task.started[0] = true
-            task.waiting_set[0] = None
-            Progressed
+            return step
           }
-          AsyncSuspendWait(ws) => {
-            task.started[0] = true
-            task.waiting_set[0] = Some(ws)
-            Progressed
-          }
-          e => raise e
         }
+        let task_id = current_task_id(async_state)
+        // Prefer results published via `canon task.return` (many async-abi
+        // functions return `[]` from core and communicate via task.return),
+        // but fall back to direct core results.
+        match async_state.task_results.get(task_id) {
+          Some(_vals) => async_state.task_returned.set(task_id, true)
+          None => {
+            let vals = core_results_to_component(
+              core_results, func_type, types, resources, store, callee_table,
+            )
+            match func_type.result {
+              Some(rty) =>
+                if vals.length() > 0 {
+                  validate_lifted_stream_future(
+                    rty,
+                    vals[0],
+                    types,
+                    async_state,
+                    callee_table.id,
+                  )
+                } else {
+                  ()
+                }
+              None => ()
+            }
+            async_state.task_returned.set(task_id, true)
+            set_task_result(async_state, task_id, callee_table.id, vals)
+          }
+        }
+        Done
       } else {
-        // No async ABI: normal call. For sync-style async funcs, results are returned directly.
-        let core_results = call_core_func_guarded(
-          store, may_enter, core_func, core_args,
-        )
+        // A core function without the canonical async option can still suspend
+        // through a sync-lowered async import.
+        let polled = poll_core(fn() raise ComponentRuntimeError {
+          call_core_func_guarded_outcome(store, may_enter, core_func, core_args)
+        })
+        let core_results = match polled {
+          CoreReady(results) => results
+          CorePending(step) => {
+            task.started[0] = true
+            return step
+          }
+        }
         let vals = core_results_to_component(
           core_results, func_type, types, resources, store, callee_table,
         )
@@ -988,6 +1036,22 @@ fn progress_one_subtask(
     }
   }
   sort_i64_by_task_order(started_ids)
+  // Resume after the last task that consumed a scheduler turn. This is a
+  // cooperative single-threaded ready queue: a task that repeatedly yields
+  // cannot starve later tasks.
+  if async_state.scheduler_cursor[0] is Some(previous) {
+    let mut previous_index = -1
+    for i, task_id in started_ids {
+      if task_id == previous {
+        previous_index = i
+        break
+      }
+    }
+    for _ in 0..<(previous_index + 1) {
+      let first = started_ids.remove(0)
+      started_ids.push(first)
+    }
+  }
   for task_id in started_ids {
     let st = match async_state.subtasks.get(task_id) {
       Some(s) => s
@@ -1005,6 +1069,7 @@ fn progress_one_subtask(
         step_task_once(t, store, st.caller_table, async_state)
     }
     pop_task(async_state)
+    async_state.scheduler_cursor[0] = Some(task_id)
     let releases_auto_backpressure = match st.driver {
       CallbackLifted(task) =>
         match task.func {
@@ -1041,15 +1106,8 @@ fn progress_one_subtask(
           async_state.task_cancelled.remove(task_id)
           async_state.task_contexts.remove(task_id)
           remove_task_meta(async_state, task_id)
-          async_state.yield_replay_upto.remove(task_id)
-          async_state.wait_results.remove(task_id)
+          async_state.yield_suspended.remove(task_id)
           async_state.waiting_ws.remove(task_id)
-          async_state.call_results.remove(task_id)
-          async_state.call_results_cb.remove(task_id)
-          async_state.call_result_ends.remove(task_id)
-          async_state.call_result_ends_cb.remove(task_id)
-          async_state.stream_results.remove(task_id)
-          async_state.stream_results_cb.remove(task_id)
           async_state.sync_lower_states.remove(task_id)
           free_shared_handle(async_state, owner_component_id, st.id)
           return true
@@ -1170,14 +1228,12 @@ fn call_component_func(
   resource_table : ResourceTable,
   async_state : AsyncState,
 ) -> Array[ComponentValue] raise ComponentRuntimeError {
-  // Many canonical ops implement replay/caching keyed by `current_task_id` and
-  // cursor stacks. When entering from the host (no active task context), run
-  // the whole component call under a fresh synthetic task id so caches don't
-  // leak across independent invocations.
+  // Host calls still need a task identity for canonical borrow scopes,
+  // cancellation, and continuation ownership.
   if async_state.task_stack.length() == 1 && async_state.task_stack[0] == 0 {
     let task_id = alloc_task_id(async_state)
-    // This is a synthetic "host entry" task used only for replay/caching keys.
-    // It must not participate in async re-entrancy checks.
+    // A synthetic host-entry task does not belong to a component instance and
+    // therefore does not participate in async re-entrancy checks.
     init_task_meta(async_state, task_id, -1, 0L)
     // Preserve the host-provided `task_can_block` flag: exported async funcs must be allowed to block.
     let can_block = async_state.task_can_block[0]
@@ -1265,52 +1321,16 @@ fn call_component_func_in_task(
           push_task(async_state, task_id, false)
           take_task_result(async_state, task_id) |> ignore
           let out = try {
-            let mut code = 0
-            while true {
-              if async_state.yield_cursor_stack.length() > 0 {
-                async_state.yield_cursor_stack[async_state.yield_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.wait_cursor_stack.length() > 0 {
-                async_state.wait_cursor_stack[async_state.wait_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.call_cursor_stack.length() > 0 {
-                async_state.call_cursor_stack[async_state.call_cursor_stack.length() -
-                1] = 0
-              }
-              if async_state.stream_cursor_stack.length() > 0 {
-                async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-                1] = 0
-              }
-              let core_results = call_core_func_guarded(
+            let initial_results = drive_core_to_completion(
+              async_state,
+              store,
+              call_core_func_guarded_outcome(
                 store, may_enter, core_func, core_args,
-              ) catch {
-                AsyncSuspendYield => {
-                  if !progress_one_subtask(async_state, store) {
-                    raise CanonCallError(
-                      "wasm trap: deadlock detected: event loop cannot make further progress",
-                    )
-                  }
-                  continue
-                }
-                AsyncSuspendWait(ws) => {
-                  while !waitable_set_has_event(async_state, ws) {
-                    if !progress_one_subtask(async_state, store) {
-                      raise CanonCallError(
-                        "wasm trap: deadlock detected: event loop cannot make further progress",
-                      )
-                    }
-                  }
-                  continue
-                }
-                e => raise e
-              }
-              code = match core_results {
-                [I32(n)] => n
-                _ => raise CanonCallError("type mismatch")
-              }
-              break
+              ),
+            )
+            let mut code = match initial_results {
+              [I32(value)] => value
+              _ => raise CanonCallError("type mismatch")
             }
             while true {
               let u = code.reinterpret_as_uint()
@@ -1320,15 +1340,16 @@ fn call_component_func_in_task(
               } else if tag == 1 {
                 // YIELD: allowed even for synchronous tasks (must not block).
                 progress_one_subtask(async_state, store) |> ignore
-                async_state.stream_results_cb.remove(
-                  current_task_id(async_state),
-                )
                 async_state.in_async_callback[0] = true
-                let r = call_core_func_guarded(store, may_enter, cb, [
-                  I32(0),
-                  I32(0),
-                  I32(0),
-                ]) catch {
+                let r = drive_core_to_completion(
+                  async_state,
+                  store,
+                  call_core_func_guarded_outcome(store, may_enter, cb, [
+                    I32(0),
+                    I32(0),
+                    I32(0),
+                  ]),
+                ) catch {
                   e => {
                     async_state.in_async_callback[0] = false
                     raise e
@@ -1396,53 +1417,40 @@ fn call_component_func_in_task(
       let core_args = component_args_to_core(
         xargs, func_type, types, resources, store, callee_table, callee_table,
       )
-      // Synchronous lifts can still hit cooperative suspension points from
-      // canonical intrinsics (e.g. sync future.read/write). Drive the event
-      // loop until the call can complete or deadlock.
-      let mut core_results : Array[@types.Value] = []
-      while true {
-        let previous_can_block = async_state.task_can_block[0]
-        async_state.task_can_block[0] = false
-        let out = call_core_func_guarded(store, may_enter, core_func, core_args) catch {
-          AsyncSuspendYield => {
-            async_state.task_can_block[0] = previous_can_block
-            let progressed = progress_one_subtask(async_state, store) catch {
-              AsyncSuspendYield => true
-              AsyncSuspendWait(_) => true
-              e => raise e
-            }
-            if !progressed {
-              raise CanonCallError(
-                "wasm trap: deadlock detected: event loop cannot make further progress",
-              )
-            }
-            continue
-          }
-          AsyncSuspendWait(ws) => {
-            async_state.task_can_block[0] = previous_can_block
-            while !waitable_set_has_event(async_state, ws) {
-              let progressed = progress_one_subtask(async_state, store) catch {
-                AsyncSuspendYield => true
-                AsyncSuspendWait(_) => true
-                e => raise e
-              }
-              if !progressed {
-                raise CanonCallError(
-                  "wasm trap: deadlock detected: event loop cannot make further progress",
-                )
-              }
-            }
-            continue
-          }
-          e => {
-            async_state.task_can_block[0] = previous_can_block
-            raise e
-          }
+      // A sync-typed lift may still reach a suspending canonical import.
+      // Instance construction conservatively propagates that fact so native
+      // code is never entered when a continuation may be required.
+      let previous_can_block = async_state.task_can_block[0]
+      async_state.task_can_block[0] = false
+      let core_results = try {
+        if core_func.may_suspend {
+          drive_core_to_completion(
+            async_state,
+            store,
+            call_core_func_guarded_outcome(
+              store, may_enter, core_func, core_args,
+            ),
+          )
+        } else {
+          call_core_func_guarded(
+            store,
+            may_enter,
+            core_func,
+            core_args,
+            mode=if core_func.native_eligible {
+              Synchronous
+            } else {
+              Interpreted
+            },
+          )
         }
-        async_state.task_can_block[0] = previous_can_block
-        core_results = out
-        break
+      } catch {
+        error => {
+          async_state.task_can_block[0] = previous_can_block
+          raise error
+        }
       }
+      async_state.task_can_block[0] = previous_can_block
       let task_id = current_task_id(async_state)
       let component_results = if async_abi {
         match take_task_result(async_state, task_id) {

--- a/modules/wasmoon/component/runtime_impl/async_types.mbt
+++ b/modules/wasmoon/component/runtime_impl/async_types.mbt
@@ -35,6 +35,9 @@ pub impl Show for ComponentValue with fn output(self, logger) {
 pub(all) struct CoreFuncRef {
   instance : @runtime.ModuleInstance
   func_idx : Int
+  engine : CoreExecutionEngine
+  may_suspend : Bool
+  native_eligible : Bool
 } derive(Debug)
 
 ///|
@@ -92,99 +95,6 @@ pub(all) struct ResourceTable {
   free_handles : Ref[Array[Int]]
   entries : Ref[Map[Int, ResourceHandle]]
 } derive(Debug)
-
-///|
-priv struct CanonCallReplaySlot {
-  cursor : Int
-  results : Map[Int, Array[@types.Value]]
-  enabled : Bool
-}
-
-///|
-fn canon_call_results_for_task(
-  async_state : AsyncState,
-  task_id : Int64,
-) -> Map[Int, Array[@types.Value]] {
-  let all_results = if async_state.in_async_callback[0] {
-    async_state.call_results_cb
-  } else {
-    async_state.call_results
-  }
-  match all_results.get(task_id) {
-    Some(results) => results
-    None => {
-      let results : Map[Int, Array[@types.Value]] = Map([])
-      all_results.set(task_id, results)
-      results
-    }
-  }
-}
-
-///|
-fn canon_call_result_ends_for_task(
-  async_state : AsyncState,
-  task_id : Int64,
-) -> Map[Int, Int] {
-  let all_ends = if async_state.in_async_callback[0] {
-    async_state.call_result_ends_cb
-  } else {
-    async_state.call_result_ends
-  }
-  match all_ends.get(task_id) {
-    Some(ends) => ends
-    None => {
-      let ends : Map[Int, Int] = Map([])
-      all_ends.set(task_id, ends)
-      ends
-    }
-  }
-}
-
-///|
-fn current_canon_call_replay_slot(
-  async_state : AsyncState,
-) -> CanonCallReplaySlot {
-  let task_id = current_task_id(async_state)
-  let cursor = if async_state.call_cursor_stack.length() == 0 {
-    0
-  } else {
-    async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-  }
-  let results = canon_call_results_for_task(async_state, task_id)
-  { cursor, results, enabled: task_id != 0L }
-}
-
-///|
-fn replay_canon_call_result(
-  async_state : AsyncState,
-  slot : CanonCallReplaySlot,
-) -> Array[@types.Value]? {
-  if !slot.enabled {
-    return None
-  }
-  match slot.results.get(slot.cursor) {
-    Some(result) => {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = slot.cursor +
-        1
-      Some(result)
-    }
-    None => None
-  }
-}
-
-///|
-fn cache_canon_call_result(
-  async_state : AsyncState,
-  slot : CanonCallReplaySlot,
-  result : Array[@types.Value],
-) -> Array[@types.Value] {
-  if slot.enabled {
-    slot.results.set(slot.cursor, result)
-  }
-  async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = slot.cursor +
-    1
-  result
-}
 
 ///|
 let resource_table_id_counter : Array[Int] = [0]
@@ -378,6 +288,7 @@ pub fn StreamTable::StreamTable() -> StreamTable {
 /// Waitable/stream/future/subtask handle numbers are per component instance (resource_table.id).
 /// Internally we key maps by `handle_key(component_id, local_handle)` to avoid collisions.
 pub(all) struct AsyncState {
+  core_engine : CoreExecutionEngine
   // Per-component handle allocator for waitables/streams/futures/subtasks/threads.
   // Handle 0 is invalid; allocation starts at 1 (matches component model ABI).
   next_handle_by_component : Map[Int, Array[Int]]
@@ -428,15 +339,6 @@ pub(all) struct AsyncState {
   // True while executing an async callback (used to conservatively reject re-entrancy).
   in_async_callback : Array[Bool]
 
-  // Per-invocation ordinals for restartable sync-style suspension points.
-  yield_cursor_stack : Array[Int]
-  wait_cursor_stack : Array[Int]
-  // Per-invocation ordinal for restartable non-suspending operations that must be replay-safe.
-  call_cursor_stack : Array[Int]
-  // Per-invocation ordinal for stream.read/write restartability (kept separate from
-  // `call_cursor_stack` to avoid collisions with non-i32 canonical calls like `stream.new`).
-  stream_cursor_stack : Array[Int]
-
   // Task tree metadata used to prevent async re-entrancy into the same component
   // instance (mirrors Wasmtime's ConcurrentState::may_enter).
   //
@@ -444,24 +346,11 @@ pub(all) struct AsyncState {
   task_caller : Map[Int64, Int64]
   // Component instance id (ResourceTable.id) associated with this task.
   task_instance : Map[Int64, Int]
-  // Replay/memoization state keyed by task id.
-  yield_replay_upto : Map[Int64, Int]
-  wait_results : Map[Int64, Map[Int, WaitResult]]
+  // A resumed yield retries the suspended host instruction exactly once.
+  yield_suspended : Map[Int64, Bool]
   waiting_ws : Map[Int64, Int64]
-  call_results : Map[Int64, Map[Int, Array[@types.Value]]]
-  // Callback invocations restart independently from the initial core function.
-  // Their call ordinals therefore need a separate replay namespace.
-  call_results_cb : Map[Int64, Map[Int, Array[@types.Value]]]
-  // Enclosing lower calls reserve a replay slot before executing nested
-  // component code. The end cursor lets replay skip the nested slots.
-  call_result_ends : Map[Int64, Map[Int, Int]]
-  call_result_ends_cb : Map[Int64, Map[Int, Int]]
-  stream_results : Map[Int64, Map[Int, Int]]
-  // Separate stream read/write memoization for callback invocations to avoid
-  // colliding with the initial core function body in callback-style async ABI.
-  stream_results_cb : Map[Int64, Map[Int, Int]]
-  // Sync-lower resumption state (keyed by task id + call cursor).
-  sync_lower_states : Map[Int64, Map[Int, SyncLowerState]]
+  // At most one sync-lowered call can be suspended in a task continuation.
+  sync_lower_states : Map[Int64, SyncLowerState]
 
   // Waitable sets and event queues.
   waitable_sets : Map[Int64, WaitableSet]
@@ -473,6 +362,8 @@ pub(all) struct AsyncState {
   subtasks : Map[Int64, Subtask]
   inflight_by_instance : Map[Int, Int]
   pending_by_instance : Map[Int, Array[Int64]]
+  // Round-robin cursor for the single-threaded host task scheduler.
+  scheduler_cursor : Array[Int64?]
 
   // Futures created by `canon future.new`.
   next_future_id : Array[Int]
@@ -496,19 +387,6 @@ struct WaitEvent {
   code : Int
   index : Int
   payload : Int
-} derive(Debug)
-
-///|
-/// Cached `waitable-set.wait` result for replay.
-///
-/// For SUBTASK+RETURNED events we also cache the return buffer slot, so replay
-/// remains correct even if subtask handles are later reused.
-struct WaitResult {
-  ev : WaitEvent
-  subtask_mem_addr : Int?
-  subtask_retptr : Int
-  // Scalar return value written at `subtask_retptr` (currently only used for i32 results).
-  subtask_i32 : Int?
 } derive(Debug)
 
 ///|
@@ -608,13 +486,14 @@ struct GuestThread {
   handle : Int
   // Root task that owns this thread.
   parent_task_id : Int64
-  // Internal task id used for replay/suspension of the explicit thread body.
+  // Internal task id that owns the explicit thread continuation.
   task_id : Int64
   start_func : CoreFuncRef
   context : Int
   phase : Array[GuestThreadPhase]
   scheduled : Array[Bool]
   waiting_ws : Array[Int64?]
+  continuation : Array[CoreContinuation?]
 } derive(Debug)
 
 ///|
@@ -638,6 +517,12 @@ enum TaskStep {
 } derive(Debug, Eq)
 
 ///|
+priv enum TaskCorePoll {
+  CoreReady(Array[@types.Value])
+  CorePending(TaskStep)
+}
+
+///|
 struct CallbackTask {
   func : ComponentFunc
   args : Array[ComponentValue]
@@ -654,6 +539,8 @@ struct CallbackTask {
   // Lazily-created state for an asynchronous host function.
   host_future : Array[HostFuture?]
   cancelled : Array[Bool]
+  // Exact core interpreter state captured at the suspension point.
+  continuation : Array[CoreContinuation?]
 } derive(Debug)
 
 ///|
@@ -682,8 +569,12 @@ struct Subtask {
 } derive(Debug)
 
 ///|
-pub fn AsyncState::AsyncState(stream_table : StreamTable) -> AsyncState {
+pub fn AsyncState::AsyncState(
+  stream_table : StreamTable,
+  core_engine? : CoreExecutionEngine = interpreter_core_execution_engine(),
+) -> AsyncState {
   {
+    core_engine,
     next_handle_by_component: Map([]),
     free_handles_by_component: Map([]),
     stream_table,
@@ -707,21 +598,10 @@ pub fn AsyncState::AsyncState(stream_table : StreamTable) -> AsyncState {
     task_can_block: [false],
     can_block_stack: [false],
     in_async_callback: [false],
-    yield_cursor_stack: [0],
-    wait_cursor_stack: [0],
-    call_cursor_stack: [0],
-    stream_cursor_stack: [0],
     task_caller: Map([]),
     task_instance: Map([]),
-    yield_replay_upto: Map([]),
-    wait_results: Map([]),
+    yield_suspended: Map([]),
     waiting_ws: Map([]),
-    call_results: Map([]),
-    call_results_cb: Map([]),
-    call_result_ends: Map([]),
-    call_result_ends_cb: Map([]),
-    stream_results: Map([]),
-    stream_results_cb: Map([]),
     sync_lower_states: Map([]),
     waitable_sets: Map([]),
     waitable_to_set: Map([]),
@@ -730,6 +610,7 @@ pub fn AsyncState::AsyncState(stream_table : StreamTable) -> AsyncState {
     subtasks: Map([]),
     inflight_by_instance: Map([]),
     pending_by_instance: Map([]),
+    scheduler_cursor: [None],
     next_future_id: [0],
     futures: Map([]),
     future_endpoints: Map([]),
@@ -849,11 +730,14 @@ fn resume_sync_waitable_use(
   owner_component_id : Int,
   handle : Int,
   task_id : Int64,
-) -> Unit {
+) -> Bool {
   let key = handle_key(owner_component_id, handle)
   if async_state.sync_waitable_users.get(key) is Some(owner_task_id) &&
     owner_task_id == task_id {
     async_state.sync_waitable_users.remove(key)
+    true
+  } else {
+    false
   }
 }
 
@@ -1201,8 +1085,8 @@ fn transfer_stream_readable_handle(
 /// Create a new readable stream handle in `to_component_id` that aliases the same stream as
 /// `handle` in `from_component_id`, without removing the original mapping.
 ///
-/// This is used to publish results early (via `canon task.return`) while the task may still be
-/// cooperatively replayed, so the callee must retain the original handle for idempotency checks.
+/// This publishes a result early via `canon task.return` while retaining the
+/// callee's original handle for the still-running producer task.
 fn clone_stream_readable_handle(
   async_state : AsyncState,
   from_component_id : Int,
@@ -2095,10 +1979,6 @@ fn push_task(async_state : AsyncState, id : Int64, can_block : Bool) -> Unit {
   async_state.task_stack.push(id)
   async_state.can_block_stack.push(can_block)
   async_state.task_can_block[0] = can_block
-  async_state.yield_cursor_stack.push(0)
-  async_state.wait_cursor_stack.push(0)
-  async_state.call_cursor_stack.push(0)
-  async_state.stream_cursor_stack.push(0)
 }
 
 ///|
@@ -2108,30 +1988,6 @@ fn pop_task(async_state : AsyncState) -> Unit {
   }
   if async_state.can_block_stack.length() > 0 {
     async_state.can_block_stack.remove(async_state.can_block_stack.length() - 1)
-    |> ignore
-  }
-  if async_state.yield_cursor_stack.length() > 0 {
-    async_state.yield_cursor_stack.remove(
-      async_state.yield_cursor_stack.length() - 1,
-    )
-    |> ignore
-  }
-  if async_state.wait_cursor_stack.length() > 0 {
-    async_state.wait_cursor_stack.remove(
-      async_state.wait_cursor_stack.length() - 1,
-    )
-    |> ignore
-  }
-  if async_state.call_cursor_stack.length() > 0 {
-    async_state.call_cursor_stack.remove(
-      async_state.call_cursor_stack.length() - 1,
-    )
-    |> ignore
-  }
-  if async_state.stream_cursor_stack.length() > 0 {
-    async_state.stream_cursor_stack.remove(
-      async_state.stream_cursor_stack.length() - 1,
-    )
     |> ignore
   }
   if async_state.can_block_stack.length() == 0 {

--- a/modules/wasmoon/component/runtime_impl/canon_future.mbt
+++ b/modules/wasmoon/component/runtime_impl/canon_future.mbt
@@ -21,31 +21,6 @@ fn instantiate_canon_future_new(
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
     }
-    // Replay-safe: `canon future.new` can be re-executed when a callback-style
-    // async core function is restarted after a suspension.
-    let task_id = current_task_id(async_state)
-    let replay_enabled = task_id != 0L
-    let cur = if async_state.call_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-    }
-    let per_task = canon_call_results_for_task(async_state, task_id)
-    if replay_enabled && per_task.get(cur) is Some(v) {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      return v
-    }
-    fn cache_i64(x : Int64) -> Array[@types.Value] {
-      let out = [@types.Value::I64(x)]
-      if replay_enabled {
-        per_task.set(cur, out)
-      }
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      out
-    }
-
     let future_id = async_state.next_future_id[0]
     async_state.next_future_id[0] = future_id + 1
     let (rh, wh) = if payload_ty is Some(_) {
@@ -101,7 +76,7 @@ fn instantiate_canon_future_new(
       wrote_value: false,
     })
     let packed = (wh.to_int64() << 32) | (rh.to_int64() & 0xFFFFFFFFL)
-    cache_i64(packed)
+    [I64(packed)]
   }
   state.core_funcs.push(alloc_host_core_func(store, core_type, host))
 }
@@ -125,43 +100,28 @@ fn instantiate_canon_future_read(
       trap_canon("cannot leave component instance")
     }
     let task_id = current_task_id(async_state)
-    let replay_enabled = task_id != 0L
-    let cur = if async_state.call_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
+    fn ret_i32(n : Int) -> Array[@types.Value] {
+      [I32(n)]
     }
-    let per_task = canon_call_results_for_task(async_state, task_id)
-    if replay_enabled && per_task.get(cur) is Some(v) {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      return v
-    }
-    fn cache_i32(n : Int) -> Array[@types.Value] {
-      let out = [@types.Value::I32(n)]
-      if replay_enabled {
-        per_task.set(cur, out)
-      }
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      out
-    }
-    match args {
+    let resumed_sync = match args {
       [I32(handle), _] => {
-        if !is_async {
+        let resumed = if !is_async {
           resume_sync_waitable_use(
             async_state, caller_component_id, handle, task_id,
           )
+        } else {
+          false
         }
         if !is_async &&
           waitable_is_in_set(async_state, caller_component_id, handle) {
           trap_canon(
             "waitable cannot be used synchronously while added to a waitable set",
           )
-          return cache_i32(0)
+          return ret_i32(0)
         }
+        resumed
       }
-      _ => ()
+      _ => false
     }
     match args {
       [I32(handle), I32(ptr)] =>
@@ -175,7 +135,7 @@ fn instantiate_canon_future_read(
             } else {
               trap_canon("unknown future handle index \{handle}")
             }
-            cache_i32(0)
+            ret_i32(0)
           }
           Some(ep) =>
             if !ep.is_readable {
@@ -184,13 +144,13 @@ fn instantiate_canon_future_read(
               } else {
                 trap_canon("type mismatch")
               }
-              cache_i32(0)
+              ret_i32(0)
             } else {
               let st0 = match async_state.futures.get(ep.future_id) {
                 Some(s) => s
                 None => {
                   trap_canon("unknown future handle index \{handle}")
-                  return cache_i32(0)
+                  return ret_i32(0)
                 }
               }
               match async_state.host_future_values.get(ep.future_id) {
@@ -199,12 +159,12 @@ fn instantiate_canon_future_read(
                     trap_canon(
                       "cannot read from future after previous read succeeded",
                     )
-                    return cache_i32(0)
+                    return ret_i32(0)
                   }
                   let polled = poll_host_future_value(host_value) catch {
                     e => {
                       trap_canon(e.to_string())
-                      return cache_i32(0)
+                      return ret_i32(0)
                     }
                   }
                   match polled {
@@ -220,7 +180,7 @@ fn instantiate_canon_future_read(
                       ) catch {
                         e => {
                           trap_canon(e.to_string())
-                          return cache_i32(0)
+                          return ret_i32(0)
                         }
                       }
                       async_state.host_future_values.remove(ep.future_id)
@@ -235,44 +195,34 @@ fn instantiate_canon_future_read(
                         write_observed_readable_drop: false,
                         wrote_value: true,
                       })
-                      return cache_i32(0)
+                      return ret_i32(0)
                     }
                     Pending => ()
                   }
                 }
                 None => ()
               }
-              let cancelled = async_state.task_cancelled.get(task_id)
-                is Some(true)
-              let mut explicit_thread_task = false
-              for kv in async_state.threads.iter() {
-                let (_k, t) = kv
-                if t.task_id == task_id {
-                  explicit_thread_task = true
-                  break
-                }
-              }
               if st0.read_done {
-                // Explicit guest thread tasks can replay suspended reads while
-                // unwinding stackful cancellation paths.
-                if cancelled || explicit_thread_task {
-                  return cache_i32(0)
+                // A completed synchronous read resumes by retrying this host
+                // instruction after the peer has already written its buffer.
+                if resumed_sync {
+                  return ret_i32(0)
                 }
                 trap_canon(
                   "cannot read from future after previous read succeeded",
                 )
-                return cache_i32(0)
+                return ret_i32(0)
               }
               if st0.pending_read is Some(_) {
                 if is_async {
                   trap_canon(
                     "cannot have concurrent operations active on a future/stream",
                   )
-                  return cache_i32(0)
+                  return ret_i32(0)
                 }
                 if !async_state.task_can_block[0] {
                   trap_canon("cannot block a synchronous task before returning")
-                  return cache_i32(0)
+                  return ret_i32(0)
                 }
                 mark_sync_waitable_blocked(
                   async_state, caller_component_id, handle, task_id,
@@ -376,7 +326,7 @@ fn instantiate_canon_future_read(
                     write_observed_readable_drop: st0.write_observed_readable_drop,
                     wrote_value: st0.wrote_value,
                   })
-                  cache_i32(0)
+                  ret_i32(0)
                 }
                 None =>
                   if st0.writable_dropped {
@@ -391,7 +341,7 @@ fn instantiate_canon_future_read(
                       write_observed_readable_drop: st0.write_observed_readable_drop,
                       wrote_value: st0.wrote_value,
                     })
-                    cache_i32(1)
+                    ret_i32(1)
                   } else {
                     // Register a pending read and report BLOCKED=-1.
                     async_state.futures.set(ep.future_id, {
@@ -416,7 +366,7 @@ fn instantiate_canon_future_read(
                       wrote_value: st0.wrote_value,
                     })
                     if is_async {
-                      cache_i32(-1)
+                      ret_i32(-1)
                     } else {
                       mark_sync_waitable_blocked(
                         async_state, caller_component_id, handle, task_id,
@@ -430,11 +380,13 @@ fn instantiate_canon_future_read(
         }
       _ => {
         trap_canon("type mismatch")
-        cache_i32(0)
+        ret_i32(0)
       }
     }
   }
-  state.core_funcs.push(alloc_host_core_func(store, core_type, host))
+  state.core_funcs.push(
+    alloc_host_core_func(store, core_type, host, may_suspend=!is_async),
+  )
 }
 
 ///|
@@ -540,26 +492,8 @@ fn instantiate_canon_future_write(
       trap_canon("cannot leave component instance")
     }
     let task_id = current_task_id(async_state)
-    let replay_enabled = task_id != 0L
-    let cur = if async_state.call_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-    }
-    let per_task = canon_call_results_for_task(async_state, task_id)
-    if replay_enabled && per_task.get(cur) is Some(v) {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      return v
-    }
-    fn cache_i32(n : Int) -> Array[@types.Value] {
-      let out = [@types.Value::I32(n)]
-      if replay_enabled {
-        per_task.set(cur, out)
-      }
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      out
+    fn ret_i32(n : Int) -> Array[@types.Value] {
+      [I32(n)]
     }
     match args {
       [I32(handle), _] => {
@@ -567,13 +501,14 @@ fn instantiate_canon_future_write(
           resume_sync_waitable_use(
             async_state, caller_component_id, handle, task_id,
           )
+          |> ignore
         }
         if !is_async &&
           waitable_is_in_set(async_state, caller_component_id, handle) {
           trap_canon(
             "waitable cannot be used synchronously while added to a waitable set",
           )
-          return cache_i32(0)
+          return ret_i32(0)
         }
       }
       _ => ()
@@ -590,7 +525,7 @@ fn instantiate_canon_future_write(
             } else {
               trap_canon("unknown future handle index \{handle}")
             }
-            cache_i32(0)
+            ret_i32(0)
           }
           Some(ep) =>
             if ep.is_readable {
@@ -599,37 +534,37 @@ fn instantiate_canon_future_write(
               } else {
                 trap_canon("type mismatch")
               }
-              cache_i32(0)
+              ret_i32(0)
             } else {
               let st0 = match async_state.futures.get(ep.future_id) {
                 Some(s) => s
                 None => {
                   trap_canon("unknown future handle index \{handle}")
-                  return cache_i32(0)
+                  return ret_i32(0)
                 }
               }
               if st0.write_succeeded {
                 trap_canon(
                   "cannot write to future after previous write succeeded",
                 )
-                return cache_i32(0)
+                return ret_i32(0)
               }
               if st0.write_observed_readable_drop {
                 trap_canon(
                   "cannot write to future after previous write succeeded or readable end dropped",
                 )
-                return cache_i32(0)
+                return ret_i32(0)
               }
               if st0.pending_write is Some(_) {
                 if is_async {
                   trap_canon(
                     "cannot have concurrent operations active on a future/stream",
                   )
-                  return cache_i32(0)
+                  return ret_i32(0)
                 }
                 if !async_state.task_can_block[0] {
                   trap_canon("cannot block a synchronous task before returning")
-                  return cache_i32(0)
+                  return ret_i32(0)
                 }
                 mark_sync_waitable_blocked(
                   async_state, caller_component_id, handle, task_id,
@@ -651,7 +586,7 @@ fn instantiate_canon_future_write(
                   write_observed_readable_drop: true,
                   wrote_value: st0.wrote_value,
                 })
-                return cache_i32(1)
+                return ret_i32(1)
               }
               match st0.pending_read {
                 Some(pr) => {
@@ -796,7 +731,7 @@ fn instantiate_canon_future_write(
                     write_observed_readable_drop: st0.write_observed_readable_drop,
                     wrote_value: true,
                   })
-                  cache_i32(0)
+                  ret_i32(0)
                 }
                 None => {
                   // Register a pending write by reading the payload once.
@@ -878,7 +813,7 @@ fn instantiate_canon_future_write(
                     wrote_value: true,
                   })
                   if is_async {
-                    cache_i32(-1)
+                    ret_i32(-1)
                   } else {
                     mark_sync_waitable_blocked(
                       async_state, caller_component_id, handle, task_id,
@@ -892,11 +827,13 @@ fn instantiate_canon_future_write(
         }
       _ => {
         trap_canon("type mismatch")
-        cache_i32(0)
+        ret_i32(0)
       }
     }
   }
-  state.core_funcs.push(alloc_host_core_func(store, core_type, host))
+  state.core_funcs.push(
+    alloc_host_core_func(store, core_type, host, may_suspend=!is_async),
+  )
 }
 
 ///|

--- a/modules/wasmoon/component/runtime_impl/canon_lift_lower.mbt
+++ b/modules/wasmoon/component/runtime_impl/canon_lift_lower.mbt
@@ -115,45 +115,12 @@ fn instantiate_canon_lower(
       let live_caller_table = registered_resource_table(
         async_state, caller_table,
       )
-      let cur_task_id = current_task_id(async_state)
-      let replay_enabled = cur_task_id != 0L
-      let cur = if async_state.call_cursor_stack.length() == 0 {
-        0
-      } else {
-        async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-      }
-      let per_task = canon_call_results_for_task(async_state, cur_task_id)
-      let per_task_ends = canon_call_result_ends_for_task(
-        async_state, cur_task_id,
-      )
-      fn cache_and_advance(out : Array[@types.Value]) -> Array[@types.Value] {
+      fn finish_call(out : Array[@types.Value]) -> Array[@types.Value] {
         set_canon_debug_message(
-          "lower.async(func=\{func_idx} cur=\{cur})-> \{to_repr(out)}",
+          "lower.async(func=\{func_idx})-> \{to_repr(out)}",
         )
-        if replay_enabled {
-          per_task.set(cur, out)
-          per_task_ends.set(
-            cur,
-            async_state.call_cursor_stack[async_state.call_cursor_stack.length() -
-            1],
-          )
-        }
         out
       }
-
-      if replay_enabled && per_task.get(cur) is Some(v) {
-        set_canon_debug_message(
-          "lower.async(replay func=\{func_idx} cur=\{cur})-> \{to_repr(v)}",
-        )
-        async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = per_task_ends
-          .get(cur)
-          .unwrap_or(cur + 1)
-        return v
-      }
-      // Reserve this lower's own replay slot. Canonical operations executed by
-      // the nested component call use the following slots.
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
 
       // Split core args into component params and optional return pointer.
       let mut retptr : Int? = None
@@ -162,7 +129,7 @@ fn instantiate_canon_lower(
         Some(_) => {
           if args.length() == 0 {
             trap_canon("missing retptr")
-            return cache_and_advance([I32(0)])
+            return finish_call([I32(0)])
           }
           for i in 0..<(args.length() - 1) {
             param_args.push(args[i])
@@ -184,7 +151,7 @@ fn instantiate_canon_lower(
       ) catch {
         e => {
           trap_canon(canon_err_message(e))
-          return cache_and_advance([I32(0)])
+          return finish_call([I32(0)])
         }
       }
       let inst_id = match func {
@@ -230,6 +197,7 @@ fn instantiate_canon_lower(
         waiting_set: [None],
         host_future: [None],
         cancelled: [false],
+        continuation: [None],
       }
       let retp = match retptr {
         Some(p) => p
@@ -244,22 +212,15 @@ fn instantiate_canon_lower(
         async_state.task_contexts.remove(task_id)
         drop_task_thread(async_state, task_id)
         remove_task_meta(async_state, task_id)
-        async_state.yield_replay_upto.remove(task_id)
-        async_state.wait_results.remove(task_id)
+        async_state.yield_suspended.remove(task_id)
         async_state.waiting_ws.remove(task_id)
-        async_state.call_results.remove(task_id)
-        async_state.call_results_cb.remove(task_id)
-        async_state.call_result_ends.remove(task_id)
-        async_state.call_result_ends_cb.remove(task_id)
-        async_state.stream_results.remove(task_id)
-        async_state.stream_results_cb.remove(task_id)
         async_state.sync_lower_states.remove(task_id)
       }
 
       fn migrate_task_id(from_id : Int64, to_id : Int64) -> Unit {
         // A shared handle may be recycled after subtask.drop. Treat the new
         // subtask as a fresh task identity even if stale bookkeeping survived
-        // an earlier replay path.
+        // an earlier task.
         cleanup_task_id(to_id)
         let owner = match async_state.task_result_owner.get(from_id) {
           Some(o) => o
@@ -289,41 +250,13 @@ fn instantiate_canon_lower(
           async_state.task_contexts.remove(from_id)
           async_state.task_contexts.set(to_id, v)
         }
-        if async_state.yield_replay_upto.get(from_id) is Some(v) {
-          async_state.yield_replay_upto.remove(from_id)
-          async_state.yield_replay_upto.set(to_id, v)
-        }
-        if async_state.wait_results.get(from_id) is Some(v) {
-          async_state.wait_results.remove(from_id)
-          async_state.wait_results.set(to_id, v)
+        if async_state.yield_suspended.get(from_id) is Some(v) {
+          async_state.yield_suspended.remove(from_id)
+          async_state.yield_suspended.set(to_id, v)
         }
         if async_state.waiting_ws.get(from_id) is Some(v) {
           async_state.waiting_ws.remove(from_id)
           async_state.waiting_ws.set(to_id, v)
-        }
-        if async_state.call_results.get(from_id) is Some(v) {
-          async_state.call_results.remove(from_id)
-          async_state.call_results.set(to_id, v)
-        }
-        if async_state.call_results_cb.get(from_id) is Some(v) {
-          async_state.call_results_cb.remove(from_id)
-          async_state.call_results_cb.set(to_id, v)
-        }
-        if async_state.call_result_ends.get(from_id) is Some(v) {
-          async_state.call_result_ends.remove(from_id)
-          async_state.call_result_ends.set(to_id, v)
-        }
-        if async_state.call_result_ends_cb.get(from_id) is Some(v) {
-          async_state.call_result_ends_cb.remove(from_id)
-          async_state.call_result_ends_cb.set(to_id, v)
-        }
-        if async_state.stream_results.get(from_id) is Some(v) {
-          async_state.stream_results.remove(from_id)
-          async_state.stream_results.set(to_id, v)
-        }
-        if async_state.stream_results_cb.get(from_id) is Some(v) {
-          async_state.stream_results_cb.remove(from_id)
-          async_state.stream_results_cb.set(to_id, v)
         }
         if async_state.sync_lower_states.get(from_id) is Some(v) {
           async_state.sync_lower_states.remove(from_id)
@@ -375,7 +308,7 @@ fn instantiate_canon_lower(
               ) catch {
                 e => {
                   trap_canon(canon_err_message(e))
-                  return cache_and_advance([I32(0)])
+                  return finish_call([I32(0)])
                 }
               }
               let core_vals = component_results_to_core(
@@ -388,18 +321,18 @@ fn instantiate_canon_lower(
               ) catch {
                 e => {
                   trap_canon(canon_err_message(e))
-                  return cache_and_advance([I32(0)])
+                  return finish_call([I32(0)])
                 }
               }
               store_async_lower_result(mem, p, core_vals) catch {
                 e => {
                   trap_canon(canon_err_message(e))
-                  return cache_and_advance([I32(0)])
+                  return finish_call([I32(0)])
                 }
               }
             }
             cleanup_task_id(tmp_task_id)
-            return cache_and_advance([I32(2)]) // RETURNED
+            return finish_call([I32(2)]) // RETURNED
           }
 
           // Some callback-style async functions publish their results early via `canon task.return`
@@ -436,7 +369,7 @@ fn instantiate_canon_lower(
               } catch {
                 e => {
                   trap_canon(canon_err_message(e))
-                  return cache_and_advance([I32(0)])
+                  return finish_call([I32(0)])
                 }
               }
               let core_vals = component_results_to_core(
@@ -449,13 +382,13 @@ fn instantiate_canon_lower(
               ) catch {
                 e => {
                   trap_canon(canon_err_message(e))
-                  return cache_and_advance([I32(0)])
+                  return finish_call([I32(0)])
                 }
               }
               store_async_lower_result(mem, p, core_vals) catch {
                 e => {
                   trap_canon(canon_err_message(e))
-                  return cache_and_advance([I32(0)])
+                  return finish_call([I32(0)])
                 }
               }
             }
@@ -477,7 +410,7 @@ fn instantiate_canon_lower(
             // `task.return` releases the callee's automatic-backpressure slot
             // even though the detached continuation still has work to do.
             async_state.inflight_by_instance.set(bp_key, 0)
-            return cache_and_advance([I32(2)]) // RETURNED
+            return finish_call([I32(2)]) // RETURNED
           }
 
           // Needs a real subtask handle: allocate and migrate the per-task state.
@@ -513,7 +446,7 @@ fn instantiate_canon_lower(
             },
           )
           async_state.subtasks.set(sub_key, st)
-          return cache_and_advance([I32((sub_id << 4) | 1)]) // STARTED
+          return finish_call([I32((sub_id << 4) | 1)]) // STARTED
         }
 
         // Non-callback async lowering: do a handle-less initial step so the task can
@@ -551,7 +484,7 @@ fn instantiate_canon_lower(
             ) catch {
               e => {
                 trap_canon(canon_err_message(e))
-                return cache_and_advance([I32(0)])
+                return finish_call([I32(0)])
               }
             }
             let core_vals = component_results_to_core(
@@ -564,18 +497,18 @@ fn instantiate_canon_lower(
             ) catch {
               e => {
                 trap_canon(canon_err_message(e))
-                return cache_and_advance([I32(0)])
+                return finish_call([I32(0)])
               }
             }
             store_async_lower_result(mem, p, core_vals) catch {
               e => {
                 trap_canon(canon_err_message(e))
-                return cache_and_advance([I32(0)])
+                return finish_call([I32(0)])
               }
             }
           }
           cleanup_task_id(tmp_task_id)
-          return cache_and_advance([I32(2)]) // RETURNED
+          return finish_call([I32(2)]) // RETURNED
         }
         let sub_id = alloc_shared_handle(async_state, caller_table.id)
         let sub_key = handle_key(caller_table.id, sub_id)
@@ -609,7 +542,7 @@ fn instantiate_canon_lower(
           },
         )
         async_state.subtasks.set(sub_key, st)
-        cache_and_advance([I32((sub_id << 4) | 1)]) // STARTED
+        finish_call([I32((sub_id << 4) | 1)]) // STARTED
       } else {
         // Backpressure/serialization: queue in STARTING state until this
         // async-lowered call becomes eligible to start.
@@ -637,7 +570,7 @@ fn instantiate_canon_lower(
         }
         q.push(sub_key)
         async_state.pending_by_instance.set(bp_key, q)
-        cache_and_advance([I32((sub_id << 4) | 0)]) // STARTING
+        finish_call([I32((sub_id << 4) | 0)]) // STARTING
       }
     }
     state.core_funcs.push(alloc_host_core_func(store, core_type, host))
@@ -662,28 +595,6 @@ fn instantiate_canon_lower(
         state.resource_table,
       )
       let outer_task_id = current_task_id(async_state)
-      let cur = if async_state.call_cursor_stack.length() == 0 {
-        0
-      } else {
-        async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-      }
-      let per_task_calls = canon_call_results_for_task(
-        async_state, outer_task_id,
-      )
-      let per_task_call_ends = canon_call_result_ends_for_task(
-        async_state, outer_task_id,
-      )
-      let replay_enabled = outer_task_id != 0L
-      if replay_enabled && per_task_calls.get(cur) is Some(v) {
-        async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = per_task_call_ends
-          .get(cur)
-          .unwrap_or(cur + 1)
-        return v
-      }
-      // Reserve the enclosing lower call's slot before invoking nested
-      // component code. Nested canonical calls then occupy subsequent slots.
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
       let component_args = core_args_to_component(
         args, func_type, func_types, resources, store, caller_table, 16, "sync lower argument",
       ) catch {
@@ -724,29 +635,15 @@ fn instantiate_canon_lower(
         async_state.task_contexts.remove(task_id)
         drop_task_thread(async_state, task_id)
         remove_task_meta(async_state, task_id)
-        async_state.yield_replay_upto.remove(task_id)
-        async_state.wait_results.remove(task_id)
+        async_state.yield_suspended.remove(task_id)
         async_state.waiting_ws.remove(task_id)
-        async_state.call_results.remove(task_id)
-        async_state.call_results_cb.remove(task_id)
-        async_state.call_result_ends.remove(task_id)
-        async_state.call_result_ends_cb.remove(task_id)
         async_state.sync_lower_states.remove(task_id)
       }
 
       let results : Array[ComponentValue] = if func_type.is_async {
         // Sync-lowering an async component function must be cooperative:
         // treat YIELD/WAIT as restartable suspension points instead of busy looping.
-        let per_task_state = match
-          async_state.sync_lower_states.get(outer_task_id) {
-          Some(m) => m
-          None => {
-            let m : Map[Int, SyncLowerState] = Map([])
-            async_state.sync_lower_states.set(outer_task_id, m)
-            m
-          }
-        }
-        let st = match per_task_state.get(cur) {
+        let st = match async_state.sync_lower_states.get(outer_task_id) {
           Some(s) => s
           None => {
             // Sync-lowering does not expose a guest-visible subtask handle, so do not
@@ -762,12 +659,13 @@ fn instantiate_canon_lower(
               waiting_set: [None],
               host_future: [None],
               cancelled: [false],
+              continuation: [None],
             }
             init_task_meta(
               async_state, inner_task_id, meta_inst_id, outer_task_id,
             )
             let s : SyncLowerState = { task_id: inner_task_id, task }
-            per_task_state.set(cur, s)
+            async_state.sync_lower_states.set(outer_task_id, s)
             s
           }
         }
@@ -792,28 +690,8 @@ fn instantiate_canon_lower(
           ) catch {
             e => {
               pop_task(async_state)
-              match e {
-                AsyncSuspendYield => {
-                  canon_suspend[0] = Some(Yield)
-                  raise Unreachable
-                }
-                AsyncSuspendWait(ws) => {
-                  canon_suspend[0] = Some(Wait(ws))
-                  raise Unreachable
-                }
-                CanonCallError(msg) =>
-                  if msg.contains("AsyncSuspendYield") {
-                    canon_suspend[0] = Some(Yield)
-                    raise Unreachable
-                  } else {
-                    trap_canon(msg)
-                    return []
-                  }
-                _ => {
-                  trap_canon(canon_err_message(e))
-                  return []
-                }
-              }
+              trap_canon(canon_err_message(e))
+              return []
             }
           }
           pop_task(async_state)
@@ -880,9 +758,8 @@ fn instantiate_canon_lower(
               resources,
               driver: CallbackLifted(st.task),
             })
-            per_task_state.remove(cur) |> ignore
+            async_state.sync_lower_states.remove(outer_task_id)
 
-            // Cache and advance call cursor (replay-safe).
             let mut out_ptr : Int? = None
             if func_type.result is Some(rty) {
               let flat = core_types_for_valtype(
@@ -912,17 +789,11 @@ fn instantiate_canon_lower(
                 ([] : Array[@types.Value])
               }
             }
-            per_task_calls.set(cur, out)
-            per_task_call_ends.set(
-              cur,
-              async_state.call_cursor_stack[async_state.call_cursor_stack.length() -
-              1],
-            )
             return out
           }
           match step {
             Done => {
-              per_task_state.remove(cur) |> ignore
+              async_state.sync_lower_states.remove(outer_task_id)
               let vals = match take_task_result(async_state, st.task_id) {
                 Some(v) => v
                 None => []
@@ -954,7 +825,6 @@ fn instantiate_canon_lower(
                 }
               }
               cleanup_sync_lower_task(st.task_id)
-              // Cache and advance call cursor (replay-safe).
               let mut out_ptr : Int? = None
               match func_type.result {
                 Some(rty) => {
@@ -988,17 +858,11 @@ fn instantiate_canon_lower(
                   ([] : Array[@types.Value])
                 }
               }
-              per_task_calls.set(cur, out)
-              per_task_call_ends.set(
-                cur,
-                async_state.call_cursor_stack[async_state.call_cursor_stack.length() -
-                1],
-              )
               return out
             }
             _ =>
               if canon_in_prerun[0] {
-                per_task_state.remove(cur) |> ignore
+                async_state.sync_lower_states.remove(outer_task_id)
                 cleanup_sync_lower_task(st.task_id)
                 trap_canon("prerun blocked")
                 ([] : Array[ComponentValue])
@@ -1047,14 +911,6 @@ fn instantiate_canon_lower(
           ([] : Array[@types.Value])
         }
       }
-      if replay_enabled {
-        per_task_calls.set(cur, out)
-        per_task_call_ends.set(
-          cur,
-          async_state.call_cursor_stack[async_state.call_cursor_stack.length() -
-          1],
-        )
-      }
       out
     }
     let func_addr = store.alloc_host_func(host, func_type=core_type, type_idx=0)
@@ -1075,6 +931,14 @@ fn instantiate_canon_lower(
       dropped_elems: [],
       dropped_datas: [],
     }
-    state.core_funcs.push({ instance, func_idx: 0 })
+    state.core_funcs.push({
+      instance,
+      func_idx: 0,
+      engine: interpreter_core_execution_engine(),
+      may_suspend: func_type.is_async,
+      // Entering this adapter may invoke another component core engine. The
+      // current native runtime does not support nested JIT activation.
+      native_eligible: false,
+    })
   }
 }

--- a/modules/wasmoon/component/runtime_impl/canon_resource.mbt
+++ b/modules/wasmoon/component/runtime_impl/canon_resource.mbt
@@ -148,13 +148,6 @@ fn instantiate_canon_resource_drop(
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
     }
-    let replay_slot = current_canon_call_replay_slot(state.async_state)
-    if replay_canon_call_result(state.async_state, replay_slot) is Some(result) {
-      return result
-    }
-    fn cache_void() -> Array[@types.Value] {
-      cache_canon_call_result(state.async_state, replay_slot, [])
-    }
     match args {
       [I32(handle)] =>
         match table.get(handle) {
@@ -235,7 +228,7 @@ fn instantiate_canon_resource_drop(
                   }
                 None => ()
               }
-              cache_void()
+              []
             }
           None => {
             trap_canon(

--- a/modules/wasmoon/component/runtime_impl/canon_stream.mbt
+++ b/modules/wasmoon/component/runtime_impl/canon_stream.mbt
@@ -29,33 +29,6 @@ fn instantiate_canon_stream_new(
       trap_canon("cannot leave component instance")
     }
 
-    // Replay-safe: `canon stream.new` can be executed multiple times if the
-    // surrounding core function is restarted after a cooperative suspension.
-    // Cache the i64 result per task/call cursor so handle numbering remains stable.
-    let task_id = current_task_id(async_state)
-    let replay_enabled = task_id != 0L
-    let cur = if async_state.call_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-    }
-    let per_task = canon_call_results_for_task(async_state, task_id)
-    if replay_enabled && per_task.get(cur) is Some(v) {
-      set_canon_debug_message("stream.new(replay cur=\{cur})-> \{to_repr(v)}")
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      return v
-    }
-    fn cache_i64(x : Int64) -> Array[@types.Value] {
-      let out = [@types.Value::I64(x)]
-      if replay_enabled {
-        per_task.set(cur, out)
-      }
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      out
-    }
-
     let sid = table.next_stream_id[0]
     table.next_stream_id[0] = sid + 1
     table.streams.set(sid, {
@@ -89,7 +62,7 @@ fn instantiate_canon_stream_new(
       "stream.new(owner=\{owner_component_id})-> rh=\{rh} wh=\{wh}",
     )
     let packed = (wh.to_int64() << 32) | (rh.to_int64() & 0xFFFFFFFFL)
-    cache_i64(packed)
+    [I64(packed)]
   }
   state.core_funcs.push(alloc_host_core_func(store, core_type, host))
 }
@@ -296,56 +269,9 @@ fn instantiate_canon_stream_read(
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
     }
-    // Replay-safe: stream.read/write can be re-executed when the surrounding core function is
-    // restarted after a cooperative suspension. Cache their return codes per task + cursor so
-    // side effects (buffer copies / handle transfers) are not repeated.
     let task_id = current_task_id(async_state)
-    let replay_enabled = task_id != 0L
-    let cur = if async_state.stream_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-      1]
-    }
-    // Callback-style async ABI runs different core functions across steps; their cursors
-    // restart at 0 each step, so keep a separate replay map for callbacks to avoid
-    // colliding with the initial core function body.
-    let per_task = if async_state.in_async_callback[0] {
-      match async_state.stream_results_cb.get(task_id) {
-        Some(m) => m
-        None => {
-          let m : Map[Int, Int] = Map([])
-          async_state.stream_results_cb.set(task_id, m)
-          m
-        }
-      }
-    } else {
-      match async_state.stream_results.get(task_id) {
-        Some(m) => m
-        None => {
-          let m : Map[Int, Int] = Map([])
-          async_state.stream_results.set(task_id, m)
-          m
-        }
-      }
-    }
-    if replay_enabled && per_task.get(cur) is Some(code) {
-      set_canon_debug_message("stream.read(replay cur=\{cur})-> \{code}")
-      async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-      1] = cur + 1
-      return [I32(code)]
-    }
-    fn cache_i32(code : Int) -> Array[@types.Value] {
-      if replay_enabled {
-        per_task.set(cur, code)
-      }
-      async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-      1] = cur + 1
-      [I32(code)]
-    }
-
     fn ret_i32(code : Int) -> Array[@types.Value] {
-      cache_i32(code)
+      [I32(code)]
     }
 
     let mem_opt : @runtime.Memory? = match payload_ty {
@@ -373,6 +299,7 @@ fn instantiate_canon_stream_read(
           resume_sync_waitable_use(
             async_state, owner_component_id, handle, task_id,
           )
+          |> ignore
         }
         if !is_async &&
           waitable_is_in_set(async_state, owner_component_id, handle) {
@@ -498,7 +425,7 @@ fn instantiate_canon_stream_read(
                       }
                     }
                     match poll_result {
-                      HostValueStreamPoll::Values(values) => {
+                      Values(values) => {
                         for i, value in values {
                           store_host_stream_value(
                             value,
@@ -517,7 +444,7 @@ fn instantiate_canon_stream_read(
                         }
                         return ret_i32(values.length() << 4)
                       }
-                      HostValueStreamPoll::Closed => {
+                      Closed => {
                         ep.notified_peer_dropped[0] = true
                         table.streams.set(ep.stream_id, {
                           elem_size: st0.elem_size,
@@ -529,7 +456,7 @@ fn instantiate_canon_stream_read(
                         })
                         return ret_i32(1)
                       }
-                      HostValueStreamPoll::Pending => {
+                      Pending => {
                         table.streams.set(ep.stream_id, {
                           elem_size: st0.elem_size,
                           own_resource_type_id: st0.own_resource_type_id,
@@ -932,7 +859,9 @@ fn instantiate_canon_stream_read(
       }
     }
   }
-  state.core_funcs.push(alloc_host_core_func(store, core_type, host))
+  state.core_funcs.push(
+    alloc_host_core_func(store, core_type, host, may_suspend=!is_async),
+  )
 }
 
 ///|
@@ -959,56 +888,9 @@ fn instantiate_canon_stream_write(
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
     }
-    // Replay-safe: stream.read/write can be re-executed when the surrounding core function is
-    // restarted after a cooperative suspension. Cache their return codes per task + cursor so
-    // side effects (buffer copies / handle transfers) are not repeated.
     let task_id = current_task_id(async_state)
-    let replay_enabled = task_id != 0L
-    let cur = if async_state.stream_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-      1]
-    }
-    // Callback-style async ABI runs different core functions across steps; their cursors
-    // restart at 0 each step, so keep a separate replay map for callbacks to avoid
-    // colliding with the initial core function body.
-    let per_task = if async_state.in_async_callback[0] {
-      match async_state.stream_results_cb.get(task_id) {
-        Some(m) => m
-        None => {
-          let m : Map[Int, Int] = Map([])
-          async_state.stream_results_cb.set(task_id, m)
-          m
-        }
-      }
-    } else {
-      match async_state.stream_results.get(task_id) {
-        Some(m) => m
-        None => {
-          let m : Map[Int, Int] = Map([])
-          async_state.stream_results.set(task_id, m)
-          m
-        }
-      }
-    }
-    if replay_enabled && per_task.get(cur) is Some(code) {
-      set_canon_debug_message("stream.write(replay cur=\{cur})-> \{code}")
-      async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-      1] = cur + 1
-      return [I32(code)]
-    }
-    fn cache_i32(code : Int) -> Array[@types.Value] {
-      if replay_enabled {
-        per_task.set(cur, code)
-      }
-      async_state.stream_cursor_stack[async_state.stream_cursor_stack.length() -
-      1] = cur + 1
-      [I32(code)]
-    }
-
     fn ret_i32(code : Int) -> Array[@types.Value] {
-      cache_i32(code)
+      [I32(code)]
     }
 
     let mem_opt : @runtime.Memory? = match payload_ty {
@@ -1036,6 +918,7 @@ fn instantiate_canon_stream_write(
           resume_sync_waitable_use(
             async_state, owner_component_id, handle, task_id,
           )
+          |> ignore
         }
         if !is_async &&
           waitable_is_in_set(async_state, owner_component_id, handle) {
@@ -1075,7 +958,8 @@ fn instantiate_canon_stream_write(
                     return ret_i32(0)
                   }
                 }
-                // If re-executing a previously blocking write, return its completion.
+                // A resumed blocking write retries this host instruction with
+                // the same pending operation.
                 match st0.pending_write {
                   Some(pw0) =>
                     if is_async {
@@ -1089,8 +973,8 @@ fn instantiate_canon_stream_write(
                       if st0.readable_dropped || pw0.sent >= total_elems {
                         // Sync stream.write should observe a drop that happens immediately after a
                         // successful rendezvous (read returns to the caller and then the caller
-                        // drops the readable end). To model this with cooperative replay, defer
-                        // completion by one yield once the write becomes fully consumed.
+                        // drops the readable end). Defer completion by one yield
+                        // once the write becomes fully consumed.
                         if !is_async &&
                           !st0.readable_dropped &&
                           pw0.sent >= total_elems &&
@@ -1499,7 +1383,9 @@ fn instantiate_canon_stream_write(
       }
     }
   }
-  state.core_funcs.push(alloc_host_core_func(store, core_type, host))
+  state.core_funcs.push(
+    alloc_host_core_func(store, core_type, host, may_suspend=!is_async),
+  )
 }
 
 ///|
@@ -1674,13 +1560,6 @@ fn instantiate_canon_stream_drop_readable(
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
     }
-    let replay_slot = current_canon_call_replay_slot(async_state)
-    if replay_canon_call_result(async_state, replay_slot) is Some(result) {
-      return result
-    }
-    fn cache_void() -> Array[@types.Value] {
-      cache_canon_call_result(async_state, replay_slot, [])
-    }
     match args {
       [I32(handle)] =>
         match table.endpoints.get(handle_key(owner_component_id, handle)) {
@@ -1769,7 +1648,7 @@ fn instantiate_canon_stream_drop_readable(
               }
               table.host_values.remove(ep.stream_id)
               free_shared_handle(async_state, owner_component_id, handle)
-              cache_void()
+              []
             }
         }
       _ => {
@@ -1796,13 +1675,6 @@ fn instantiate_canon_stream_drop_writable(
   ) -> Array[@types.Value] raise @runtime.RuntimeError {
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
-    }
-    let replay_slot = current_canon_call_replay_slot(async_state)
-    if replay_canon_call_result(async_state, replay_slot) is Some(result) {
-      return result
-    }
-    fn cache_void() -> Array[@types.Value] {
-      cache_canon_call_result(async_state, replay_slot, [])
     }
     match args {
       [I32(handle)] =>
@@ -1886,7 +1758,7 @@ fn instantiate_canon_stream_drop_writable(
               )
               table.endpoints.remove(handle_key(owner_component_id, handle))
               free_shared_handle(async_state, owner_component_id, handle)
-              cache_void()
+              []
             }
         }
       _ => {

--- a/modules/wasmoon/component/runtime_impl/canon_subtask.mbt
+++ b/modules/wasmoon/component/runtime_impl/canon_subtask.mbt
@@ -17,24 +17,8 @@ fn instantiate_canon_subtask_cancel(
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
     }
-    let task_id = current_task_id(async_state)
-    let cur = if async_state.call_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-    }
-    let per_task = canon_call_results_for_task(async_state, task_id)
-    if per_task.get(cur) is Some(v) {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      return v
-    }
-    fn cache_i32(n : Int) -> Array[@types.Value] {
-      let out = [@types.Value::I32(n)]
-      per_task.set(cur, out)
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      out
+    fn ret_i32(n : Int) -> Array[@types.Value] {
+      [I32(n)]
     }
 
     match args {
@@ -44,22 +28,22 @@ fn instantiate_canon_subtask_cancel(
           trap_canon(
             "waitable cannot be used synchronously while added to a waitable set",
           )
-          return cache_i32(0)
+          return ret_i32(0)
         }
         if !is_async_cancel && !async_state.task_can_block[0] {
           trap_canon("cannot block a synchronous task before returning")
-          return cache_i32(0)
+          return ret_i32(0)
         }
         let skey = handle_key(owner_component_id, id)
         match async_state.subtasks.get(skey) {
           None => {
             trap_canon("unknown subtask handle index \{id}")
-            cache_i32(0)
+            ret_i32(0)
           }
           Some(st) => {
             if st.phase[0] == Returned {
               // Already resolved.
-              return cache_i32(0)
+              return ret_i32(0)
             }
             async_state.task_cancelled.set(skey, true)
 
@@ -91,7 +75,7 @@ fn instantiate_canon_subtask_cancel(
                 }
               }
               // CANCELLED_BEFORE_STARTED.
-              return cache_i32(3)
+              return ret_i32(3)
             }
 
             // Best-effort: if the subtask uses the callback-style async ABI,
@@ -125,7 +109,7 @@ fn instantiate_canon_subtask_cancel(
                     e => {
                       pop_task(async_state)
                       trap_canon(canon_err_message(e))
-                      return cache_i32(0)
+                      return ret_i32(0)
                     }
                   }
                   pop_task(async_state)
@@ -140,7 +124,7 @@ fn instantiate_canon_subtask_cancel(
                         payload: 4,
                       })
                       // CANCELLED_BEFORE_RETURNED=4 (component-spec convention).
-                      return cache_i32(4)
+                      return ret_i32(4)
                     }
                     _ => ()
                   }
@@ -149,13 +133,13 @@ fn instantiate_canon_subtask_cancel(
             }
 
             // BLOCKED=-1 (cancellation didn't complete synchronously).
-            cache_i32(-1)
+            ret_i32(-1)
           }
         }
       }
       _ => {
         trap_canon("type mismatch")
-        cache_i32(0)
+        ret_i32(0)
       }
     }
   }
@@ -176,24 +160,8 @@ fn instantiate_canon_subtask_drop(
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
     }
-    let task_id = current_task_id(async_state)
-    let cur = if async_state.call_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-    }
-    let per_task = canon_call_results_for_task(async_state, task_id)
-    if per_task.get(cur) is Some(v) {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      return v
-    }
-    fn cache_void() -> Array[@types.Value] {
-      let out : Array[@types.Value] = []
-      per_task.set(cur, out)
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-        1
-      out
+    fn ret_void() -> Array[@types.Value] {
+      []
     }
 
     match args {
@@ -205,13 +173,13 @@ fn instantiate_canon_subtask_drop(
           Some(st) =>
             if st.phase[0] != Returned {
               trap_canon("cannot drop a subtask which has not yet resolved")
-              return cache_void()
+              return ret_void()
             } else {
               async_state.subtasks.remove(skey)
             }
           None => {
             trap_canon("unknown subtask handle index \{id}")
-            return cache_void()
+            return ret_void()
           }
         }
 
@@ -247,13 +215,8 @@ fn instantiate_canon_subtask_drop(
         async_state.task_cancelled.remove(skey)
         async_state.task_contexts.remove(skey)
         drop_task_thread(async_state, skey)
-        async_state.yield_replay_upto.remove(skey)
-        async_state.wait_results.remove(skey)
+        async_state.yield_suspended.remove(skey)
         async_state.waiting_ws.remove(skey)
-        async_state.call_results.remove(skey)
-        async_state.call_results_cb.remove(skey)
-        async_state.call_result_ends.remove(skey)
-        async_state.call_result_ends_cb.remove(skey)
         async_state.sync_lower_states.remove(skey)
 
         // Remove from pending queues if it was still STARTING.
@@ -281,11 +244,11 @@ fn instantiate_canon_subtask_drop(
           }
         }
         free_shared_handle(async_state, owner_component_id, id)
-        cache_void()
+        ret_void()
       }
       _ => {
         trap_canon("type mismatch")
-        cache_void()
+        ret_void()
       }
     }
   }

--- a/modules/wasmoon/component/runtime_impl/canon_task.mbt
+++ b/modules/wasmoon/component/runtime_impl/canon_task.mbt
@@ -81,45 +81,9 @@ fn instantiate_canon_task_return(
       trap_canon("borrow handles still remain at the end of the call")
       return []
     }
-    // `canon task.return` can be executed multiple times if the surrounding
-    // core function is cooperatively replayed after a suspension (e.g. a
-    // sync stream.read/write inside a callback-style async task).
-    // Treat re-execution as idempotent as long as it returns the same value.
     if async_state.task_returned.get(task_id) is Some(_) {
-      match result {
-        None => return []
-        Some(vt) => {
-          let v = lift_task_return_value(
-            vt,
-            args,
-            resources,
-            types,
-            state.resource_table,
-            store,
-          ) catch {
-            e => {
-              trap_canon(canon_err_message(e))
-              return []
-            }
-          }
-          // NOTE: Unlike wasmtime, wasmoon currently implements sync-style
-          // suspension by cooperatively replaying the whole core function.
-          // This means `task.return` may be re-executed after its stream/future
-          // readable handles have already been transferred to the caller's
-          // component instance. In that case, re-validating the handle against
-          // the original component's handle table would spuriously trap.
-          match async_state.task_results.get(task_id) {
-            Some(prev) =>
-              if prev.length() == 1 && prev[0] == v {
-                return []
-              } else {
-                trap_canon("task.return called more than once")
-                return []
-              }
-            None => return []
-          }
-        }
-      }
+      trap_canon("task.return called more than once")
+      return []
     }
     async_state.task_returned.set(task_id, true)
     let vals : Array[ComponentValue] = match result {

--- a/modules/wasmoon/component/runtime_impl/canon_thread.mbt
+++ b/modules/wasmoon/component/runtime_impl/canon_thread.mbt
@@ -174,15 +174,8 @@ fn cleanup_thread_task(async_state : AsyncState, task_id : Int64) -> Unit {
   async_state.task_contexts.remove(task_id)
   drop_task_thread(async_state, task_id)
   remove_task_meta(async_state, task_id)
-  async_state.yield_replay_upto.remove(task_id)
-  async_state.wait_results.remove(task_id)
+  async_state.yield_suspended.remove(task_id)
   async_state.waiting_ws.remove(task_id)
-  async_state.call_results.remove(task_id)
-  async_state.call_results_cb.remove(task_id)
-  async_state.call_result_ends.remove(task_id)
-  async_state.call_result_ends_cb.remove(task_id)
-  async_state.stream_results.remove(task_id)
-  async_state.stream_results_cb.remove(task_id)
   async_state.sync_lower_states.remove(task_id)
 }
 
@@ -220,31 +213,43 @@ fn run_explicit_thread_once(
   }
 
   push_task(async_state, t.task_id, true)
-  let mut done = false
-  let mut wait_ws : Int64? = None
-  let _ = try {
-    call_core_func(store, t.start_func, [I32(t.context)]) |> ignore
-    done = true
-    ()
+  let outcome = try {
+    match t.continuation[0] {
+      Some(continuation) => {
+        t.continuation[0] = None
+        continuation.continue_execution()
+      }
+      None =>
+        call_core_func_outcome(
+          store,
+          t.start_func,
+          [I32(t.context)],
+          Suspendable,
+        )
+    }
   } catch {
-    AsyncSuspendYield => ()
-    AsyncSuspendWait(ws) => wait_ws = Some(ws)
-    e => {
+    error => {
       pop_task(async_state)
-      raise e
+      raise error
     }
   }
   pop_task(async_state)
 
-  if done {
-    t.phase[0] = Completed
-    t.waiting_ws[0] = None
-    cleanup_thread_task(async_state, t.task_id)
-    return
+  match outcome {
+    Returned(_) => {
+      t.phase[0] = Completed
+      t.waiting_ws[0] = None
+      cleanup_thread_task(async_state, t.task_id)
+    }
+    Suspended(reason, continuation) => {
+      t.continuation[0] = Some(continuation)
+      t.phase[0] = Suspended
+      t.waiting_ws[0] = match reason {
+        Yield => None
+        Wait(waitable_set) => Some(waitable_set)
+      }
+    }
   }
-
-  t.phase[0] = Suspended
-  t.waiting_ws[0] = wait_ws
 }
 
 ///|
@@ -360,24 +365,16 @@ fn execute_thread_suspension_intrinsic(
     }
   }
 
-  let cur = if async_state.yield_cursor_stack.length() == 0 {
-    0
-  } else {
-    async_state.yield_cursor_stack[async_state.yield_cursor_stack.length() - 1]
-  }
-  let replay_upto = match async_state.yield_replay_upto.get(task_id) {
-    Some(n) => n
-    None => 0
-  }
+  let resuming = async_state.yield_suspended.get(task_id) is Some(true)
 
   if is_explicit {
     if maybe_consume_cancelled(async_state, task_id, cancellable) {
+      async_state.yield_suspended.remove(task_id)
       return [I32(1)]
     }
 
-    if cur < replay_upto {
-      async_state.yield_cursor_stack[async_state.yield_cursor_stack.length() - 1] = cur +
-        1
+    if resuming {
+      async_state.yield_suspended.remove(task_id)
       return [I32(0)]
     }
 
@@ -399,23 +396,20 @@ fn execute_thread_suspension_intrinsic(
       |> ignore
     }
 
-    async_state.yield_replay_upto.set(task_id, replay_upto + 1)
+    async_state.yield_suspended.set(task_id, true)
     canon_suspend[0] = Some(Yield)
     raise Unreachable
   }
 
-  // Implicit `thread.yield` is modeled as cooperative suspension. On replay
-  // we consume exactly one suspended yield and continue execution.
+  // Implicit `thread.yield` is modeled as cooperative suspension. Resuming
+  // retries this host instruction once and then continues at its successor.
   if maybe_consume_cancelled(async_state, task_id, cancellable) {
+    async_state.yield_suspended.remove(task_id)
     return [I32(1)]
   }
 
-  if async_state.task_can_block[0] &&
-    schedule_current &&
-    target is None &&
-    cur < replay_upto {
-    async_state.yield_cursor_stack[async_state.yield_cursor_stack.length() - 1] = cur +
-      1
+  if resuming {
+    async_state.yield_suspended.remove(task_id)
     return [I32(0)]
   }
 
@@ -487,7 +481,7 @@ fn execute_thread_suspension_intrinsic(
         if !async_state.task_can_block[0] {
           return [I32(0)]
         }
-        async_state.yield_replay_upto.set(task_id, replay_upto + 1)
+        async_state.yield_suspended.set(task_id, true)
         canon_suspend[0] = Some(Yield)
         raise Unreachable
       }
@@ -519,6 +513,7 @@ fn resolve_start_core_func(
   store : @runtime.Store,
   table_addr : Int,
   start_func_idx : Int,
+  engine : CoreExecutionEngine,
 ) -> CoreFuncRef raise ComponentRuntimeError {
   let table = store.get_table(table_addr) catch {
     e => raise CanonCallError(e.to_string())
@@ -544,7 +539,13 @@ fn resolve_start_core_func(
   if func_idx < 0 {
     raise CanonCallError("unknown thread start function")
   }
-  { instance: owner, func_idx }
+  {
+    instance: owner,
+    func_idx,
+    engine,
+    may_suspend: true,
+    native_eligible: false,
+  }
 }
 
 ///|
@@ -598,7 +599,9 @@ fn instantiate_canon_thread_yield(
       owner_component_id,
     )
   }
-  state.core_funcs.push(alloc_host_core_func(store, core_type, host))
+  state.core_funcs.push(
+    alloc_host_core_func(store, core_type, host, may_suspend=true),
+  )
 }
 
 ///|
@@ -632,7 +635,9 @@ fn instantiate_canon_thread_yield_then_resume(
       owner_component_id,
     )
   }
-  state.core_funcs.push(alloc_host_core_func(store, core_type, host))
+  state.core_funcs.push(
+    alloc_host_core_func(store, core_type, host, may_suspend=true),
+  )
 }
 
 ///|
@@ -699,7 +704,9 @@ fn instantiate_canon_thread_suspend(
       owner_component_id,
     )
   }
-  state.core_funcs.push(alloc_host_core_func(store, core_type, host))
+  state.core_funcs.push(
+    alloc_host_core_func(store, core_type, host, may_suspend=true),
+  )
 }
 
 ///|
@@ -737,7 +744,12 @@ fn instantiate_canon_thread_new_indirect(
         return [I32(0)]
       }
     }
-    let start_func = resolve_start_core_func(store, table_addr, start_idx) catch {
+    let start_func = resolve_start_core_func(
+      store,
+      table_addr,
+      start_idx,
+      async_state.core_engine,
+    ) catch {
       e => {
         trap_canon(canon_err_message(e))
         return [I32(0)]
@@ -772,6 +784,7 @@ fn instantiate_canon_thread_new_indirect(
       phase: [NotStarted],
       scheduled: [false],
       waiting_ws: [None],
+      continuation: [None],
     })
 
     [I32(id)]

--- a/modules/wasmoon/component/runtime_impl/canon_waitable.mbt
+++ b/modules/wasmoon/component/runtime_impl/canon_waitable.mbt
@@ -3,6 +3,21 @@
 /// (group: waitable)
 
 ///|
+fn release_waiter(
+  async_state : AsyncState,
+  task_id : Int64,
+  ws_key : Int64,
+) -> Unit {
+  if async_state.waiting_ws.get(task_id) is Some(active_ws) &&
+    active_ws == ws_key {
+    async_state.waiting_ws.remove(task_id)
+    if async_state.waitable_sets.get(ws_key) is Some(set) {
+      set.waiters[0] = set.waiters[0] - 1
+    }
+  }
+}
+
+///|
 fn instantiate_canon_waitable_set_new(
   state : BuildState,
   store : @runtime.Store,
@@ -16,50 +31,14 @@ fn instantiate_canon_waitable_set_new(
     if !canon_may_leave[0] {
       trap_canon("cannot leave component instance")
     }
-    let task_id = current_task_id(async_state)
-    let cur = if async_state.call_cursor_stack.length() == 0 {
-      0
-    } else {
-      async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1]
-    }
-    let per_task = canon_call_results_for_task(async_state, task_id)
-    match per_task.get(cur) {
-      Some(v) => {
-        async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-          1
-        // Replay-safe: if the waitable-set was created and later dropped in a
-        // previous run (before a suspension forced replay), recreate it so the
-        // cached id remains usable.
-        match v {
-          [I32(id)] =>
-            if async_state.waitable_sets.get(handle_key(owner_component_id, id))
-              is None {
-              async_state.waitable_sets.set(
-                handle_key(owner_component_id, id),
-                { id, members: Map([]), queue: [], waiters: [0] },
-              )
-            } else {
-              ()
-            }
-          _ => ()
-        }
-        v
-      }
-      None => {
-        let id = alloc_shared_handle(async_state, owner_component_id)
-        async_state.waitable_sets.set(handle_key(owner_component_id, id), {
-          id,
-          members: Map([]),
-          queue: [],
-          waiters: [0],
-        })
-        let out = [@types.Value::I32(id)]
-        per_task.set(cur, out)
-        async_state.call_cursor_stack[async_state.call_cursor_stack.length() - 1] = cur +
-          1
-        out
-      }
-    }
+    let id = alloc_shared_handle(async_state, owner_component_id)
+    async_state.waitable_sets.set(handle_key(owner_component_id, id), {
+      id,
+      members: Map([]),
+      queue: [],
+      waiters: [0],
+    })
+    [I32(id)]
   }
   state.core_funcs.push(alloc_host_core_func(store, core_type, host))
 }
@@ -91,8 +70,7 @@ fn instantiate_canon_waitable_set_wait(
       }
     }
     fn ensure_subtask_return_ready(ev : WaitEvent) -> Unit {
-      // Replay can clobber the caller's return buffer; ensure it is rewritten
-      // before exposing a RETURNED subtask event.
+      // Materialize the subtask result immediately before exposing RETURNED.
       if ev.code != 1 || ev.payload != 2 {
         return
       }
@@ -208,163 +186,44 @@ fn instantiate_canon_waitable_set_wait(
           return [I32(0)]
         }
         let task_id = current_task_id(async_state)
-        let cur = if async_state.wait_cursor_stack.length() == 0 {
-          0
-        } else {
-          async_state.wait_cursor_stack[async_state.wait_cursor_stack.length() -
-          1]
+        if _cancellable && async_state.task_cancelled.get(task_id) is Some(true) {
+          async_state.task_cancelled.remove(task_id)
+          release_waiter(async_state, task_id, ws_key)
+          return [I32(6)]
         }
-        let per_task = match async_state.wait_results.get(task_id) {
-          Some(m) => m
-          None => {
-            let m : Map[Int, WaitResult] = Map([])
-            async_state.wait_results.set(task_id, m)
-            m
-          }
-        }
-        match per_task.get(cur) {
-          Some(cached) => {
-            let ev = cached.ev
-            // Replay: write cached event and return its code.
-            match cached.subtask_i32 {
-              Some(n) =>
-                match cached.subtask_mem_addr {
-                  Some(addr) =>
-                    match (Some(store.get_mem(addr)) catch { _ => None }) {
-                      Some(mem2) =>
-                        mem2.store_i32(cached.subtask_retptr, n) catch {
-                          _ => ()
-                        }
-                      None => ()
-                    }
-                  None => ()
-                }
-              None => ensure_subtask_return_ready(ev)
-            }
-            mem.store_i32(ptr + 0, ev.index) catch {
-              _ => ()
-            }
-            mem.store_i32(ptr + 4, ev.payload) catch {
-              _ => ()
-            }
-            match async_state.waiting_ws.get(task_id) {
-              Some(ws0) =>
-                if ws0 == ws_key {
-                  async_state.waiting_ws.remove(task_id)
-                  match async_state.waitable_sets.get(ws_key) {
-                    Some(set) => set.waiters[0] = set.waiters[0] - 1
-                    None => ()
-                  }
-                }
+        if !waitable_set_has_event(async_state, ws_key) {
+          // Track the dormant continuation so `waitable-set.drop` can reject
+          // a set with an active waiter.
+          if async_state.waiting_ws.get(task_id) is None {
+            match async_state.waitable_sets.get(ws_key) {
+              Some(set) => set.waiters[0] = set.waiters[0] + 1
               None => ()
             }
-            async_state.wait_cursor_stack[async_state.wait_cursor_stack.length() -
-            1] = cur + 1
-            set_canon_debug_message(
-              "waitable-set.wait(replay cur=\{cur} ws=\{ws})-> code=\{ev.code} index=\{ev.index} payload=\{ev.payload}\{subtask_result_dbg(ev)}",
-            )
-            [I32(ev.code)]
+            async_state.waiting_ws.set(task_id, ws_key)
           }
+          canon_suspend[0] = Some(Wait(ws_key))
+          raise Unreachable
+        }
+        let ev = match pop_waitable_event(async_state, ws_key) {
+          Some(ev) => ev
           None => {
-            if _cancellable &&
-              async_state.task_cancelled.get(task_id) is Some(true) {
-              async_state.task_cancelled.remove(task_id)
-              let ev : WaitEvent = {
-                owner_component_id,
-                code: 6,
-                index: 0,
-                payload: 0,
-              }
-              per_task.set(cur, {
-                ev,
-                subtask_mem_addr: None,
-                subtask_retptr: 0,
-                subtask_i32: None,
-              })
-              async_state.wait_cursor_stack[async_state.wait_cursor_stack.length() -
-              1] = cur + 1
-              return [I32(6)]
-            }
-            // Cooperative wait: suspend the current task until an event exists.
-            // (The sync-style async ABI will replay this call and consume the event.)
-            if !waitable_set_has_event(async_state, ws_key) {
-              // Track that this task is a waiter so `waitable-set.drop` can trap.
-              if async_state.waiting_ws.get(task_id) is None {
-                match async_state.waitable_sets.get(ws_key) {
-                  Some(set) => set.waiters[0] = set.waiters[0] + 1
-                  None => ()
-                }
-                async_state.waiting_ws.set(task_id, ws_key)
-              }
-              canon_suspend[0] = Some(Wait(ws_key))
-              raise Unreachable
-            }
-            let ev = match pop_waitable_event(async_state, ws_key) {
-              Some(ev) => ev
-              None => {
-                canon_suspend[0] = Some(Wait(ws_key))
-                raise Unreachable
-              }
-            }
-            ensure_subtask_return_ready(ev)
-            acknowledge_waitable_event(async_state, ev)
-            match async_state.waiting_ws.get(task_id) {
-              Some(ws0) =>
-                if ws0 == ws_key {
-                  async_state.waiting_ws.remove(task_id)
-                  match async_state.waitable_sets.get(ws_key) {
-                    Some(set) => set.waiters[0] = set.waiters[0] - 1
-                    None => ()
-                  }
-                }
-              None => ()
-            }
-            // Cache event and (for SUBTASK+RETURNED) cache the scalar return value at the
-            // time of delivery so replay remains correct even if handle ids are later reused.
-            let mut cached_mem : Int? = None
-            let mut cached_retptr = 0
-            let mut cached_i32 : Int? = None
-            if ev.code == 1 && ev.payload == 2 {
-              let sub_key = handle_key(ev.owner_component_id, ev.index)
-              match async_state.subtasks.get(sub_key) {
-                Some(st) =>
-                  match st.mem_addr {
-                    Some(addr) => {
-                      cached_mem = Some(addr)
-                      cached_retptr = st.retptr
-                      match (Some(store.get_mem(addr)) catch { _ => None }) {
-                        Some(mem2) =>
-                          cached_i32 = Some(mem2.load_i32(st.retptr)) catch {
-                            _ => None
-                          }
-                        None => ()
-                      }
-                    }
-                    None => ()
-                  }
-                None => ()
-              }
-            }
-            per_task.set(cur, {
-              ev,
-              subtask_mem_addr: cached_mem,
-              subtask_retptr: cached_retptr,
-              subtask_i32: cached_i32,
-            })
-            mem.store_i32(ptr + 0, ev.index) catch {
-              _ => ()
-            }
-            mem.store_i32(ptr + 4, ev.payload) catch {
-              _ => ()
-            }
-            async_state.wait_cursor_stack[async_state.wait_cursor_stack.length() -
-            1] = cur + 1
-            set_canon_debug_message(
-              "waitable-set.wait(cur=\{cur} ws=\{ws})-> code=\{ev.code} index=\{ev.index} payload=\{ev.payload}\{subtask_result_dbg(ev)}",
-            )
-            [I32(ev.code)]
+            canon_suspend[0] = Some(Wait(ws_key))
+            raise Unreachable
           }
         }
+        ensure_subtask_return_ready(ev)
+        acknowledge_waitable_event(async_state, ev)
+        release_waiter(async_state, task_id, ws_key)
+        mem.store_i32(ptr + 0, ev.index) catch {
+          _ => ()
+        }
+        mem.store_i32(ptr + 4, ev.payload) catch {
+          _ => ()
+        }
+        set_canon_debug_message(
+          "waitable-set.wait(ws=\{ws})-> code=\{ev.code} index=\{ev.index} payload=\{ev.payload}\{subtask_result_dbg(ev)}",
+        )
+        [I32(ev.code)]
       }
       _ => {
         trap_canon("type mismatch")
@@ -372,7 +231,9 @@ fn instantiate_canon_waitable_set_wait(
       }
     }
   }
-  state.core_funcs.push(alloc_host_core_func(store, core_type, host))
+  state.core_funcs.push(
+    alloc_host_core_func(store, core_type, host, may_suspend=true),
+  )
 }
 
 ///|
@@ -562,7 +423,7 @@ fn instantiate_canon_waitable_join(
             match async_state.waitable_to_set.get(waitable_key) {
               Some(prev_ws_key) =>
                 if prev_ws_key == ws_key {
-                  // Idempotent on replay: do not re-flush backlog.
+                  // Joining an existing set is idempotent; do not re-flush backlog.
                   []
                 } else {
                   // Move membership between sets.

--- a/modules/wasmoon/component/runtime_impl/component_api.mbt
+++ b/modules/wasmoon/component/runtime_impl/component_api.mbt
@@ -248,6 +248,7 @@ pub fn ComponentInstance::get_core_instance(
 ///|
 struct ComponentLinker {
   core_linker : @runtime.Linker
+  core_engine : CoreExecutionEngine
   components : Array[(String, ComponentInstance)]
   imports : Map[String, ComponentExtern]
   // Mutable counter stored in a 1-element array so methods can bump it without
@@ -257,8 +258,21 @@ struct ComponentLinker {
 
 ///|
 pub fn ComponentLinker::ComponentLinker() -> ComponentLinker {
+  ComponentLinker::with_core_execution_engine(
+    interpreter_core_execution_engine(),
+  )
+}
+
+///|
+/// Create a component linker with an embedding-provided core execution engine.
+pub fn ComponentLinker::with_core_execution_engine(
+  core_engine : CoreExecutionEngine,
+) -> ComponentLinker {
+  let core_linker = @runtime.Linker::Linker()
+  core_engine.prepare_store(core_linker.get_store())
   {
-    core_linker: Linker(),
+    core_linker,
+    core_engine,
     components: [],
     imports: Map([]),
     resource_id_counter: [0],

--- a/modules/wasmoon/component/runtime_impl/core_engine.mbt
+++ b/modules/wasmoon/component/runtime_impl/core_engine.mbt
@@ -1,0 +1,236 @@
+///|
+/// Whether a core call is allowed to suspend.
+///
+/// A native JIT adapter must reject or route `Suspendable` calls to a resumable
+/// engine before entering native code. Native stacks are not continuations.
+pub(all) enum CoreExecutionMode {
+  Synchronous
+  Interpreted
+  Suspendable
+} derive(Debug, Eq)
+
+///|
+/// Why a core execution continuation stopped.
+pub(all) enum CoreSuspension {
+  Yield
+  Wait(Int64)
+} derive(Debug, Eq)
+
+///|
+/// A suspended core computation.
+///
+/// The continuation owns the execution state needed to resume after the
+/// suspension point. `cancel` releases that state without resuming it.
+struct CoreContinuation {
+  resume_fn : () -> CoreExecutionOutcome raise ComponentRuntimeError
+  cancel_fn : () -> Unit
+}
+
+///|
+pub fn CoreContinuation::CoreContinuation(
+  continue_with : () -> CoreExecutionOutcome raise ComponentRuntimeError,
+  cancel : () -> Unit,
+) -> CoreContinuation {
+  { resume_fn: continue_with, cancel_fn: cancel }
+}
+
+///|
+pub fn CoreContinuation::continue_execution(
+  self : CoreContinuation,
+) -> CoreExecutionOutcome raise ComponentRuntimeError {
+  (self.resume_fn)()
+}
+
+///|
+pub fn CoreContinuation::cancel(self : CoreContinuation) -> Unit {
+  (self.cancel_fn)()
+}
+
+///|
+pub impl Debug for CoreContinuation with fn to_repr(_self) {
+  Repr::literal("<core-continuation>")
+}
+
+///|
+/// Result of entering or resuming a core function.
+pub(all) enum CoreExecutionOutcome {
+  Returned(Array[@types.Value])
+  Suspended(CoreSuspension, CoreContinuation)
+} derive(Debug)
+
+///|
+/// Component-owned seam for core Wasm execution.
+///
+/// `register_instance` is called once after interpreter instantiation has
+/// allocated the shared store objects. `invoke` may then select an interpreter
+/// or JIT adapter according to `mode`.
+struct CoreExecutionEngine {
+  prepare_store_fn : (@runtime.Store) -> Unit
+  register_instance_fn : (
+    @runtime.Store,
+    @types.Module,
+    @runtime.ModuleInstance,
+  ) -> Unit raise ComponentRuntimeError
+  invoke_fn : (
+    @runtime.Store,
+    @runtime.ModuleInstance,
+    Int,
+    Array[@types.Value],
+    CoreExecutionMode,
+  ) -> CoreExecutionOutcome raise ComponentRuntimeError
+}
+
+///|
+pub fn CoreExecutionEngine::CoreExecutionEngine(
+  register_instance : (@runtime.Store, @types.Module, @runtime.ModuleInstance) -> Unit raise ComponentRuntimeError,
+  invoke : (
+    @runtime.Store,
+    @runtime.ModuleInstance,
+    Int,
+    Array[@types.Value],
+    CoreExecutionMode,
+  ) -> CoreExecutionOutcome raise ComponentRuntimeError,
+  prepare_store? : (@runtime.Store) -> Unit = fn(_store) { () },
+) -> CoreExecutionEngine {
+  {
+    prepare_store_fn: prepare_store,
+    register_instance_fn: register_instance,
+    invoke_fn: invoke,
+  }
+}
+
+///|
+pub fn CoreExecutionEngine::prepare_store(
+  self : CoreExecutionEngine,
+  store : @runtime.Store,
+) -> Unit {
+  (self.prepare_store_fn)(store)
+}
+
+///|
+pub fn CoreExecutionEngine::register_instance(
+  self : CoreExecutionEngine,
+  store : @runtime.Store,
+  module_ : @types.Module,
+  instance : @runtime.ModuleInstance,
+) -> Unit raise ComponentRuntimeError {
+  (self.register_instance_fn)(store, module_, instance)
+}
+
+///|
+pub fn CoreExecutionEngine::invoke(
+  self : CoreExecutionEngine,
+  store : @runtime.Store,
+  instance : @runtime.ModuleInstance,
+  func_idx : Int,
+  args : Array[@types.Value],
+  mode : CoreExecutionMode,
+) -> CoreExecutionOutcome raise ComponentRuntimeError {
+  (self.invoke_fn)(store, instance, func_idx, args, mode)
+}
+
+///|
+pub impl Debug for CoreExecutionEngine with fn to_repr(_self) {
+  Repr::literal("<core-execution-engine>")
+}
+
+///|
+fn core_suspension_from_token(token : Int64) -> CoreSuspension {
+  if token == -1L {
+    Yield
+  } else {
+    Wait(token)
+  }
+}
+
+///|
+fn resume_interpreter_continuation(
+  continuation : @executor.ExecutionContinuation,
+) -> CoreExecutionOutcome raise ComponentRuntimeError {
+  let outcome = continuation.continue_execution() catch {
+    error => {
+      let message = match canon_trap_message[0] {
+        Some(message) => message
+        None => error.to_string()
+      }
+      let debug = match canon_debug_message[0] {
+        Some(marker) => " [last=\{marker}]"
+        None => ""
+      }
+      raise CanonCallError("\{message}\{debug}")
+    }
+  }
+  interpreter_outcome(outcome)
+}
+
+///|
+fn interpreter_outcome(
+  outcome : @executor.ResumableCallOutcome,
+) -> CoreExecutionOutcome {
+  match outcome {
+    Returned(results) => Returned(results)
+    Suspended(token, continuation) => {
+      // The typed outcome now owns the suspension reason. Do not let the
+      // process-local canonical marker classify a later, unrelated trap.
+      canon_suspend[0] = None
+      Suspended(
+        core_suspension_from_token(token),
+        CoreContinuation(
+          fn() raise ComponentRuntimeError {
+            resume_interpreter_continuation(continuation)
+          },
+          fn() { continuation.cancel() },
+        ),
+      )
+    }
+  }
+}
+
+///|
+/// Default core execution adapter.
+pub fn interpreter_core_execution_engine() -> CoreExecutionEngine {
+  CoreExecutionEngine(fn(_store, _module, _instance) { () }, fn(
+    store,
+    instance,
+    func_idx,
+    args,
+    mode,
+  ) raise ComponentRuntimeError {
+    match mode {
+      Synchronous => {
+        let results = @executor.call_func_by_index(
+          store, instance, func_idx, args,
+        ) catch {
+          error => raise CanonCallError(error.to_string())
+        }
+        Returned(results)
+      }
+      Interpreted => {
+        let results = @executor.call_func_by_index(
+          store, instance, func_idx, args,
+        ) catch {
+          error => raise CanonCallError(error.to_string())
+        }
+        Returned(results)
+      }
+      Suspendable => {
+        let outcome = @executor.call_func_by_index_resumable(
+          store,
+          instance,
+          func_idx,
+          args,
+          fn(_error) {
+            match canon_suspend[0] {
+              Some(Yield) => Some(-1L)
+              Some(Wait(waitable_set)) => Some(waitable_set)
+              None => None
+            }
+          },
+        ) catch {
+          error => raise CanonCallError(error.to_string())
+        }
+        interpreter_outcome(outcome)
+      }
+    }
+  })
+}

--- a/modules/wasmoon/component/runtime_impl/core_func.mbt
+++ b/modules/wasmoon/component/runtime_impl/core_func.mbt
@@ -3,6 +3,8 @@ pub fn alloc_host_core_func(
   store : @runtime.Store,
   core_type : @types.FuncType,
   host : (Array[@types.Value]) -> Array[@types.Value] raise @runtime.RuntimeError,
+  may_suspend? : Bool = false,
+  native_eligible? : Bool = true,
 ) -> CoreFuncRef {
   let func_addr = store.alloc_host_func(host, func_type=core_type, type_idx=0)
   let instance : @runtime.ModuleInstance = {
@@ -22,7 +24,13 @@ pub fn alloc_host_core_func(
     dropped_elems: [],
     dropped_datas: [],
   }
-  { instance, func_idx: 0 }
+  {
+    instance,
+    func_idx: 0,
+    engine: interpreter_core_execution_engine(),
+    may_suspend,
+    native_eligible,
+  }
 }
 
 ///|
@@ -65,7 +73,27 @@ fn call_core_func(
   store : @runtime.Store,
   core_func : CoreFuncRef,
   args : Array[@types.Value],
+  mode? : CoreExecutionMode = Synchronous,
 ) -> Array[@types.Value] raise ComponentRuntimeError {
+  let outcome = call_core_func_outcome(store, core_func, args, mode)
+  match outcome {
+    Returned(results) => results
+    Suspended(_, continuation) => {
+      continuation.cancel()
+      raise CanonCallError(
+        "core execution engine returned a continuation to a synchronous caller",
+      )
+    }
+  }
+}
+
+///|
+fn call_core_func_outcome(
+  store : @runtime.Store,
+  core_func : CoreFuncRef,
+  args : Array[@types.Value],
+  mode : CoreExecutionMode,
+) -> CoreExecutionOutcome raise ComponentRuntimeError {
   // Reset any previous canonical trap so we don't leak messages across calls.
   clear_canon_trap_message()
   clear_canon_debug_message()
@@ -74,21 +102,20 @@ fn call_core_func(
     set_canon_debug_message(msg)
   }
   canon_suspend[0] = None
-  @executor.call_func_by_index(
+  let outcome = core_func.engine.invoke(
     store,
     core_func.instance,
     core_func.func_idx,
     args,
+    mode,
   ) catch {
     e => {
       match canon_suspend[0] {
-        Some(Yield) => {
+        Some(_) => {
           canon_suspend[0] = None
-          raise AsyncSuspendYield
-        }
-        Some(Wait(ws)) => {
-          canon_suspend[0] = None
-          raise AsyncSuspendWait(ws)
+          raise CanonCallError(
+            "core execution attempted to suspend in synchronous mode",
+          )
         }
         None => ()
       }
@@ -97,7 +124,10 @@ fn call_core_func(
         None => {
           // Include a tiny bit of context to make debugging easier when the trap
           // originates from core wasm (e.g. `unreachable` inside a component-spec test).
-          let error_message = e.to_string()
+          let error_message = match e {
+            CanonCallError(message) => message
+            _ => e.to_string()
+          }
           let trap_msg = if error_message == "unreachable" ||
             error_message.contains("wasm `unreachable` instruction executed") {
             "wasm trap: wasm `unreachable` instruction executed"
@@ -126,6 +156,10 @@ fn call_core_func(
       }
     }
   }
+  if outcome is Suspended(_, _) {
+    canon_suspend[0] = None
+  }
+  outcome
 }
 
 ///|
@@ -134,20 +168,13 @@ fn call_core_func_guarded(
   may_enter : Ref[Bool],
   core_func : CoreFuncRef,
   args : Array[@types.Value],
+  mode? : CoreExecutionMode = Synchronous,
 ) -> Array[@types.Value] raise ComponentRuntimeError {
   let prev = may_enter.val
   // Mark this component instance as in-progress to prevent re-entrancy via
   // lowered functions (component-spec/async/trap-on-reenter.wast).
   may_enter.val = false
-  let out = call_core_func(store, core_func, args) catch {
-    AsyncSuspendYield as e => {
-      may_enter.val = prev
-      raise e
-    }
-    AsyncSuspendWait(_) as e => {
-      may_enter.val = prev
-      raise e
-    }
+  let out = call_core_func(store, core_func, args, mode~) catch {
     e =>
       // A trap while executing a component instance permanently poisons that
       // instance. Subsequent entry attempts must fail instead of observing
@@ -156,6 +183,56 @@ fn call_core_func_guarded(
   }
   may_enter.val = prev
   out
+}
+
+///|
+fn guard_core_outcome(
+  outcome : CoreExecutionOutcome,
+  may_enter : Ref[Bool],
+  previous : Bool,
+) -> CoreExecutionOutcome {
+  match outcome {
+    Returned(results) => {
+      may_enter.val = previous
+      Returned(results)
+    }
+    Suspended(reason, continuation) => {
+      // A captured continuation is not actively executing guest code. Release
+      // the dynamic entry guard while it waits; task ancestry still prevents
+      // prohibited async re-entry. Re-acquire it immediately before resuming.
+      may_enter.val = previous
+      Suspended(
+        reason,
+        CoreContinuation(
+          fn() raise ComponentRuntimeError {
+            if !may_enter.val {
+              raise CanonCallError("cannot enter component instance")
+            }
+            may_enter.val = false
+            let resumed = continuation.continue_execution()
+            guard_core_outcome(resumed, may_enter, previous)
+          },
+          fn() {
+            continuation.cancel()
+            may_enter.val = previous
+          },
+        ),
+      )
+    }
+  }
+}
+
+///|
+fn call_core_func_guarded_outcome(
+  store : @runtime.Store,
+  may_enter : Ref[Bool],
+  core_func : CoreFuncRef,
+  args : Array[@types.Value],
+) -> CoreExecutionOutcome raise ComponentRuntimeError {
+  let previous = may_enter.val
+  may_enter.val = false
+  let outcome = call_core_func_outcome(store, core_func, args, Suspendable)
+  guard_core_outcome(outcome, may_enter, previous)
 }
 
 ///|

--- a/modules/wasmoon/component/runtime_impl/core_typecheck.mbt
+++ b/modules/wasmoon/component/runtime_impl/core_typecheck.mbt
@@ -1,6 +1,9 @@
 ///|
 fn core_instance_from_module(
   instance : @runtime.ModuleInstance,
+  engine : CoreExecutionEngine,
+  may_suspend : Bool,
+  native_eligible : Bool,
 ) -> CoreInstance {
   let funcs : Map[String, CoreFuncRef] = Map([])
   let tables : Map[String, Int] = Map([])
@@ -9,7 +12,14 @@ fn core_instance_from_module(
   let tags : Map[String, Int] = Map([])
   for exp in instance.exports {
     match exp.desc {
-      Func(idx) => funcs.set(exp.name, { instance, func_idx: idx })
+      Func(idx) =>
+        funcs.set(exp.name, {
+          instance,
+          func_idx: idx,
+          engine,
+          may_suspend,
+          native_eligible,
+        })
       Table(idx) => tables.set(exp.name, instance.table_addrs[idx])
       Memory(idx) => memories.set(exp.name, instance.mem_addrs[idx])
       Global(idx) => globals.set(exp.name, instance.global_addrs[idx])

--- a/modules/wasmoon/component/runtime_impl/error.mbt
+++ b/modules/wasmoon/component/runtime_impl/error.mbt
@@ -30,9 +30,6 @@ pub(all) suberror ComponentRuntimeError {
   HostCallError(String)
   /// Structured termination requested by an embedding-provided command host.
   HostExit(Int)
-  // Cooperative suspension used by sync-style async lifting (canon lift ... async).
-  AsyncSuspendYield
-  AsyncSuspendWait(Int64)
   InvalidStartResultCount(Int)
   OuterAliasOutOfRange(Int)
   AliasTargetMismatch(String)

--- a/modules/wasmoon/component/runtime_impl/instantiate.mbt
+++ b/modules/wasmoon/component/runtime_impl/instantiate.mbt
@@ -14,7 +14,7 @@ fn instantiate_component(
   let async_state = if outer_stack.length() > 0 {
     outer_stack[outer_stack.length() - 1].async_state
   } else {
-    AsyncState(stream_table)
+    AsyncState(stream_table, core_engine=linker.core_engine)
   }
   let state = BuildState::BuildState(stream_table, async_state)
   if outer_stack.length() > 0 {
@@ -53,11 +53,13 @@ fn instantiate_component(
               let mod_ = state.core_modules[module_idx]
               validate_core_import_args(mod_, args, state)
               let imports = core_imports_from_args(args, state)
+              let may_suspend = core_args_may_suspend(args, state)
+              let native_eligible = core_args_native_eligible(args, state)
               let module_name = "\{name}::coreinst\{state.core_instances.length()}"
               clear_canon_trap_message()
-              // Core module instantiation can execute start functions that call back into
-              // canonical host imports. Run under a dedicated task id so per-task replay/caching
-              // state (e.g. waitable-set.new) does not leak across component instances.
+              // Core module instantiation can execute start functions that call
+              // canonical host imports. Give start its own task-scoped borrow,
+              // cancellation, and continuation state.
               let inst_task_id = alloc_task_id(async_state)
               // Core start runs during instantiation and must not block.
               push_task(async_state, inst_task_id, false)
@@ -78,7 +80,15 @@ fn instantiate_component(
               // Register a stable name for debugging core traps.
               register_core_instance_name(instance.store_idx, module_name)
               linker.core_linker.register(module_name, instance)
-              state.core_instances.push(core_instance_from_module(instance))
+              linker.core_engine.register_instance(store, mod_, instance)
+              state.core_instances.push(
+                core_instance_from_module(
+                  instance,
+                  linker.core_engine,
+                  may_suspend,
+                  native_eligible,
+                ),
+              )
             }
             InlineExports(exports) =>
               state.core_instances.push(

--- a/modules/wasmoon/component/runtime_impl/instantiate_helpers.mbt
+++ b/modules/wasmoon/component/runtime_impl/instantiate_helpers.mbt
@@ -403,6 +403,53 @@ fn core_imports_from_args(
 }
 
 ///|
+fn core_args_may_suspend(
+  args : Array[CoreInstantiateArg],
+  state : BuildState,
+) -> Bool raise ComponentRuntimeError {
+  for arg in args {
+    match resolve_sortidx(arg.sortidx, state) {
+      CoreInstance(instance) =>
+        for entry in instance.funcs.iter() {
+          let (_, func) = entry
+          if func.may_suspend {
+            return true
+          }
+        }
+      CoreFunc(func) => if func.may_suspend { return true }
+      CoreTable(_) | CoreMemory(_) | CoreGlobal(_) | CoreTag(_) => ()
+      _ => raise AliasTargetMismatch("core instantiate arg")
+    }
+  }
+  false
+}
+
+///|
+fn core_args_native_eligible(
+  args : Array[CoreInstantiateArg],
+  state : BuildState,
+) -> Bool raise ComponentRuntimeError {
+  for arg in args {
+    match resolve_sortidx(arg.sortidx, state) {
+      CoreInstance(instance) =>
+        for entry in instance.funcs.iter() {
+          let (_, func) = entry
+          if !func.native_eligible {
+            return false
+          }
+        }
+      CoreFunc(func) => if !func.native_eligible { return false }
+      // An imported function table can indirect through a component adapter.
+      // Keep such modules interpreted until nested native entry is supported.
+      CoreTable(_) => return false
+      CoreMemory(_) | CoreGlobal(_) | CoreTag(_) => ()
+      _ => raise AliasTargetMismatch("core instantiate arg")
+    }
+  }
+  true
+}
+
+///|
 fn supplied_core_func_for_import(
   mod_name : String,
   field : String,

--- a/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
+++ b/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
@@ -10,9 +10,11 @@ import {
 }
 
 // Values
-pub fn alloc_host_core_func(@runtime.Store, @types.FuncType, (Array[@types.Value]) -> Array[@types.Value] raise @runtime.RuntimeError) -> CoreFuncRef
+pub fn alloc_host_core_func(@runtime.Store, @types.FuncType, (Array[@types.Value]) -> Array[@types.Value] raise @runtime.RuntimeError, may_suspend? : Bool, native_eligible? : Bool) -> CoreFuncRef
 
 pub fn clear_canon_debug_message() -> Unit
+
+pub fn interpreter_core_execution_engine() -> CoreExecutionEngine
 
 pub fn preset_canon_debug_message(String) -> Unit
 
@@ -53,8 +55,6 @@ pub(all) suberror ComponentRuntimeError {
   CanonCallError(String)
   HostCallError(String)
   HostExit(Int)
-  AsyncSuspendYield
-  AsyncSuspendWait(Int64)
   InvalidStartResultCount(Int)
   OuterAliasOutOfRange(Int)
   AliasTargetMismatch(String)
@@ -65,6 +65,7 @@ pub impl Show for ComponentRuntimeError
 
 // Types and methods
 pub(all) struct AsyncState {
+  core_engine : CoreExecutionEngine
   next_handle_by_component : Map[Int, Array[Int]]
   free_handles_by_component : Map[Int, Array[Int]]
   stream_table : StreamTable
@@ -87,22 +88,11 @@ pub(all) struct AsyncState {
   task_can_block : Array[Bool]
   can_block_stack : Array[Bool]
   in_async_callback : Array[Bool]
-  yield_cursor_stack : Array[Int]
-  wait_cursor_stack : Array[Int]
-  call_cursor_stack : Array[Int]
-  stream_cursor_stack : Array[Int]
   task_caller : Map[Int64, Int64]
   task_instance : Map[Int64, Int]
-  yield_replay_upto : Map[Int64, Int]
-  wait_results : Map[Int64, Map[Int, WaitResult]]
+  yield_suspended : Map[Int64, Bool]
   waiting_ws : Map[Int64, Int64]
-  call_results : Map[Int64, Map[Int, Array[@types.Value]]]
-  call_results_cb : Map[Int64, Map[Int, Array[@types.Value]]]
-  call_result_ends : Map[Int64, Map[Int, Int]]
-  call_result_ends_cb : Map[Int64, Map[Int, Int]]
-  stream_results : Map[Int64, Map[Int, Int]]
-  stream_results_cb : Map[Int64, Map[Int, Int]]
-  sync_lower_states : Map[Int64, Map[Int, SyncLowerState]]
+  sync_lower_states : Map[Int64, SyncLowerState]
   waitable_sets : Map[Int64, WaitableSet]
   waitable_to_set : Map[Int64, Int64]
   waitable_events : Map[Int64, Array[WaitEvent]]
@@ -110,6 +100,7 @@ pub(all) struct AsyncState {
   subtasks : Map[Int64, Subtask]
   inflight_by_instance : Map[Int, Int]
   pending_by_instance : Map[Int, Array[Int64]]
+  scheduler_cursor : Array[Int64?]
   next_future_id : Array[Int]
   futures : Map[Int, FutureState]
   future_endpoints : Map[Int64, FutureEndpoint]
@@ -118,7 +109,7 @@ pub(all) struct AsyncState {
   next_error_context_by_component : Map[Int, Array[Int]]
   error_contexts : Map[Int64, String]
 } derive(@debug.Debug)
-pub fn AsyncState::AsyncState(StreamTable) -> Self
+pub fn AsyncState::AsyncState(StreamTable, core_engine? : CoreExecutionEngine) -> Self
 
 type CallbackTask derive(@debug.Debug)
 
@@ -198,6 +189,7 @@ pub fn ComponentLinker::host_instance_builder(Self, String, HostRuntimeState) ->
 pub fn ComponentLinker::instantiate(Self, String, @model.Component) -> ComponentInstance raise ComponentRuntimeError
 pub fn ComponentLinker::new_host_resource_type(Self) -> @model.TypeDef?
 pub fn ComponentLinker::register(Self, String, ComponentInstance) -> Unit
+pub fn ComponentLinker::with_core_execution_engine(CoreExecutionEngine) -> Self
 
 pub(all) enum ComponentValue {
   Bool(Bool)
@@ -221,9 +213,36 @@ pub(all) enum ComponentValue {
 } derive(Eq, @debug.Debug)
 pub impl Show for ComponentValue
 
+type CoreContinuation
+pub fn CoreContinuation::CoreContinuation(() -> CoreExecutionOutcome raise ComponentRuntimeError, () -> Unit) -> Self
+pub fn CoreContinuation::cancel(Self) -> Unit
+pub fn CoreContinuation::continue_execution(Self) -> CoreExecutionOutcome raise ComponentRuntimeError
+pub impl @debug.Debug for CoreContinuation
+
+type CoreExecutionEngine
+pub fn CoreExecutionEngine::CoreExecutionEngine((@runtime.Store, @types.Module, @runtime.ModuleInstance) -> Unit raise ComponentRuntimeError, (@runtime.Store, @runtime.ModuleInstance, Int, Array[@types.Value], CoreExecutionMode) -> CoreExecutionOutcome raise ComponentRuntimeError, prepare_store? : (@runtime.Store) -> Unit) -> Self
+pub fn CoreExecutionEngine::invoke(Self, @runtime.Store, @runtime.ModuleInstance, Int, Array[@types.Value], CoreExecutionMode) -> CoreExecutionOutcome raise ComponentRuntimeError
+pub fn CoreExecutionEngine::prepare_store(Self, @runtime.Store) -> Unit
+pub fn CoreExecutionEngine::register_instance(Self, @runtime.Store, @types.Module, @runtime.ModuleInstance) -> Unit raise ComponentRuntimeError
+pub impl @debug.Debug for CoreExecutionEngine
+
+pub(all) enum CoreExecutionMode {
+  Synchronous
+  Interpreted
+  Suspendable
+} derive(Eq, @debug.Debug)
+
+pub(all) enum CoreExecutionOutcome {
+  Returned(Array[@types.Value])
+  Suspended(CoreSuspension, CoreContinuation)
+} derive(@debug.Debug)
+
 pub(all) struct CoreFuncRef {
   instance : @runtime.ModuleInstance
   func_idx : Int
+  engine : CoreExecutionEngine
+  may_suspend : Bool
+  native_eligible : Bool
 } derive(@debug.Debug)
 
 pub(all) struct CoreInstance {
@@ -234,6 +253,11 @@ pub(all) struct CoreInstance {
   tags : Map[String, Int]
 }
 pub impl Show for CoreInstance
+
+pub(all) enum CoreSuspension {
+  Yield
+  Wait(Int64)
+} derive(Eq, @debug.Debug)
 
 type DecodedCallbackCode derive(@debug.Debug)
 
@@ -365,8 +389,6 @@ type SyncLowerState derive(@debug.Debug)
 type TaskStep derive(Eq, @debug.Debug)
 
 type WaitEvent derive(@debug.Debug)
-
-type WaitResult derive(@debug.Debug)
 
 type WaitableSet derive(@debug.Debug)
 

--- a/modules/wasmoon/executor/context.mbt
+++ b/modules/wasmoon/executor/context.mbt
@@ -85,6 +85,26 @@ impl Debug for CancellationPoller with fn to_repr(_self) {
 }
 
 ///|
+priv struct SuspensionClassifier {
+  classify : (@runtime.RuntimeError) -> Int64?
+}
+
+///|
+impl Debug for SuspensionClassifier with fn to_repr(_self) {
+  Repr::literal("<suspension-classifier>")
+}
+
+///|
+priv struct ResumeAction {
+  run : () -> Unit raise
+}
+
+///|
+impl Debug for ResumeAction with fn to_repr(_self) {
+  Repr::literal("<resume-action>")
+}
+
+///|
 /// Execution context for running WASM code
 struct ExecContext {
   stack : @runtime.Stack
@@ -97,6 +117,9 @@ struct ExecContext {
   gc_stress_every : Int
   mut gc_stress_alloc_count : Int
   cancel : CancellationPoller?
+  suspension_classifier : SuspensionClassifier?
+  mut resume_action : ResumeAction?
+  mut suspension_token : Int64?
 } derive(Debug)
 
 ///|
@@ -104,6 +127,7 @@ fn ExecContext::ExecContext(
   store : @runtime.Store,
   instance : @runtime.ModuleInstance,
   cancel? : (() -> Bool)? = None,
+  classify_suspension? : (@runtime.RuntimeError) -> Int64? = fn(_) { None },
 ) -> ExecContext {
   {
     stack: Stack(),
@@ -116,6 +140,9 @@ fn ExecContext::ExecContext(
     gc_stress_every: gc_stress_every(),
     gc_stress_alloc_count: 0,
     cancel: cancel.map(fn(callback) { { callback, } }),
+    suspension_classifier: Some({ classify: classify_suspension }),
+    resume_action: None,
+    suspension_token: None,
   }
 }
 

--- a/modules/wasmoon/executor/continuation.mbt
+++ b/modules/wasmoon/executor/continuation.mbt
@@ -1,0 +1,190 @@
+///|
+/// Result of entering or resuming a suspendable interpreter invocation.
+pub(all) enum ResumableCallOutcome {
+  Returned(Array[@types.Value])
+  Suspended(Int64, ExecutionContinuation)
+} derive(Debug)
+
+///|
+/// Explicit continuation for one interpreter invocation.
+///
+/// The captured execution context owns the operand stack, Wasm frames, locals,
+/// labels, current module instance, and a composed closure for the remaining
+/// structured control flow.
+struct ExecutionContinuation {
+  context : ExecContext
+  return_arity : Int
+  active : Array[Bool]
+}
+
+///|
+pub impl Debug for ExecutionContinuation with fn to_repr(_self) {
+  Repr::literal("<execution-continuation>")
+}
+
+///|
+fn ExecContext::set_base_resume_action(
+  self : ExecContext,
+  token : Int64,
+  action : () -> Unit raise,
+) -> Unit {
+  self.suspension_token = Some(token)
+  self.resume_action = Some({ run: action })
+}
+
+///|
+/// Compose work that must run after the currently captured continuation
+/// completes normally. If the inner continuation suspends again, the same
+/// suffix is reattached to the newly captured base action.
+fn ExecContext::append_resume_suffix(
+  self : ExecContext,
+  suffix : () -> Unit raise,
+) -> Unit {
+  guard self.resume_action is Some(previous) else {
+    abort("missing interpreter resume action")
+  }
+  self.resume_action = Some({
+    run: fn() raise {
+      (previous.run)() catch {
+        ExecutionSuspended => {
+          self.append_resume_suffix(suffix)
+          raise ExecutionSuspended
+        }
+        error => raise error
+      }
+      suffix()
+    },
+  })
+}
+
+///|
+/// Compose a structured-control handler around the captured continuation.
+/// Unlike a plain suffix, the handler observes branch/return/exception signals
+/// produced after resumption.
+fn ExecContext::append_resume_handler(
+  self : ExecContext,
+  handler : (ExecBlockResult) -> Unit raise,
+) -> Unit {
+  guard self.resume_action is Some(previous) else {
+    abort("missing interpreter resume action")
+  }
+  self.resume_action = Some({
+    run: fn() raise {
+      let result = try (previous.run)() catch {
+        ExecutionSuspended => {
+          self.append_resume_handler(handler)
+          raise ExecutionSuspended
+        }
+        error => ExecBlockRaised(error)
+      } noraise {
+        _ => ExecBlockCompleted
+      }
+      handler(result)
+    },
+  })
+}
+
+///|
+fn ExecContext::suspend_host_call(
+  self : ExecContext,
+  error : @runtime.RuntimeError,
+  retry : () -> Unit raise,
+) -> Unit raise {
+  match self.suspension_classifier {
+    Some(classifier) =>
+      match (classifier.classify)(error) {
+        Some(token) => {
+          self.set_base_resume_action(token, retry)
+          raise ExecutionSuspended
+        }
+        None => raise InvocationSignal::HostInvocation(error)
+      }
+    None => raise InvocationSignal::HostInvocation(error)
+  }
+}
+
+///|
+fn ExecContext::collect_call_results(
+  self : ExecContext,
+  return_arity : Int,
+) -> Array[@types.Value] raise @runtime.RuntimeError {
+  let results : Array[@types.Value] = []
+  for _ in 0..<return_arity {
+    results.push(self.stack.pop())
+  }
+  results.rev_in_place()
+  results
+}
+
+///|
+fn suspended_outcome(
+  context : ExecContext,
+  return_arity : Int,
+  active : Array[Bool],
+) -> ResumableCallOutcome {
+  guard context.suspension_token is Some(token) else {
+    abort("missing interpreter suspension token")
+  }
+  context.suspension_token = None
+  Suspended(token, { context, return_arity, active })
+}
+
+///|
+/// Resume this continuation exactly once.
+pub fn ExecutionContinuation::continue_execution(
+  self : ExecutionContinuation,
+) -> ResumableCallOutcome raise @runtime.RuntimeError {
+  if !self.active[0] {
+    raise Unreachable
+  }
+  guard self.context.resume_action is Some(action) else {
+    self.active[0] = false
+    raise Unreachable
+  }
+  self.context.resume_action = None
+  (action.run)() catch {
+    ExecutionSuspended =>
+      return suspended_outcome(self.context, self.return_arity, self.active)
+    error => {
+      self.active[0] = false
+      raise normalize_runtime_error(error)
+    }
+  }
+  self.active[0] = false
+  Returned(self.context.collect_call_results(self.return_arity))
+}
+
+///|
+/// Drop the captured interpreter state without resuming it.
+pub fn ExecutionContinuation::cancel(self : ExecutionContinuation) -> Unit {
+  if self.active[0] {
+    self.active[0] = false
+    self.context.resume_action = None
+    self.context.frames.clear()
+    self.context.labels.clear()
+    self.context.stack.clear()
+  }
+}
+
+///|
+/// Enter a function using the explicit continuation interpreter seam.
+pub fn call_func_by_index_resumable(
+  store : @runtime.Store,
+  instance : @runtime.ModuleInstance,
+  func_idx : Int,
+  args : Array[@types.Value],
+  classify_suspension : (@runtime.RuntimeError) -> Int64?,
+) -> ResumableCallOutcome raise @runtime.RuntimeError {
+  let context = ExecContext(store, instance, classify_suspension~)
+  let store_addr = instance.func_addrs[func_idx]
+  let func_inst = store.get_func_inst(store_addr)
+  let type_idx = instance.func_type_indices[func_idx]
+  let func_type = instance.get_func_type(type_idx)
+  let return_arity = func_type.results.length()
+  context.call_func_inst_with_context(store_addr, func_inst, args, return_arity) catch {
+    ExecutionSuspended =>
+      return suspended_outcome(context, return_arity, [true])
+    error => raise normalize_runtime_error(error)
+  }
+  Returned(context.collect_call_results(return_arity))
+}

--- a/modules/wasmoon/executor/error.mbt
+++ b/modules/wasmoon/executor/error.mbt
@@ -20,3 +20,8 @@ priv suberror InvocationSignal {
   HostInvocation(Error)
   Cancelled
 } derive(Debug)
+
+///|
+/// Internal control signal used only while building a resumable interpreter
+/// continuation. It must never escape the public resumable-call seam.
+priv suberror ExecutionSuspended derive(Debug)

--- a/modules/wasmoon/executor/exec_instr.mbt
+++ b/modules/wasmoon/executor/exec_instr.mbt
@@ -565,71 +565,17 @@ fn ExecContext::exec_instr(
       let stack_height = self.stack.size()
       self.push_label(false, arity)
       let result = try self.exec_block(body) catch {
+        ExecutionSuspended => {
+          self.append_resume_handler(fn(result) raise {
+            self.finish_try_table(result, handlers, stack_height)
+          })
+          raise ExecutionSuspended
+        }
         e => ExecBlockRaised(e)
       } noraise {
         _ => ExecBlockCompleted
       }
-      self.pop_label()
-      match result {
-        ExecBlockCompleted => ()
-        ExecBlockRaised(ThrowException(tag_addr, values)) => {
-          // Find a matching handler
-          for handler in handlers {
-            match handler {
-              Catch(handler_tag_idx, label_idx) => {
-                let handler_tag_addr = self.instance.tag_addrs[handler_tag_idx]
-                if handler_tag_addr == tag_addr {
-                  // Match! Push exception values and branch
-                  self.restore_stack_to(stack_height)
-                  for v in values {
-                    self.stack.push(v)
-                  }
-                  raise BranchWith(label_idx, values)
-                }
-              }
-              CatchRef(handler_tag_idx, label_idx) => {
-                let handler_tag_addr = self.instance.tag_addrs[handler_tag_idx]
-                if handler_tag_addr == tag_addr {
-                  // Match! Push exception values and exnref, then branch
-                  let exn_addr = self.store.alloc_exn(tag_addr, values)
-                  self.restore_stack_to(stack_height)
-                  for v in values {
-                    self.stack.push(v)
-                  }
-                  self.stack.push(ExnRef(exn_addr))
-                  let branch_values = values.copy()
-                  branch_values.push(ExnRef(exn_addr))
-                  raise BranchWith(label_idx, branch_values)
-                }
-              }
-              CatchAll(label_idx) => {
-                // Matches any exception
-                self.restore_stack_to(stack_height)
-                raise BranchWith(label_idx, [])
-              }
-              CatchAllRef(label_idx) => {
-                // Matches any exception and pushes exnref
-                let exn_addr = self.store.alloc_exn(tag_addr, values)
-                self.restore_stack_to(stack_height)
-                self.stack.push(ExnRef(exn_addr))
-                raise BranchWith(label_idx, [ExnRef(exn_addr)])
-              }
-            }
-          }
-          // No handler matched, re-raise the exception
-          raise ThrowException(tag_addr, values)
-        }
-        ExecBlockRaised(BranchWith(0, values)) => {
-          // Normal branch to end of try_table
-          self.restore_stack_to(stack_height)
-          for v in values {
-            self.stack.push(v)
-          }
-        }
-        ExecBlockRaised(BranchWith(n, values)) =>
-          raise BranchWith(n - 1, values)
-        ExecBlockRaised(e) => raise e
-      }
+      self.finish_try_table(result, handlers, stack_height)
     }
 
     // GC instructions - struct operations
@@ -940,6 +886,69 @@ fn ExecContext::exec_instr(
     | I16x8RelaxedQ15mulrS
     | I16x8RelaxedDotI8x16I7x16S
     | I32x4RelaxedDotI8x16I7x16AddS => self.exec_simd(instr)
+  }
+}
+
+///|
+fn ExecContext::finish_try_table(
+  self : ExecContext,
+  result : ExecBlockResult,
+  handlers : Array[@types.CatchHandler],
+  stack_height : Int,
+) -> Unit raise {
+  self.pop_label()
+  match result {
+    ExecBlockCompleted => ()
+    ExecBlockRaised(ThrowException(tag_addr, values)) => {
+      for handler in handlers {
+        match handler {
+          Catch(handler_tag_idx, label_idx) => {
+            let handler_tag_addr = self.instance.tag_addrs[handler_tag_idx]
+            if handler_tag_addr == tag_addr {
+              self.restore_stack_to(stack_height)
+              for value in values {
+                self.stack.push(value)
+              }
+              raise BranchWith(label_idx, values)
+            }
+          }
+          CatchRef(handler_tag_idx, label_idx) => {
+            let handler_tag_addr = self.instance.tag_addrs[handler_tag_idx]
+            if handler_tag_addr == tag_addr {
+              let exn_addr = self.store.alloc_exn(tag_addr, values)
+              self.restore_stack_to(stack_height)
+              for value in values {
+                self.stack.push(value)
+              }
+              self.stack.push(ExnRef(exn_addr))
+              let branch_values = values.copy()
+              branch_values.push(ExnRef(exn_addr))
+              raise BranchWith(label_idx, branch_values)
+            }
+          }
+          CatchAll(label_idx) => {
+            self.restore_stack_to(stack_height)
+            raise BranchWith(label_idx, [])
+          }
+          CatchAllRef(label_idx) => {
+            let exn_addr = self.store.alloc_exn(tag_addr, values)
+            self.restore_stack_to(stack_height)
+            self.stack.push(ExnRef(exn_addr))
+            raise BranchWith(label_idx, [ExnRef(exn_addr)])
+          }
+        }
+      }
+      raise ThrowException(tag_addr, values)
+    }
+    ExecBlockRaised(BranchWith(0, values)) => {
+      self.restore_stack_to(stack_height)
+      for value in values {
+        self.stack.push(value)
+      }
+    }
+    ExecBlockRaised(BranchWith(depth, values)) =>
+      raise BranchWith(depth - 1, values)
+    ExecBlockRaised(error) => raise error
   }
 }
 

--- a/modules/wasmoon/executor/instr_call.mbt
+++ b/modules/wasmoon/executor/instr_call.mbt
@@ -212,15 +212,28 @@ fn ExecContext::call_func_inst_with_context(
       self.call_wasm_func(code, args, num_results)
     }
   } else if func_inst is HostFunc(host_fn) {
-    // Call host function directly
-    let caller = @runtime.Caller::Caller(self.store, self.instance)
-    let results = host_fn(caller, args) catch {
-      e => raise InvocationSignal::HostInvocation(e)
+    self.invoke_host_func(host_fn, self.instance, args)
+  }
+}
+
+///|
+fn ExecContext::invoke_host_func(
+  self : ExecContext,
+  host_fn : (@runtime.Caller, Array[@types.Value]) -> Array[@types.Value] raise @runtime.RuntimeError,
+  caller_instance : @runtime.ModuleInstance,
+  args : Array[@types.Value],
+) -> Unit raise {
+  let caller = @runtime.Caller::Caller(self.store, caller_instance)
+  let results = host_fn(caller, args) catch {
+    error => {
+      self.suspend_host_call(error, fn() raise {
+        self.invoke_host_func(host_fn, caller_instance, args)
+      })
+      return
     }
-    // Push results onto the stack
-    for result in results {
-      self.stack.push(result)
-    }
+  }
+  for result in results {
+    self.stack.push(result)
   }
 }
 
@@ -283,6 +296,12 @@ fn ExecContext::call_wasm_func_with_instance(
       self.pop_frame()
       should_continue = false
     } catch {
+      ExecutionSuspended => {
+        self.append_resume_handler(fn(result) raise {
+          self.finish_suspended_wasm_frame(saved_instance, result)
+        })
+        raise ExecutionSuspended
+      }
       ControlSignal::TailCall(store_addr, func_inst, tail_args, _) => {
         // Tail call detected! Pop current frame and loop with new target
         self.pop_frame()
@@ -324,6 +343,53 @@ fn ExecContext::call_wasm_func_with_instance(
 
   // Restore original instance
   self.instance = saved_instance
+}
+
+///|
+fn ExecContext::finish_suspended_wasm_frame(
+  self : ExecContext,
+  saved_instance : @runtime.ModuleInstance,
+  result : ExecBlockResult,
+) -> Unit raise {
+  match result {
+    ExecBlockCompleted => {
+      self.pop_frame()
+      self.instance = saved_instance
+    }
+    ExecBlockRaised(
+      ControlSignal::TailCall(store_addr, func_inst, tail_args, num_results)
+    ) => {
+      let caller_instance = self.instance
+      self.pop_frame()
+      self.instance = saved_instance
+      match func_inst {
+        WasmFunc(code) => {
+          let target_instance = match self.store.get_func_owner(store_addr) {
+            Some(owner) => owner
+            None => saved_instance
+          }
+          self.call_wasm_func_with_instance(
+            target_instance, code, tail_args, num_results,
+          )
+        }
+        HostFunc(host_fn) => {
+          self.invoke_host_func(host_fn, caller_instance, tail_args) catch {
+            ExecutionSuspended => {
+              self.append_resume_suffix(fn() { self.instance = saved_instance })
+              raise ExecutionSuspended
+            }
+            error => raise error
+          }
+          self.instance = saved_instance
+        }
+      }
+    }
+    ExecBlockRaised(error) => {
+      self.pop_frame()
+      self.instance = saved_instance
+      raise error
+    }
+  }
 }
 
 ///|

--- a/modules/wasmoon/executor/instr_control.mbt
+++ b/modules/wasmoon/executor/instr_control.mbt
@@ -47,31 +47,17 @@ fn ExecContext::exec_control(
       }
       self.push_label(false, arity) // Block branches use result arity
       let result = try self.exec_block(body) catch {
-        e => ExecBlockRaised(e)
+        ExecutionSuspended => {
+          self.append_resume_handler(fn(result) raise {
+            self.finish_block_control(result, arity, stack_height)
+          })
+          raise ExecutionSuspended
+        }
+        error => ExecBlockRaised(error)
       } noraise {
         _ => ExecBlockCompleted
       }
-      self.pop_label()
-      match result {
-        ExecBlockCompleted => {
-          // Normal completion: keep only block results on the outer stack.
-          let results = self.stack.pop_n(arity)
-          self.restore_stack_to(stack_height)
-          for v in results {
-            self.stack.push(v)
-          }
-        }
-        ExecBlockRaised(BranchWith(0, values)) => {
-          // br 0: jump to end, keep carried values only.
-          self.restore_stack_to(stack_height)
-          for v in values {
-            self.stack.push(v)
-          }
-        }
-        ExecBlockRaised(BranchWith(n, values)) =>
-          raise BranchWith(n - 1, values)
-        ExecBlockRaised(e) => raise e
-      }
+      self.finish_block_control(result, arity, stack_height)
     }
     // Loop: execute body, br 0 jumps to start
     Loop(bt, body) => {
@@ -83,42 +69,7 @@ fn ExecContext::exec_control(
         self.stack.push(v)
       }
       self.push_label(true, param_arity) // Loop branches use param arity
-      while true {
-        self.check_cancellation()
-        let result = try self.exec_block(body) catch {
-          e => ExecBlockRaised(e)
-        } noraise {
-          _ => ExecBlockCompleted
-        }
-        match result {
-          ExecBlockCompleted => {
-            self.pop_label()
-            // Normal loop exit: keep only loop results on the outer stack.
-            let results = self.stack.pop_n(result_arity)
-            self.restore_stack_to(stack_height)
-            for v in results {
-              self.stack.push(v)
-            }
-            break // Normal exit
-          }
-          ExecBlockRaised(BranchWith(0, values)) => {
-            // For loop, branch to start: restore stack and push params back
-            self.restore_stack_to(stack_height)
-            for v in values {
-              self.stack.push(v)
-            }
-            continue
-          }
-          ExecBlockRaised(BranchWith(n, values)) => {
-            self.pop_label()
-            raise BranchWith(n - 1, values)
-          }
-          ExecBlockRaised(e) => {
-            self.pop_label()
-            raise e
-          }
-        }
-      }
+      self.exec_loop_body(body, result_arity, stack_height)
     }
     // If-else: pop condition, execute appropriate branch
     If(bt, then_body, else_body) => {
@@ -133,30 +84,17 @@ fn ExecContext::exec_control(
       }
       self.push_label(false, arity) // If branches use result arity
       let result = try self.exec_block(body) catch {
-        e => ExecBlockRaised(e)
+        ExecutionSuspended => {
+          self.append_resume_handler(fn(result) raise {
+            self.finish_block_control(result, arity, stack_height)
+          })
+          raise ExecutionSuspended
+        }
+        error => ExecBlockRaised(error)
       } noraise {
         _ => ExecBlockCompleted
       }
-      self.pop_label()
-      match result {
-        ExecBlockCompleted => {
-          // Normal completion: keep only if results on the outer stack.
-          let results = self.stack.pop_n(arity)
-          self.restore_stack_to(stack_height)
-          for v in results {
-            self.stack.push(v)
-          }
-        }
-        ExecBlockRaised(BranchWith(0, values)) => {
-          self.restore_stack_to(stack_height)
-          for v in values {
-            self.stack.push(v)
-          }
-        }
-        ExecBlockRaised(BranchWith(n, values)) =>
-          raise BranchWith(n - 1, values)
-        ExecBlockRaised(e) => raise e
-      }
+      self.finish_block_control(result, arity, stack_height)
     }
     // Unconditional branch - collect values based on target block arity
     Br(depth) => {
@@ -239,13 +177,147 @@ fn ExecContext::exec_control(
 }
 
 ///|
+fn ExecContext::finish_block_control(
+  self : ExecContext,
+  result : ExecBlockResult,
+  arity : Int,
+  stack_height : Int,
+) -> Unit raise {
+  self.pop_label()
+  match result {
+    ExecBlockCompleted => {
+      let results = self.stack.pop_n(arity)
+      self.restore_stack_to(stack_height)
+      for value in results {
+        self.stack.push(value)
+      }
+    }
+    ExecBlockRaised(BranchWith(0, values)) => {
+      self.restore_stack_to(stack_height)
+      for value in values {
+        self.stack.push(value)
+      }
+    }
+    ExecBlockRaised(BranchWith(depth, values)) =>
+      raise BranchWith(depth - 1, values)
+    ExecBlockRaised(error) => raise error
+  }
+}
+
+///|
+fn ExecContext::exec_loop_body(
+  self : ExecContext,
+  body : Array[@types.Instruction],
+  result_arity : Int,
+  stack_height : Int,
+) -> Unit raise {
+  while true {
+    self.check_cancellation()
+    let result = try self.exec_block(body) catch {
+      ExecutionSuspended => {
+        self.append_resume_handler(fn(result) raise {
+          self.finish_suspended_loop_iteration(
+            result, body, result_arity, stack_height,
+          )
+        })
+        raise ExecutionSuspended
+      }
+      error => ExecBlockRaised(error)
+    } noraise {
+      _ => ExecBlockCompleted
+    }
+    match result {
+      ExecBlockCompleted => {
+        self.finish_loop(result, result_arity, stack_height)
+        return
+      }
+      ExecBlockRaised(BranchWith(0, values)) => {
+        self.restore_stack_to(stack_height)
+        for value in values {
+          self.stack.push(value)
+        }
+      }
+      _ => {
+        self.finish_loop(result, result_arity, stack_height)
+        return
+      }
+    }
+  }
+}
+
+///|
+fn ExecContext::finish_suspended_loop_iteration(
+  self : ExecContext,
+  result : ExecBlockResult,
+  body : Array[@types.Instruction],
+  result_arity : Int,
+  stack_height : Int,
+) -> Unit raise {
+  match result {
+    ExecBlockRaised(BranchWith(0, values)) => {
+      self.restore_stack_to(stack_height)
+      for value in values {
+        self.stack.push(value)
+      }
+      self.exec_loop_body(body, result_arity, stack_height)
+    }
+    _ => self.finish_loop(result, result_arity, stack_height)
+  }
+}
+
+///|
+fn ExecContext::finish_loop(
+  self : ExecContext,
+  result : ExecBlockResult,
+  result_arity : Int,
+  stack_height : Int,
+) -> Unit raise {
+  match result {
+    ExecBlockCompleted => {
+      self.pop_label()
+      let results = self.stack.pop_n(result_arity)
+      self.restore_stack_to(stack_height)
+      for value in results {
+        self.stack.push(value)
+      }
+    }
+    ExecBlockRaised(BranchWith(0, _)) =>
+      abort("loop continuation did not resume the next iteration")
+    ExecBlockRaised(BranchWith(depth, values)) => {
+      self.pop_label()
+      raise BranchWith(depth - 1, values)
+    }
+    ExecBlockRaised(error) => {
+      self.pop_label()
+      raise error
+    }
+  }
+}
+
+///|
 /// Execute a block body (can raise ControlSignal)
 fn ExecContext::exec_block(
   self : ExecContext,
   instrs : Array[@types.Instruction],
 ) -> Unit raise {
-  for instr in instrs {
+  self.exec_block_from(instrs, 0)
+}
+
+///|
+fn ExecContext::exec_block_from(
+  self : ExecContext,
+  instrs : Array[@types.Instruction],
+  start : Int,
+) -> Unit raise {
+  for i in start..<instrs.length() {
+    let instr = instrs[i]
     self.exec_instr(instr) catch {
+      ExecutionSuspended => {
+        self.append_resume_suffix(fn() raise {
+          self.exec_block_from(instrs, i + 1)
+        })
+        raise ExecutionSuspended
+      }
       @runtime.TypeMismatch => {
         @logger.debug("type mismatch at instr: \{instr}")
         raise @runtime.TypeMismatch
@@ -261,14 +333,34 @@ fn ExecContext::exec_expr(
   self : ExecContext,
   instrs : Array[@types.Instruction],
 ) -> Unit raise {
-  self.exec_block(instrs) catch {
-    Return => () // Explicit return
-    BranchWith(0, values) =>
+  let result = try self.exec_block(instrs) catch {
+    ExecutionSuspended => {
+      self.append_resume_handler(fn(result) raise {
+        self.finish_exec_expr(result)
+      })
+      raise ExecutionSuspended
+    }
+    error => ExecBlockRaised(error)
+  } noraise {
+    _ => ExecBlockCompleted
+  }
+  self.finish_exec_expr(result)
+}
+
+///|
+fn ExecContext::finish_exec_expr(
+  self : ExecContext,
+  result : ExecBlockResult,
+) -> Unit raise {
+  match result {
+    ExecBlockCompleted => ()
+    ExecBlockRaised(Return) => () // Explicit return
+    ExecBlockRaised(BranchWith(0, values)) =>
       // Branch to function (br 0 from outermost block) acts like return
       // Push the return values back onto the stack
       for v in values {
         self.stack.push(v)
       }
-    e => raise e
+    ExecBlockRaised(error) => raise error
   }
 }

--- a/modules/wasmoon/executor/pkg.generated.mbti
+++ b/modules/wasmoon/executor/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub fn call_exported_func_with_options(@runtime.Store, @runtime.ModuleInstance, 
 
 pub fn call_func_by_index(@runtime.Store, @runtime.ModuleInstance, Int, Array[@types.Value]) -> Array[@types.Value] raise @runtime.RuntimeError
 
+pub fn call_func_by_index_resumable(@runtime.Store, @runtime.ModuleInstance, Int, Array[@types.Value], (@runtime.RuntimeError) -> Int64?) -> ResumableCallOutcome raise @runtime.RuntimeError
+
 pub fn call_func_by_index_with_exception(@runtime.Store, @runtime.ModuleInstance, Int, Array[@types.Value]) -> InvokeWithExceptionResult raise @runtime.RuntimeError
 
 pub fn eval_const_expr(Array[@types.Instruction], func_addrs? : Array[Int], globals? : Array[@runtime.GlobalInstance], store? : @runtime.Store?, types? : Array[@types.SubType]) -> @types.Value raise @runtime.RuntimeError
@@ -70,6 +72,11 @@ pub fn ExecContext::exec_tail_call(Self, Int) -> Unit raise
 pub fn ExecContext::exec_tail_call_indirect(Self, Int, Int) -> Unit raise
 pub fn ExecContext::exec_tail_call_ref(Self, Int) -> Unit raise
 
+type ExecutionContinuation
+pub fn ExecutionContinuation::cancel(Self) -> Unit
+pub fn ExecutionContinuation::continue_execution(Self) -> ResumableCallOutcome raise @runtime.RuntimeError
+pub impl @debug.Debug for ExecutionContinuation
+
 pub struct ImportDiagnostic {
   import_index : Int
   module_name : String
@@ -102,6 +109,11 @@ pub(all) enum InvokeWithExceptionResult {
   Returned(Array[@types.Value])
   Thrown(Int, Array[@types.Value])
 }
+
+pub(all) enum ResumableCallOutcome {
+  Returned(Array[@types.Value])
+  Suspended(Int64, ExecutionContinuation)
+} derive(@debug.Debug)
 
 // Type aliases
 

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -197,6 +197,248 @@ test "component runtime: canon lift core func" {
 }
 
 ///|
+test "component runtime: core execution crosses the configured engine seam" {
+  let wat = "(module (func (export \"inc\") (param i32) (result i32) local.get 0 i32.const 1 i32.add))"
+  let mod_ = @wat.parse(wat) catch {
+    e => return fail("parse wat failed: \{e}")
+  }
+  let wasm_bytes : Array[Byte] = @encoder.encode(mod_).map(v => v.to_byte())
+  let core_instance_payload = vec_payload([core_instance_instantiate(0)])
+  let name_inc : Array[Byte] = [b'i', b'n', b'c']
+  let alias_payload = vec_payload([alias_core_export_func(0, name_inc)])
+  let type_payload : Array[Byte] = [0x01, 0x40, 0x01, 0x00, 0x7a, 0x00, 0x7a]
+  let canon_payload = vec_payload([canon_lift_entry(0, 0)])
+  let export_payload = vec_payload([export_entry_func(name_inc, 0)])
+  let bytes = build_component([
+    (1, wasm_bytes),
+    (2, core_instance_payload),
+    (6, alias_payload),
+    (7, type_payload),
+    (8, canon_payload),
+    (11, export_payload),
+  ])
+  let component = @component.parse_component(bytes) catch {
+    e => return fail("parse component failed: \{e}")
+  }
+  let registrations : Array[(Int, Int)] = []
+  let calls : Array[
+    (Int, Int, Array[@types.Value], @runtime_impl.CoreExecutionMode),
+  ] = []
+  let engine = @runtime_impl.CoreExecutionEngine(
+    fn(_store, module_, instance) {
+      registrations.push((module_.codes.length(), instance.store_idx))
+    },
+    fn(
+      store,
+      instance,
+      func_idx,
+      args,
+      mode,
+    ) raise @runtime_impl.ComponentRuntimeError {
+      calls.push((instance.store_idx, func_idx, args.copy(), mode))
+      let results = @executor.call_func_by_index(
+        store, instance, func_idx, args,
+      ) catch {
+        e => raise CanonCallError(e.to_string())
+      }
+      Returned(results)
+    },
+  )
+  let linker = @runtime_impl.ComponentLinker::with_core_execution_engine(engine)
+  let instance = linker.instantiate("engine_seam", component)
+  let results = instance.call_exported_func("inc", [S32(41)])
+  debug_inspect(
+    (registrations, calls, results),
+    content="([(1, 0)], [(0, 0, [I32(41)], Synchronous)], [S32(42)])",
+  )
+}
+
+///|
+test "executor continuation resumes after the suspended instruction" {
+  let source =
+    #|(module
+    #|  (import "host" "suspend" (func $suspend))
+    #|  (global $count (mut i32) (i32.const 0))
+    #|  (func (export "run") (result i32)
+    #|    global.get $count
+    #|    i32.const 1
+    #|    i32.add
+    #|    global.set $count
+    #|    call $suspend
+    #|    global.get $count
+    #|    i32.const 1
+    #|    i32.add
+    #|    global.set $count
+    #|    global.get $count))
+  let module_ = @wat.parse(source) catch {
+    error => return fail("parse wat failed: \{error}")
+  }
+  let linker = @runtime.Linker::Linker()
+  let attempts = [0]
+  linker.add_host_func("host", "suspend", fn(
+    _args,
+  ) raise @runtime.RuntimeError {
+    attempts[0] = attempts[0] + 1
+    if attempts[0] == 1 {
+      raise Unreachable
+    }
+    []
+  })
+  let instance = @executor.instantiate_with_linker(
+    linker, "continuation", module_,
+  )
+  let initial = @executor.call_func_by_index_resumable(
+    linker.get_store(),
+    instance,
+    1,
+    [],
+    fn(_error) { if attempts[0] == 1 { Some(7L) } else { None } },
+  )
+  guard initial is Suspended(7L, continuation) else {
+    return fail("expected suspended interpreter invocation")
+  }
+  let resumed = continuation.continue_execution()
+  debug_inspect((attempts, resumed), content="([2], Returned([I32(2)]))")
+}
+
+///|
+test "executor continuation preserves nested calls and control frames" {
+  let source =
+    #|(module
+    #|  (import "host" "suspend" (func $suspend))
+    #|  (global $count (mut i32) (i32.const 0))
+    #|  (func $nested (result i32)
+    #|    global.get $count
+    #|    i32.const 1
+    #|    i32.add
+    #|    global.set $count
+    #|    block (result i32)
+    #|      call $suspend
+    #|      global.get $count
+    #|      i32.const 10
+    #|      i32.add
+    #|    end)
+    #|  (func (export "run") (result i32)
+    #|    call $nested
+    #|    i32.const 2
+    #|    i32.mul))
+  let module_ = @wat.parse(source) catch {
+    error => return fail("parse wat failed: \{error}")
+  }
+  let linker = @runtime.Linker::Linker()
+  let attempts = [0]
+  linker.add_host_func("host", "suspend", fn(
+    _args,
+  ) raise @runtime.RuntimeError {
+    attempts[0] = attempts[0] + 1
+    if attempts[0] == 1 {
+      raise Unreachable
+    }
+    []
+  })
+  let instance = @executor.instantiate_with_linker(
+    linker, "nested_continuation", module_,
+  )
+  let initial = @executor.call_func_by_index_resumable(
+    linker.get_store(),
+    instance,
+    2,
+    [],
+    fn(_error) { if attempts[0] == 1 { Some(11L) } else { None } },
+  )
+  guard initial is Suspended(11L, continuation) else {
+    return fail("expected nested interpreter invocation to suspend")
+  }
+  let resumed = continuation.continue_execution()
+  debug_inspect((attempts, resumed), content="([2], Returned([I32(22)]))")
+}
+
+///|
+test "executor continuation resumes repeated loop suspensions" {
+  let source =
+    #|(module
+    #|  (import "host" "suspend" (func $suspend))
+    #|  (global $count (mut i32) (i32.const 0))
+    #|  (func (export "run") (result i32)
+    #|    loop
+    #|      call $suspend
+    #|      global.get $count
+    #|      i32.const 1
+    #|      i32.add
+    #|      global.set $count
+    #|      global.get $count
+    #|      i32.const 3
+    #|      i32.lt_s
+    #|      br_if 0
+    #|    end
+    #|    global.get $count))
+  let module_ = @wat.parse(source) catch {
+    error => return fail("parse wat failed: \{error}")
+  }
+  let linker = @runtime.Linker::Linker()
+  let attempts = [0]
+  linker.add_host_func("host", "suspend", fn(
+    _args,
+  ) raise @runtime.RuntimeError {
+    attempts[0] = attempts[0] + 1
+    if attempts[0] % 2 == 1 {
+      raise Unreachable
+    }
+    []
+  })
+  let instance = @executor.instantiate_with_linker(
+    linker, "loop_continuation", module_,
+  )
+  let mut outcome = @executor.call_func_by_index_resumable(
+    linker.get_store(),
+    instance,
+    1,
+    [],
+    fn(_error) { if attempts[0] % 2 == 1 { Some(13L) } else { None } },
+  )
+  let suspensions = [0]
+  while outcome is Suspended(_, _) {
+    match outcome {
+      Suspended(13L, continuation) => {
+        suspensions[0] = suspensions[0] + 1
+        outcome = continuation.continue_execution()
+      }
+      _ => return fail("unexpected continuation token")
+    }
+  }
+  debug_inspect(
+    (attempts, suspensions, outcome),
+    content="([6], [3], Returned([I32(3)]))",
+  )
+}
+
+///|
+test "ordinary interpreter loops remain iterative" {
+  let source =
+    #|(module
+    #|  (func (export "run") (param i32) (result i32)
+    #|    loop
+    #|      local.get 0
+    #|      i32.const 1
+    #|      i32.sub
+    #|      local.tee 0
+    #|      br_if 0
+    #|    end
+    #|    local.get 0))
+  let module_ = @wat.parse(source) catch {
+    error => return fail("parse wat failed: \{error}")
+  }
+  let linker = @runtime.Linker::Linker()
+  let instance = @executor.instantiate_with_linker(
+    linker, "iterative_loop", module_,
+  )
+  let result = @executor.call_func_by_index(linker.get_store(), instance, 0, [
+    I32(100000),
+  ])
+  debug_inspect(result, content="[I32(0)]")
+}
+
+///|
 test "component runtime: canon lower to core func" {
   let name_inc : Array[Byte] = [b'i', b'n', b'c']
   let name_core : Array[Byte] = [b'c', b'o', b'r', b'e']

--- a/modules/wasmoon/wast/jit_call.mbt
+++ b/modules/wasmoon/wast/jit_call.mbt
@@ -1,0 +1,141 @@
+///|
+/// Structured failure while invoking a prepared JIT module context.
+pub(all) suberror JITCoreCallError {
+  FunctionUnavailable(Int)
+  ArgumentTypeMismatch(Int)
+  ResultTypeMismatch(Int)
+  Trap(String)
+  Cancelled
+  Exit(Int)
+  GcSetupFailed(String)
+} derive(Debug, Eq)
+
+///|
+pub impl Show for JITCoreCallError with fn output(self, logger) {
+  logger.write_string(@types.compact_show_repr(to_repr(self).to_string()))
+}
+
+///|
+fn encode_jit_entry_args(
+  args : Array[@types.Value],
+  param_types : Array[@types.ValueType],
+  jit_module : @jit.JITModule,
+  instance : @runtime.ModuleInstance,
+) -> Array[Int64] raise JITCoreCallError {
+  if args.length() != param_types.length() {
+    raise ArgumentTypeMismatch(args.length())
+  }
+  let slots : Array[Int64] = []
+  for i, ty in param_types {
+    match encode_value(ty, args[i], jit_module, instance) {
+      Some(encoded) =>
+        for raw in encoded {
+          slots.push(raw)
+        }
+      None => raise ArgumentTypeMismatch(i)
+    }
+  }
+  slots
+}
+
+///|
+fn decode_jit_entry_results(
+  results : Array[Int64],
+  result_types : Array[@types.ValueType],
+  store : @runtime.Store,
+  jit_module : @jit.JITModule,
+  instance : @runtime.ModuleInstance,
+) -> Array[@types.Value] raise JITCoreCallError {
+  let values : Array[@types.Value] = []
+  let mut slot = 0
+  for i, ty in result_types {
+    let needed = if ty is V128 { 2 } else { 1 }
+    if slot + needed > results.length() {
+      raise ResultTypeMismatch(i)
+    }
+    let value : @types.Value = match ty {
+      I32 => I32(@types.FromInt64::from_int64_bits(results[slot]))
+      I64 => I64(@types.FromInt64::from_int64_bits(results[slot]))
+      F32 => F32(@types.FromInt64::from_int64_bits(results[slot]))
+      F64 => F64(@types.FromInt64::from_int64_bits(results[slot]))
+      V128 =>
+        V128(@types.int64_pair_to_v128_le(results[slot], results[slot + 1]))
+      _ => decode_ref_value(ty, results[slot], store, jit_module, instance)
+    }
+    values.push(value)
+    slot = slot + needed
+  }
+  if slot != results.length() {
+    raise ResultTypeMismatch(result_types.length())
+  }
+  values
+}
+
+///|
+/// Invoke one function through a prepared JIT module context.
+///
+/// This is the shared entry-call seam used by WAST and component adapters. It
+/// keeps globals and tables coherent with interpreter-visible store state and
+/// scopes the C-heap registration to the native invocation.
+pub fn JITModuleContext::call_core_func(
+  self : JITModuleContext,
+  store : @runtime.Store,
+  instance : @runtime.ModuleInstance,
+  func_idx : Int,
+  args : Array[@types.Value],
+) -> Array[@types.Value] raise JITCoreCallError {
+  guard self.jit_module.get_func(func_idx) is Some(func) else {
+    raise FunctionUnavailable(func_idx)
+  }
+  let encoded_args = encode_jit_entry_args(
+    args,
+    func.param_types,
+    self.jit_module,
+    instance,
+  )
+  sync_store_globals_to_jit(self, store)
+  sync_tables_to_jit(
+    instance,
+    store,
+    self.jit_module,
+    use_subtype_indirect_check=self.use_subtype_indirect_check,
+  )
+  let mut gc_active = false
+  defer {
+    if gc_active {
+      @wasmoon_jit.gc_teardown(self.jit_module.get_context_ptr())
+    }
+    sync_jit_globals_to_store(self, store)
+    sync_jit_tables_to_store(self, store)
+  }
+  match store.c_heap {
+    Some(heap) => {
+      @wasmoon_jit.gc_setup(
+        heap,
+        self.module_types,
+        self.canonical_type_indices,
+        ctx_ptr=self.jit_module.get_context_ptr(),
+        func_type_indices=self.func_type_indices,
+        func_table_ptr=self.jit_module.get_func_table_ptr(),
+        num_funcs=self.jit_module.get_func_count(),
+      ) catch {
+        error => raise GcSetupFailed(error.to_string())
+      }
+      gc_active = true
+      self.jit_module.set_gc_heap(heap.get_ptr())
+    }
+    None => ()
+  }
+  let raw_results = self.jit_module.call_with_context(func, encoded_args) catch {
+    JITTrap(message) => raise Trap(message)
+    JITCancelled => raise Cancelled
+    JITExit(code) => raise Exit(code)
+  }
+  decode_jit_entry_results(
+    raw_results,
+    func.result_types,
+    store,
+    self.jit_module,
+    instance,
+  )
+}

--- a/modules/wasmoon/wast/jit_support.mbt
+++ b/modules/wasmoon/wast/jit_support.mbt
@@ -1500,6 +1500,8 @@ pub fn install_jit_hostcall_dispatcher(
   jit_module : @jit.JITModule,
   store : @runtime.Store,
   instance : @runtime.ModuleInstance,
+  before_dispatch? : () -> Unit = fn() { () },
+  after_dispatch? : () -> Unit = fn() { () },
 ) -> Unit {
   fn call_func_by_addr(
     store : @runtime.Store,
@@ -1557,10 +1559,17 @@ pub fn install_jit_hostcall_dispatcher(
       slot = slot + used
     }
 
-    // Invoke imported function (host or wasm).
+    // Imported code observes interpreter-owned globals and tables. Publish the
+    // caller's native state before dispatch, then pull mutations back before
+    // returning to native code.
+    before_dispatch()
     let invoke_result = call_func_by_addr(store, instance, func_addr, args) catch {
-      e => return runtime_error_to_trap_code(e)
+      e => {
+        after_dispatch()
+        return runtime_error_to_trap_code(e)
+      }
     }
+    after_dispatch()
     let results : Array[@types.Value] = match invoke_result {
       Returned(values) => values
       Thrown(tag_addr, values) => {

--- a/modules/wasmoon/wast/pkg.generated.mbti
+++ b/modules/wasmoon/wast/pkg.generated.mbti
@@ -8,6 +8,7 @@ import {
   "Milky2018/wasmoon/wasi",
   "Milky2018/wasmoon/wat/parser_impl",
   "Milky2018/wasmoon_jit",
+  "moonbitlang/core/debug",
   "moonbitlang/core/hashset",
 }
 
@@ -52,7 +53,7 @@ pub fn init_jit_globals_from_store(@runtime.ModuleInstance, @runtime.Store, @jit
 
 pub fn init_jit_memories_from_store(@runtime.ModuleInstance, @runtime.Store, @jit.JITModule) -> Array[@wasmoon_jit.MemoryInfo]?
 
-pub fn install_jit_hostcall_dispatcher(@jit.JITModule, @runtime.Store, @runtime.ModuleInstance) -> Unit
+pub fn install_jit_hostcall_dispatcher(@jit.JITModule, @runtime.Store, @runtime.ModuleInstance, before_dispatch? : () -> Unit, after_dispatch? : () -> Unit) -> Unit
 
 pub fn invoke_action(WastContext, @parser_impl.WastAction) -> Array[@types.Value] raise WastRunnerError
 
@@ -81,6 +82,17 @@ pub fn values_match(@types.Value, @parser_impl.WastValue) -> Bool
 pub fn wast_value_to_runtime(@parser_impl.WastValue) -> @types.Value
 
 // Errors
+pub(all) suberror JITCoreCallError {
+  FunctionUnavailable(Int)
+  ArgumentTypeMismatch(Int)
+  ResultTypeMismatch(Int)
+  Trap(String)
+  Cancelled
+  Exit(Int)
+  GcSetupFailed(String)
+} derive(Eq, @debug.Debug)
+pub impl Show for JITCoreCallError
+
 pub(all) suberror WastRunnerError {
   ModuleNotFound(String)
   NoCurrentModule
@@ -107,6 +119,7 @@ pub struct JITModuleContext {
   use_subtype_indirect_check : Bool
 }
 pub fn JITModuleContext::JITModuleContext(@jit.JITModule, Int64, Array[Int], Array[Int], Array[Int], Array[Int], Array[Int], Array[@types.SubType], Array[Int], Bool) -> Self
+pub fn JITModuleContext::call_core_func(Self, @runtime.Store, @runtime.ModuleInstance, Int, Array[@types.Value]) -> Array[@types.Value] raise JITCoreCallError
 
 pub struct WastContext {
   store : @runtime.Store

--- a/scripts/run_component_wast.py
+++ b/scripts/run_component_wast.py
@@ -771,15 +771,19 @@ def wit_names_for_path(wast_file: Path) -> bool:
 
 
 def run_component_script(
-    script: dict, wasmoon: Path, tmp: Path
+    script: dict, wasmoon: Path, tmp: Path, *, no_jit: bool = False
 ) -> Tuple[int, int, int, list[str], str, bool]:
     script_path = tmp / "component_script.json"
     script_path.write_text(
         json.dumps(script, ensure_ascii=True, indent=2),
         encoding="utf-8",
     )
+    command = [str(wasmoon), "component-test"]
+    if no_jit:
+        command.append("--no-jit")
+    command.append(str(script_path))
     returncode, stdout, stderr, timed_out = run_command(
-        [str(wasmoon), "component-test", str(script_path)],
+        command,
         timeout_sec=DEFAULT_SCRIPT_TIMEOUT_SECONDS,
     )
     if timed_out:
@@ -814,6 +818,7 @@ def run_file(
     wasm_tools: Path,
     *,
     keep_tmp_on_failure: bool = False,
+    no_jit: bool = False,
 ) -> dict:
     text = path.read_text(encoding="utf-8")
     passed = failed = 0
@@ -1177,7 +1182,12 @@ def run_file(
                 sfailures,
                 raw,
                 saw_result,
-            ) = run_component_script(script, wasmoon, tmp_path)
+            ) = run_component_script(
+                script,
+                wasmoon,
+                tmp_path,
+                no_jit=no_jit,
+            )
             passed += spassed
             failed += sfailed
             if sskipped:
@@ -1222,6 +1232,11 @@ def main() -> int:
         "--keep-tmp-on-failure",
         action="store_true",
         help="Keep per-file temporary directories when a file fails (debug)",
+    )
+    parser.add_argument(
+        "--no-jit",
+        action="store_true",
+        help="Run component core functions with the interpreter instead of JIT",
     )
     parser.add_argument(
         "--wasmoon-tools",
@@ -1304,6 +1319,7 @@ def main() -> int:
         return 1
 
     print(f"Found {len(wast_files)} .wast test files in '{test_dir}'")
+    print(f"Core execution mode: {'interpreter' if args.no_jit else 'JIT'}")
     print(
         "Timeout settings: "
         f"validate={DEFAULT_VALIDATE_TIMEOUT_SECONDS}s(base {BASE_VALIDATE_TIMEOUT_SECONDS}s), "
@@ -1322,6 +1338,7 @@ def main() -> int:
             wasmoon_tools,
             wasm_tools,
             keep_tmp_on_failure=args.keep_tmp_on_failure,
+            no_jit=args.no_jit,
         )
         total_passed += result["passed"]
         total_failed += result["failed"]


### PR DESCRIPTION
## Summary

- route component core execution through a configurable engine and use native JIT for eligible synchronous calls
- replace async entry-point replay with explicit interpreter continuations and a cooperative single-threaded host event loop
- add interpreter opt-outs, dual-engine component CI coverage, architecture documentation, and ISS-280 through ISS-285 tracking

This is stacked on #443 because it depends on the pinned component-model snapshot and suite split introduced there.

## Validation

- moon check --target native --warn-list +73
- moon test --target native (2380/2380)
- python3 scripts/run_all_wast.py --rec (258/258 files, 62563 assertions in each of interpreter and JIT modes)
- stable-0.2 component suite in JIT and interpreter modes (53/53 files, 982 commands each)
- async-0.3 component suite in JIT and interpreter modes (24/24 files, 153 commands each)
- future-gated component suite in JIT and interpreter modes (13/13 files, 439 commands each)
- python3 scripts/audit_module_boundaries.py
- python3 scripts/check_component_snapshot.py
- git diff --check