### PR TITLE
Add stable component runtime and typed invocation APIs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,7 @@ Reusable modules must not import `Milky2018/wasmoon`, `Milky2018/wasmoon_jit`, o
 | Core `.wasm` binary | `wasmoon/parser` | `wasm_core/types.Module` |
 | Core `.wat` text | `wasmoon/wat` | `wasm_core/types.Module` |
 | `.wast` script | `wasmoon/wat` plus `wasmoon/wast` runner | Test commands and modules |
-| Component binary or text | `wasmoon/component/*` | Component-model structures and runtime inputs |
+| Component binary or text | `wasmoon/component` | Validated component instances, typed exports, and WIT-shaped values |
 | Persisted JIT artifact | `wasmoon_jit/artifact` | Verified v9 ordinary-data artifact |
 
 Core modules pass through `wasmoon/validator` before the CLI instantiates or compiles them. Component validation is implemented separately under `wasmoon/validator/component_model`.
@@ -106,8 +106,17 @@ for each entry:
   and structured-control state. Resumption continues at the suspended host-call
   boundary; it does not replay the function from its first instruction.
 
-The default `component` and `component-test` commands enable the JIT engine.
-`--no-jit` selects the interpreter engine for differential testing.
+The default `component --run` and `component-test` commands enable the JIT
+engine. `--no-jit` selects the interpreter engine for differential testing.
+
+The stable library surface is `Milky2018/wasmoon/component`. It owns opaque
+runtime, instance, and function handles plus typed values and structured
+errors; applications do not depend on `component/runtime_impl`. Its portable
+runtime constructor uses the continuation-aware interpreter. The product CLI
+retains the separate native engine adapter for WASI command execution and
+conformance runs. `Milky2018/wasmoon/wit` can bind a resolved world eagerly
+against a stable component instance, rejecting missing or incompatible exports
+before the first call.
 
 Component async execution uses one cooperative host event loop. MoonBit
 processes and component tasks are logical scheduling units, not operating-system

--- a/docs/component-model-plan.md
+++ b/docs/component-model-plan.md
@@ -7,7 +7,9 @@ same runtime objects, interpreter, and native compiler as ordinary core Wasm.
 
 ## Package Boundaries
 
-- `wasmoon/component`: component binary model and parser.
+- `wasmoon/component`: stable parse, validation, instantiation, typed-value, and
+  invocation facade.
+- `wasmoon/component/model`: component binary data model and section parsers.
 - `wasmoon/validator/component_model`: component validation.
 - `wasmoon/component/runtime_impl`: linker, instantiation, canonical ABI,
   resources, tasks, streams, futures, and host adapters.
@@ -17,6 +19,11 @@ same runtime objects, interpreter, and native compiler as ordinary core Wasm.
 Component execution does not add product dependencies to reusable compiler
 modules. The component runtime selects a core execution engine through an
 adapter owned by Wasmoon.
+
+Ordinary embedders depend only on the root component facade. The validator and
+runtime implementation depend directly on `component/model`, so the root
+package can compose them without a dependency cycle. Public facade signatures
+do not contain runtime implementation types.
 
 ## Core Execution Contract
 

--- a/issues/ISS-286.md
+++ b/issues/ISS-286.md
@@ -1,0 +1,55 @@
+# ISS-286: Establish the stable component invocation surface
+
+## Metadata
+- Type: epic
+- Status: closed
+- Priority: 1
+- Labels: component-model, api, cli, wit, runtime
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+Component execution is currently exposed through
+`wasmoon/component/runtime_impl`, so callers must depend on mutable scheduler,
+resource-table, core-instance, and canonical-ABI implementation types. The CLI
+only has a special-purpose WASI command runner, while WIT declarations cannot
+be bound to component exports through a checked public API.
+
+## Design
+Make `Milky2018/wasmoon/component` the stable facade above the model,
+validator, and runtime implementation. The facade owns its public instance,
+function, type, value, and error vocabulary. Add a general component invocation
+command and a WIT adapter that checks a resolved WIT declaration against the
+actual component export before returning a callable binding.
+
+## Acceptance Criteria
+- [x] Normal embedders can parse, validate, instantiate, inspect, bind, and
+      invoke a component without importing `component/runtime_impl`.
+- [x] Public values preserve WIT record fields, cases, flags, options, and
+      results instead of exposing canonical tuple/tag/bitset encodings.
+- [x] The CLI can invoke an arbitrary direct or interface-nested component
+      export with typed JSON arguments and results.
+- [x] Resolved WIT worlds can produce bindings that reject missing or
+      structurally incompatible exports before invocation.
+- [x] Public API docs, black-box tests, generated interfaces, and native quality
+      gates pass.
+
+## Relationships
+- Depends on: ISS-285
+- Parent: none
+- Related: ISS-269
+- Discovered from: none
+
+## Notes
+- 2026-07-28: Native JIT selection remains a Wasmoon embedding policy; the
+  stable value and binding contract must not expose the JIT adapter or
+  `runtime_impl` types.
+
+## Close Notes
+
+Added the stable component facade, general CLI invocation, and checked WIT
+binding layer. The public generated interfaces contain no `runtime_impl` types.
+Native `moon check --warn-list +73`, all 2390 tests, and the reusable-module
+boundary audit pass.

--- a/issues/ISS-287.md
+++ b/issues/ISS-287.md
@@ -1,0 +1,52 @@
+# ISS-287: Add the stable component runtime facade
+
+## Metadata
+- Type: feature
+- Status: closed
+- Priority: 1
+- Labels: component-model, runtime, api, facade
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+The only component linker and instance API is owned by
+`component/runtime_impl`. Its generated interface exposes implementation arrays,
+resource tables, async scheduler maps, core runtime objects, and canonical ABI
+closures.
+
+## Design
+Move lower layers to depend directly on `component/model`, then make the root
+`component` package own an opaque runtime, instance, and function facade. Copy
+and resolve function contracts at the boundary. Convert between public
+WIT-semantic values and private canonical runtime values according to the bound
+function contract, returning stable structured errors for every failure phase.
+
+## Acceptance Criteria
+- [x] `Runtime` parses, validates, and instantiates component bytes through one
+      operation.
+- [x] `Instance::bind` resolves direct exports and `#`-separated nested
+      instance exports.
+- [x] `Function::call` checks arity and recursively converts every supported
+      component value type.
+- [x] Public generated signatures contain no `runtime_impl` types.
+- [x] Black-box tests cover primitive and compound calls, invalid paths, type
+      mismatches, and structured parse/validation/runtime errors.
+
+## Relationships
+- Depends on: none
+- Parent: ISS-286
+- Related: ISS-269
+- Discovered from: ISS-286
+
+## Notes
+- 2026-07-28: The initial `Runtime` constructor uses the portable interpreter.
+  Product-native JIT policy stays outside the stable public type system.
+
+## Close Notes
+
+Inverted the component model dependencies and added opaque runtime, instance,
+function, resource, and resource-type handles with structured errors and
+schema-directed value conversion. Facade regression tests pass as part of the
+520-test `wasmoon/testsuite` package.

--- a/issues/ISS-288.md
+++ b/issues/ISS-288.md
@@ -1,0 +1,49 @@
+# ISS-288: Add general component invocation to the CLI
+
+## Metadata
+- Type: feature
+- Status: closed
+- Priority: 1
+- Labels: component-model, cli, invoke, json
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+`wasmoon component` can inspect a component or run the pinned
+`wasi:cli/run` worlds, but it cannot invoke an arbitrary exported component
+function. The component-spec command runner has a private typed value parser
+that cannot be reused by users or embedders.
+
+## Design
+Add `--invoke <export[#function]>` to `wasmoon component`. Parse each repeated
+`--arg` as schema-directed JSON using the stable facade contract and print the
+typed result as JSON. Reject ambiguous command combinations, unknown exports,
+wrong arity, malformed values, and runtime traps with the existing structured
+CLI error envelope.
+
+## Acceptance Criteria
+- [x] Direct and nested-interface exports can be invoked.
+- [x] Primitive, list, tuple, record, variant, enum, flags, option, and result
+      values have documented JSON forms and round-trip through the CLI.
+- [x] `--run` and `--invoke` are mutually exclusive.
+- [x] Text and JSON error modes report parse, bind, argument, and invocation
+      failures without aborting.
+- [x] CLI black-box tests cover successful and failing invocations.
+
+## Relationships
+- Depends on: ISS-287
+- Parent: ISS-286
+- Related: none
+- Discovered from: ISS-286
+
+## Notes
+- None.
+
+## Close Notes
+
+Added `wasmoon component --invoke`, repeated typed JSON `--arg` values, JSON
+results, mutual-exclusion checks, and structured error envelopes. The command
+package's 28 tests include successful nested invocation and malformed argument
+coverage.

--- a/issues/ISS-289.md
+++ b/issues/ISS-289.md
@@ -1,0 +1,52 @@
+# ISS-289: Add checked WIT typed bindings
+
+## Metadata
+- Type: feature
+- Status: closed
+- Priority: 1
+- Labels: component-model, wit, bindings, api
+- Assignee: codex
+- Created: 2026-07-28
+- Updated: 2026-07-28
+- External ref: none
+
+## Description
+The WIT package parses and resolves packages but provides no bridge from a WIT
+world or interface declaration to a callable component instance. Callers must
+manually reproduce export paths, type aliases, record layouts, variant tags,
+and canonical value encodings.
+
+## Design
+Compile a resolved WIT world's exported functions and interfaces into a typed
+binding schema. Resolve aliases and named declarations within their WIT scope,
+then bind each requested function against the actual component facade
+signature. Return a callable `TypedFunction` only after names, async mode,
+parameter/result shape, and resource identities are compatible.
+
+## Acceptance Criteria
+- [x] Direct world exports, inline interfaces, and referenced package
+      interfaces can be bound by name.
+- [x] Primitive and compound WIT type expressions resolve through aliases and
+      named declarations.
+- [x] Missing worlds/interfaces/functions and recursive or unsupported type
+      declarations return structured binding errors.
+- [x] Signature mismatches are rejected at bind time.
+- [x] Black-box tests invoke a component through bindings produced from parsed
+      and resolved WIT.
+
+## Relationships
+- Depends on: ISS-287
+- Parent: ISS-286
+- Related: none
+- Discovered from: ISS-286
+
+## Notes
+- 2026-07-28: This API is a checked dynamic binding foundation. Source code
+  generation can build on it later without changing the runtime value contract.
+
+## Close Notes
+
+Added `ResolveResult::bind_world` and opaque `WitBindings`, with eager export
+checks, named and compound type resolution, dependency-interface lookup,
+resource identity matching, and structured failures. Black-box coverage binds
+and invokes direct, inline, local-interface, and dependency-interface exports.

--- a/issues/README.md
+++ b/issues/README.md
@@ -301,6 +301,10 @@ graph TD
   ISS_283["ISS-283: Drive component continuations from the host event loop"]
   ISS_284["ISS-284: Remove component async replay state"]
   ISS_285["ISS-285: Add the component JIT adapter and execution gates"]
+  ISS_286["ISS-286: Establish the stable component invocation surface"]
+  ISS_287["ISS-287: Add the stable component runtime facade"]
+  ISS_288["ISS-288: Add general component invocation to the CLI"]
+  ISS_289["ISS-289: Add checked WIT typed bindings"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005
@@ -599,6 +603,9 @@ graph TD
   ISS_282 --> ISS_283
   ISS_283 --> ISS_284
   ISS_281 --> ISS_285
+  ISS_285 --> ISS_286
+  ISS_287 --> ISS_288
+  ISS_287 --> ISS_289
 ```
 
 ## Warnings

--- a/modules/README.md
+++ b/modules/README.md
@@ -16,6 +16,8 @@ Wasmoon runtime integration packages. The main public packages are:
 | `Milky2018/x64_target` | x64 instruction selection, ABI, allocation, frame layout, emission, and linking. | `lower`, `allocate`, `plan_frame`, `emit`, and `prepare_x64_link`. |
 | `Milky2018/aarch64_target` | AArch64 instruction selection, ABI, allocation, frame layout, emission, and linking. | `lower`, `allocate`, `plan_frame`, `emit`, and `prepare_aarch64_link`. |
 | `Milky2018/wasmoon_jit` | Native runtime and JIT integration for Wasmoon. | v9 artifact production, bounded loading, transactional installation, Wasm entry/hostcall trampolines, VMContext layout, runtime symbols, and integration planning. |
+| `Milky2018/wasmoon/component` | Stable Component Model parser and runtime facade. | `ComponentRuntime`, opaque instances/functions, WIT-shaped `ComponentValue`, typed JSON codecs, checked export binding and invocation. |
+| `Milky2018/wasmoon/wit` | WIT parsing, resolution, encoding, and runtime binding. | `parse_package`, `resolve_package`, `ResolveResult::bind_world`, and checked `WitBindings`. |
 
 ## Tested READMEs
 

--- a/modules/wasmoon/README.mbt.md
+++ b/modules/wasmoon/README.mbt.md
@@ -117,6 +117,9 @@ wasmoon explore --help
 
 # component
 wasmoon component path/to/component.wasm --validate
+wasmoon component path/to/component.wasm \
+  --invoke 'math#increment' \
+  --arg 41
 wasmoon component path/to/command.component.wasm --run \
   --dir /srv/data::/data \
   --network loopback

--- a/modules/wasmoon/cmd/wasmoon/commands/component_cmd.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/component_cmd.mbt
@@ -266,6 +266,107 @@ pub fn run_component_command(
 }
 
 ///|
+fn component_invoke_success_json(
+  path : String,
+  values : Array[@component.ComponentValue],
+) -> String {
+  "{\"ok\":true,\"phase\":\"invoke\",\"detail\":\"\{json_escape_string(path)}\",\"result\":\{@component.component_values_to_json(values).stringify()}}"
+}
+
+///|
+priv struct ComponentInvokeEvalResult {
+  ok : Bool
+  phase : String
+  detail : String
+  values : Array[@component.ComponentValue]
+}
+
+///|
+fn run_component_invoke_eval(
+  file_path : String,
+  export_path : String,
+  args : Array[String],
+  wit_names : Bool,
+) -> ComponentInvokeEvalResult {
+  let bytes = @fs.read_file_to_bytes(file_path) catch {
+    IOError(error) =>
+      return { ok: false, phase: "read", detail: error, values: [] }
+  }
+  let instance = @component.ComponentRuntime(wit_names~).instantiate(
+    "invoke", bytes,
+  ) catch {
+    error =>
+      return {
+        ok: false,
+        phase: "instantiate",
+        detail: error.to_string(),
+        values: [],
+      }
+  }
+  let function = instance.bind(export_path) catch {
+    error =>
+      return { ok: false, phase: "bind", detail: error.to_string(), values: [] }
+  }
+  let function_type = function.type_()
+  if args.length() != function_type.params.length() {
+    return {
+      ok: false,
+      phase: "arguments",
+      detail: "expected \{function_type.params.length()} arguments but received \{args.length()}",
+      values: [],
+    }
+  }
+  let values = []
+  for index in 0..<args.length() {
+    let value = @component.parse_component_value_json(
+      args[index],
+      function_type.params[index].ty,
+    ) catch {
+      error =>
+        return {
+          ok: false,
+          phase: "arguments",
+          detail: "argument \{index}: \{error}",
+          values: [],
+        }
+    }
+    values.push(value)
+  }
+  let results = function.call(values) catch {
+    error =>
+      return {
+        ok: false,
+        phase: "invoke",
+        detail: error.to_string(),
+        values: [],
+      }
+  }
+  { ok: true, phase: "invoke", detail: export_path, values: results }
+}
+
+///|
+pub fn run_component_invoke_command(
+  file_path : String,
+  export_path : String,
+  args : Array[String],
+  wit_names : Bool,
+  error_format : ComponentErrorFormat,
+) -> Int {
+  let result = run_component_invoke_eval(
+    file_path, export_path, args, wit_names,
+  )
+  if !result.ok {
+    return report_component_run_error(error_format, result.phase, result.detail)
+  }
+  if error_format is Json {
+    println(component_invoke_success_json(export_path, result.values))
+  } else {
+    println(@component.component_values_to_json(result.values).stringify())
+  }
+  0
+}
+
+///|
 fn component_command_run_instance(
   instance : @runtime_impl.ComponentInstance,
 ) -> @runtime_impl.ComponentInstance? {
@@ -317,6 +418,14 @@ fn report_component_run_error(
     println("component \{phase} error: \{detail}")
   }
   1
+}
+
+///|
+pub fn report_component_option_error(
+  format : ComponentErrorFormat,
+  detail : String,
+) -> Int {
+  report_component_run_error(format, "options", detail)
 }
 
 ///|

--- a/modules/wasmoon/cmd/wasmoon/commands/component_error_wbtest.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/component_error_wbtest.mbt
@@ -192,6 +192,58 @@ test "component command executes a pinned Preview 3 async run export" {
 }
 
 ///|
+test "component invoke evaluates a nested export with typed JSON" {
+  @fs.create_dir("tmp") catch {
+    _ => ()
+  }
+  let path = "tmp/component-invoke.component.wasm"
+  let bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (core module $m
+      #|    (func (export "increment") (param i32) (result i32)
+      #|      local.get 0
+      #|      i32.const 1
+      #|      i32.add))
+      #|  (core instance $i (instantiate $m))
+      #|  (func $increment (param "value" u32) (result u32)
+      #|    (canon lift (core func $i "increment")))
+      #|  (instance $math (export "increment" (func $increment)))
+      #|  (export "math" (instance $math)))
+      #|
+    ),
+  )
+  @fs.write_bytes_to_file(path, bytes) catch {
+    IOError(error) => fail(error)
+  }
+  defer (@fs.remove_file(path) catch { _ => () })
+  let success = run_component_invoke_eval(path, "math#increment", ["41"], true)
+  debug_inspect(
+    (success.ok, success.phase, success.detail, success.values),
+    content=(
+      #|(true, "invoke", "math#increment", [U32(42)])
+    ),
+  )
+  let failure = run_component_invoke_eval(
+    path,
+    "math#increment",
+    ["\"bad\""],
+    true,
+  )
+  debug_inspect(
+    (failure.ok, failure.phase, failure.detail, failure.values),
+    content=(
+      #|(
+      #|  false,
+      #|  "arguments",
+      #|  "argument 0: JsonValueError(\"invalid u32 integer 'bad'\")",
+      #|  [],
+      #|)
+    ),
+  )
+}
+
+///|
 test "component-test json helper includes status fields" {
   let result = ScriptResult::ScriptResult()
   result.add_passed()

--- a/modules/wasmoon/cmd/wasmoon/commands/moon.pkg
+++ b/modules/wasmoon/cmd/wasmoon/commands/moon.pkg
@@ -30,3 +30,7 @@ import {
   "moonbitlang/core/string",
   "moonbitlang/core/strconv",
 }
+
+import {
+  "Milky2018/wasmoon/component/text_parser" @component_text,
+} for "wbtest"

--- a/modules/wasmoon/cmd/wasmoon/commands/pkg.generated.mbti
+++ b/modules/wasmoon/cmd/wasmoon/commands/pkg.generated.mbti
@@ -18,7 +18,11 @@ pub fn compile_module_to_jit(@types.Module, Bool, Bool, actual_memory_max? : Int
 
 pub fn func_to_wat(String, @types.FuncType, Array[@types.ValueType], Array[@types.Instruction]) -> String
 
+pub fn report_component_option_error(ComponentErrorFormat, String) -> Int
+
 pub fn run_component_command(String, Bool, Bool, Bool, ComponentErrorFormat) -> Int
+
+pub fn run_component_invoke_command(String, String, Array[String], Bool, ComponentErrorFormat) -> Int
 
 pub fn run_component_script(String, ComponentErrorFormat, use_jit? : Bool) -> Int
 

--- a/modules/wasmoon/cmd/wasmoon/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon/main.mbt
@@ -106,12 +106,16 @@ fn main {
           "run": @clap.Arg::flag(
             help="Run a pinned WASI Preview 2 or Preview 3 command component",
           ),
+          "invoke": @clap.Arg::named(
+            nargs=AtMost(1),
+            help="Invoke export or interface#function with typed JSON arguments",
+          ),
           "no-jit": @clap.Arg::flag(
             help="Disable JIT compilation for synchronous component core functions",
           ),
           "arg": @clap.Arg::named(
             nargs=Any,
-            help="Command arguments passed after the component path",
+            help="Command strings for --run or typed JSON values for --invoke",
           ),
           "env": @clap.Arg::named(
             nargs=Any,
@@ -296,6 +300,10 @@ fn main {
                 let dump = sub.flags.get("dump") is Some(true)
                 let validate = sub.flags.get("validate") is Some(true)
                 let run = sub.flags.get("run") is Some(true)
+                let invoke = match sub.args.get("invoke") {
+                  Some([path]) => Some(path)
+                  _ => None
+                }
                 let wit_names = match sub.flags.get("no-wit-names") {
                   Some(true) => false
                   _ => true
@@ -309,17 +317,30 @@ fn main {
                     }
                   None => Text
                 }
-                let status = if run {
+                let component_args = match sub.args.get("arg") {
+                  Some(values) => values
+                  None => []
+                }
+                let status = if run && invoke is Some(_) {
+                  @commands.report_component_option_error(
+                    error_format, "--run and --invoke are mutually exclusive",
+                  )
+                } else if invoke is Some(export_path) {
+                  @commands.run_component_invoke_command(
+                    positional[0],
+                    export_path,
+                    component_args,
+                    wit_names,
+                    error_format,
+                  )
+                } else if run {
                   let use_jit = match sub.flags.get("no-jit") {
                     Some(true) => false
                     _ => true
                   }
                   @commands.run_wasi_component_command(
                     positional[0],
-                    match sub.args.get("arg") {
-                      Some(values) => values
-                      None => []
-                    },
+                    component_args,
                     match sub.args.get("env") {
                       Some(values) => values
                       None => []

--- a/modules/wasmoon/component/README.mbt.md
+++ b/modules/wasmoon/component/README.mbt.md
@@ -1,0 +1,115 @@
+# Component runtime facade
+
+`Milky2018/wasmoon/component` is the stable embedding package for WebAssembly
+components. It combines component parsing, validation, instantiation, export
+lookup, WIT-shaped values, and checked calls behind a small API:
+
+```text
+component bytes
+    -> ComponentRuntime::instantiate
+    -> ComponentInstance::bind
+    -> ComponentFunction::call
+```
+
+Do not import `Milky2018/wasmoon/component/runtime_impl` from ordinary
+applications. That package owns canonical ABI adapters, resource tables, the
+cooperative async scheduler, core runtime objects, and other mutable
+implementation state.
+
+## Invoke an export
+
+The stable facade validates before instantiation and returns structured
+`ComponentRuntimeError` values for parse, validation, linking, binding, value,
+and invocation failures:
+
+```moonbit skip
+///|
+let runtime = @component.ComponentRuntime()
+
+///|
+let instance = runtime.instantiate("demo", component_bytes)
+
+///|
+let increment = instance.bind("math#increment")
+
+///|
+let results = increment.call([@component.ComponentValue::U32(41U)])
+```
+
+Export paths use `#` only to cross component instance exports. A top-level
+function is named `run`; a function in an exported interface instance is named
+`wasi:cli/run@0.2.11#run`. The separator does not conflict with WIT package,
+interface, or version syntax.
+
+`ComponentFunction::type_` returns a stable `ComponentFuncType`.
+`ComponentInstance::bind_typed` additionally checks an expected type before
+returning a function. The check includes async mode, parameter names and order,
+record fields, variant cases, flags, compound types, and a consistent
+bidirectional mapping of resource identities.
+
+## Values and JSON
+
+`ComponentValue` represents WIT meaning rather than canonical ABI layout:
+
+- records retain field names instead of becoming anonymous tuples;
+- variants and enums retain case names instead of numeric tags;
+- flags retain selected names instead of a bitset;
+- options and results use explicit value constructors;
+- resource values carry an opaque identity and can be passed back to a
+  compatible parameter.
+
+The CLI and library use the same schema-directed JSON forms:
+
+| WIT shape | JSON |
+| --- | --- |
+| scalar | JSON boolean, number, or string |
+| `list<T>`, `tuple<...>` | array |
+| record | object keyed by field name |
+| variant | `{"case":"name"}` or `{"case":"name","value":...}` |
+| enum | case-name string |
+| flags | array of selected name strings |
+| `option<T>` | `null`, `{"some":...}`, or an unwrapped non-null value |
+| `result<T, E>` | `{"ok":...}` or `{"err":...}` |
+
+Use `parse_component_value_json` when a `ComponentValueType` is already known.
+Use `component_value_to_json` or `component_values_to_json` for output. Signed
+and unsigned 64-bit JSON numbers preserve their exact decimal spelling.
+
+## WIT bindings
+
+`Milky2018/wasmoon/wit` turns a resolved world into an eagerly checked binding
+set:
+
+```moonbit skip
+///|
+let resolved = @wit.resolve_package(root_package, dependencies)
+
+///|
+let bindings = resolved.bind_world("demo", instance)
+
+///|
+let function = bindings.function("math#increment")
+
+///|
+let results = function.call([@component.ComponentValue::U32(41U)])
+```
+
+Binding is not delayed until the first call. Missing exports and incompatible
+WIT signatures fail in `bind_world`; `WitBindings::paths` reports the functions
+that were successfully bound. Direct world functions, inline interfaces, local
+interfaces, and dependency-package interfaces are supported.
+
+The current checked API is dynamic: it gives generated binding tools a stable
+runtime target, but does not itself emit MoonBit source.
+
+## Execution policy
+
+`ComponentRuntime` uses the portable continuation-aware interpreter. Native JIT
+selection is a Wasmoon product embedding policy because constructing a native
+engine requires Store, core-module, VM context, and hostcall coordination that
+must not appear in this stable facade.
+
+The `wasmoon component --run` WASI command path and component conformance runner
+continue to use Wasmoon's native JIT by default, with `--no-jit` for
+differential testing. General facade and `--invoke` behavior stays independent
+of target-specific engine types.

--- a/modules/wasmoon/component/moon.pkg
+++ b/modules/wasmoon/component/moon.pkg
@@ -1,3 +1,7 @@
 import {
   "Milky2018/wasmoon/component/model",
+  "Milky2018/wasmoon/component/runtime_impl",
+  "Milky2018/wasmoon/validator/component_model",
+  "moonbitlang/core/json",
+  "moonbitlang/core/string",
 }

--- a/modules/wasmoon/component/pkg.generated.mbti
+++ b/modules/wasmoon/component/pkg.generated.mbti
@@ -3,9 +3,16 @@ package "Milky2018/wasmoon/component"
 
 import {
   "Milky2018/wasmoon/component/model",
+  "moonbitlang/core/debug",
 }
 
 // Values
+pub fn component_value_from_json(Json, ComponentValueType) -> ComponentValue raise ComponentRuntimeError
+
+pub fn component_value_to_json(ComponentValue) -> Json
+
+pub fn component_values_to_json(Array[ComponentValue]) -> Json
+
 pub fn parse_alias_section(Bytes) -> Array[@model.Alias] raise @model.ComponentParseError
 
 pub fn parse_canon_section(Bytes) -> Array[@model.Canon] raise @model.ComponentParseError
@@ -13,6 +20,8 @@ pub fn parse_canon_section(Bytes) -> Array[@model.Canon] raise @model.ComponentP
 pub fn parse_component(Bytes) -> @model.Component raise @model.ComponentParseError
 
 pub fn parse_component_binary(Bytes) -> @model.ComponentBinary raise @model.ComponentParseError
+
+pub fn parse_component_value_json(String, ComponentValueType) -> ComponentValue raise ComponentRuntimeError
 
 pub fn parse_core_instance_section(Bytes) -> Array[@model.CoreInstanceDecl] raise @model.ComponentParseError
 
@@ -29,8 +38,130 @@ pub fn parse_type_section(Bytes) -> Array[@model.TypeDef] raise @model.Component
 pub fn sniff_binary_kind(Bytes) -> @model.BinaryKind?
 
 // Errors
+pub(all) suberror ComponentRuntimeError {
+  ParseFailed(String)
+  ValidationFailed(String)
+  InstantiationFailed(String)
+  InvalidExportPath(String)
+  UnknownExport(String)
+  ExportNotFunction(String)
+  InvalidContract(String)
+  BindingTypeMismatch(path~ : String, expected~ : ComponentFuncType, actual~ : ComponentFuncType)
+  ArgumentCountMismatch(expected~ : Int, actual~ : Int)
+  TypeMismatch(path~ : String, expected~ : ComponentValueType, actual~ : String)
+  InvocationFailed(String)
+  JsonValueError(String)
+} derive(Eq, @debug.Debug)
+pub impl Show for ComponentRuntimeError
 
 // Types and methods
+pub struct ComponentCase {
+  name : String
+  ty : ComponentValueType?
+} derive(Eq, @debug.Debug)
+pub fn ComponentCase::ComponentCase(String, ComponentValueType?) -> Self
+pub impl Show for ComponentCase
+
+pub struct ComponentField {
+  name : String
+  ty : ComponentValueType
+} derive(Eq, @debug.Debug)
+pub fn ComponentField::ComponentField(String, ComponentValueType) -> Self
+pub impl Show for ComponentField
+
+pub struct ComponentFuncType {
+  is_async : Bool
+  params : Array[ComponentParam]
+  result : ComponentValueType?
+} derive(Eq, @debug.Debug)
+pub fn ComponentFuncType::ComponentFuncType(Array[ComponentParam], ComponentValueType?, is_async? : Bool) -> Self
+pub impl Show for ComponentFuncType
+
+type ComponentFunction
+pub fn ComponentFunction::call(Self, Array[ComponentValue]) -> Array[ComponentValue] raise ComponentRuntimeError
+pub fn ComponentFunction::type_(Self) -> ComponentFuncType
+
+type ComponentInstance
+pub fn ComponentInstance::bind(Self, String) -> ComponentFunction raise ComponentRuntimeError
+pub fn ComponentInstance::bind_typed(Self, String, ComponentFuncType) -> ComponentFunction raise ComponentRuntimeError
+
+pub struct ComponentParam {
+  name : String
+  ty : ComponentValueType
+} derive(Eq, @debug.Debug)
+pub fn ComponentParam::ComponentParam(String, ComponentValueType) -> Self
+pub impl Show for ComponentParam
+
+type ComponentResource derive(Eq, @debug.Debug)
+pub fn ComponentResource::type_(Self) -> ComponentResourceType
+
+type ComponentResourceType derive(Eq, @debug.Debug)
+pub fn ComponentResourceType::name(Self) -> String
+pub fn ComponentResourceType::named(String) -> Self
+
+type ComponentRuntime
+pub fn ComponentRuntime::ComponentRuntime(wit_names? : Bool) -> Self
+pub fn ComponentRuntime::instantiate(Self, String, Bytes) -> ComponentInstance raise ComponentRuntimeError
+pub fn ComponentRuntime::instantiate_component(Self, String, @model.Component) -> ComponentInstance raise ComponentRuntimeError
+
+pub(all) enum ComponentValue {
+  Bool(Bool)
+  S8(Int)
+  U8(Int)
+  S16(Int)
+  U16(Int)
+  S32(Int)
+  U32(UInt)
+  S64(Int64)
+  U64(UInt64)
+  F32(Float)
+  F64(Double)
+  Char(Char)
+  String(String)
+  ErrorContext(String)
+  List(Array[ComponentValue])
+  Tuple(Array[ComponentValue])
+  Record(Array[(String, ComponentValue)])
+  Variant(String, ComponentValue?)
+  Enum(String)
+  Flags(Array[String])
+  OptionNone
+  OptionSome(ComponentValue)
+  ResultOk(ComponentValue?)
+  ResultErr(ComponentValue?)
+  Resource(ComponentResource)
+} derive(Eq, @debug.Debug)
+pub impl Show for ComponentValue
+
+pub(all) enum ComponentValueType {
+  Bool
+  S8
+  U8
+  S16
+  U16
+  S32
+  U32
+  S64
+  U64
+  F32
+  F64
+  Char
+  String
+  ErrorContext
+  List(ComponentValueType)
+  Tuple(Array[ComponentValueType])
+  Record(Array[ComponentField])
+  Variant(Array[ComponentCase])
+  Enum(Array[String])
+  Flags(Array[String])
+  Option(ComponentValueType)
+  Result(ComponentValueType?, ComponentValueType?)
+  Own(ComponentResourceType)
+  Borrow(ComponentResourceType)
+  Stream(ComponentValueType?)
+  Future(ComponentValueType?)
+} derive(Eq, @debug.Debug)
+pub impl Show for ComponentValueType
 
 // Type aliases
 pub using @model {type Alias}

--- a/modules/wasmoon/component/runtime_facade.mbt
+++ b/modules/wasmoon/component/runtime_facade.mbt
@@ -1,0 +1,1492 @@
+///|
+/// Stable component runtime facade.
+///
+/// Normal embedders should use the types in this file instead of importing
+/// `Milky2018/wasmoon/component/runtime_impl`. The facade owns its public value,
+/// type, error, instance, and function vocabulary. Canonical ABI encodings and
+/// scheduler state remain private implementation details.
+
+///|
+struct ComponentResourceType {
+  identity : String
+} derive(Debug, Eq)
+
+///|
+pub fn ComponentResourceType::named(name : String) -> ComponentResourceType {
+  { identity: name }
+}
+
+///|
+pub fn ComponentResourceType::name(self : ComponentResourceType) -> String {
+  self.identity
+}
+
+///|
+pub(all) enum ComponentValueType {
+  Bool
+  S8
+  U8
+  S16
+  U16
+  S32
+  U32
+  S64
+  U64
+  F32
+  F64
+  Char
+  String
+  ErrorContext
+  List(ComponentValueType)
+  Tuple(Array[ComponentValueType])
+  Record(Array[ComponentField])
+  Variant(Array[ComponentCase])
+  Enum(Array[String])
+  Flags(Array[String])
+  Option(ComponentValueType)
+  Result(ComponentValueType?, ComponentValueType?)
+  Own(ComponentResourceType)
+  Borrow(ComponentResourceType)
+  Stream(ComponentValueType?)
+  Future(ComponentValueType?)
+} derive(Debug, Eq)
+
+///|
+pub impl Show for ComponentValueType with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+pub struct ComponentField {
+  name : String
+  ty : ComponentValueType
+} derive(Debug, Eq)
+
+///|
+pub impl Show for ComponentField with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+pub fn ComponentField::ComponentField(
+  name : String,
+  ty : ComponentValueType,
+) -> ComponentField {
+  { name, ty }
+}
+
+///|
+pub struct ComponentCase {
+  name : String
+  ty : ComponentValueType?
+} derive(Debug, Eq)
+
+///|
+pub impl Show for ComponentCase with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+pub fn ComponentCase::ComponentCase(
+  name : String,
+  ty : ComponentValueType?,
+) -> ComponentCase {
+  { name, ty }
+}
+
+///|
+pub struct ComponentParam {
+  name : String
+  ty : ComponentValueType
+} derive(Debug, Eq)
+
+///|
+pub impl Show for ComponentParam with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+pub fn ComponentParam::ComponentParam(
+  name : String,
+  ty : ComponentValueType,
+) -> ComponentParam {
+  { name, ty }
+}
+
+///|
+pub struct ComponentFuncType {
+  is_async : Bool
+  params : Array[ComponentParam]
+  result : ComponentValueType?
+} derive(Debug, Eq)
+
+///|
+pub impl Show for ComponentFuncType with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+pub fn ComponentFuncType::ComponentFuncType(
+  params : Array[ComponentParam],
+  result : ComponentValueType?,
+  is_async? : Bool = false,
+) -> ComponentFuncType {
+  { is_async, params, result }
+}
+
+///|
+struct ComponentResource {
+  handle : Int
+  type_ : ComponentResourceType
+} derive(Debug, Eq)
+
+///|
+pub fn ComponentResource::type_(
+  self : ComponentResource,
+) -> ComponentResourceType {
+  self.type_
+}
+
+///|
+pub(all) enum ComponentValue {
+  Bool(Bool)
+  S8(Int)
+  U8(Int)
+  S16(Int)
+  U16(Int)
+  S32(Int)
+  U32(UInt)
+  S64(Int64)
+  U64(UInt64)
+  F32(Float)
+  F64(Double)
+  Char(Char)
+  String(String)
+  ErrorContext(String)
+  List(Array[ComponentValue])
+  Tuple(Array[ComponentValue])
+  Record(Array[(String, ComponentValue)])
+  Variant(String, ComponentValue?)
+  Enum(String)
+  Flags(Array[String])
+  OptionNone
+  OptionSome(ComponentValue)
+  ResultOk(ComponentValue?)
+  ResultErr(ComponentValue?)
+  Resource(ComponentResource)
+} derive(Debug, Eq)
+
+///|
+pub impl Show for ComponentValue with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+pub(all) suberror ComponentRuntimeError {
+  ParseFailed(String)
+  ValidationFailed(String)
+  InstantiationFailed(String)
+  InvalidExportPath(String)
+  UnknownExport(String)
+  ExportNotFunction(String)
+  InvalidContract(String)
+  BindingTypeMismatch(
+    path~ : String,
+    expected~ : ComponentFuncType,
+    actual~ : ComponentFuncType
+  )
+  ArgumentCountMismatch(expected~ : Int, actual~ : Int)
+  TypeMismatch(path~ : String, expected~ : ComponentValueType, actual~ : String)
+  InvocationFailed(String)
+  JsonValueError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl Show for ComponentRuntimeError with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+struct ComponentRuntime {
+  linker : @runtime_impl.ComponentLinker
+  wit_names : Bool
+}
+
+///|
+struct ComponentInstance {
+  inner : @runtime_impl.ComponentInstance
+}
+
+///|
+struct ComponentFunction {
+  instance : @runtime_impl.ComponentInstance
+  name : String
+  public_type : ComponentFuncType
+}
+
+///|
+pub fn ComponentRuntime::ComponentRuntime(
+  wit_names? : Bool = true,
+) -> ComponentRuntime {
+  { linker: ComponentLinker(), wit_names }
+}
+
+///|
+pub fn ComponentRuntime::instantiate(
+  self : ComponentRuntime,
+  name : String,
+  bytes : Bytes,
+) -> ComponentInstance raise ComponentRuntimeError {
+  let component = @model.parse_component(bytes) catch {
+    error => raise ParseFailed(error.to_string())
+  }
+  self.instantiate_component(name, component)
+}
+
+///|
+pub fn ComponentRuntime::instantiate_component(
+  self : ComponentRuntime,
+  name : String,
+  component : Component,
+) -> ComponentInstance raise ComponentRuntimeError {
+  @component_model.validate_component_with_config(
+    component,
+    ComponentValidationConfig(self.wit_names),
+  ) catch {
+    error => raise ValidationFailed(error.to_string())
+  }
+  let inner = self.linker.instantiate(name, component) catch {
+    error => raise InstantiationFailed(error.to_string())
+  }
+  { inner, }
+}
+
+///|
+fn component_primitive_type(ty : @model.PrimValType) -> ComponentValueType {
+  match ty {
+    Bool => Bool
+    S8 => S8
+    U8 => U8
+    S16 => S16
+    U16 => U16
+    S32 => S32
+    U32 => U32
+    S64 => S64
+    U64 => U64
+    F32 => F32
+    F64 => F64
+    Char => Char
+    String => String
+    ErrorContext => ErrorContext
+  }
+}
+
+///|
+fn component_resource_identity(index : Int) -> ComponentResourceType {
+  { identity: "type[\{index}]" }
+}
+
+///|
+fn resolve_component_value_type(
+  ty : @model.ValType,
+  types : Array[@model.TypeDef?],
+) -> ComponentValueType raise ComponentRuntimeError {
+  match ty {
+    Prim(primitive) => component_primitive_type(primitive)
+    TypeIdx(index) => {
+      guard index >= 0 && types.get(index) is Some(Some(type_def)) else {
+        raise InvalidContract("unknown component value type \{index}")
+      }
+      match type_def {
+        DefValType(primitive) => component_primitive_type(primitive)
+        List(element) => List(resolve_component_value_type(element, types))
+        Tuple(elements) => {
+          let resolved = []
+          for element in elements {
+            resolved.push(resolve_component_value_type(element, types))
+          }
+          Tuple(resolved)
+        }
+        Record(fields) => {
+          let resolved = []
+          for field in fields {
+            resolved.push(
+              ComponentField(
+                field.label,
+                resolve_component_value_type(field.ty, types),
+              ),
+            )
+          }
+          Record(resolved)
+        }
+        Variant(cases) => {
+          let resolved = []
+          for case in cases {
+            resolved.push(
+              ComponentCase(
+                case.label,
+                match case.ty {
+                  Some(payload) =>
+                    Some(resolve_component_value_type(payload, types))
+                  None => None
+                },
+              ),
+            )
+          }
+          Variant(resolved)
+        }
+        Enum(labels) => Enum(labels.copy())
+        Flags(labels) => Flags(labels.copy())
+        Option(payload) => Option(resolve_component_value_type(payload, types))
+        Result(ok, err) =>
+          Result(
+            match ok {
+              Some(payload) =>
+                Some(resolve_component_value_type(payload, types))
+              None => None
+            },
+            match err {
+              Some(payload) =>
+                Some(resolve_component_value_type(payload, types))
+              None => None
+            },
+          )
+        Own(resource_index) => Own(component_resource_identity(resource_index))
+        Borrow(resource_index) =>
+          Borrow(component_resource_identity(resource_index))
+        Stream(payload) =>
+          Stream(
+            match payload {
+              Some(payload) =>
+                Some(resolve_component_value_type(payload, types))
+              None => None
+            },
+          )
+        Future(payload) =>
+          Future(
+            match payload {
+              Some(payload) =>
+                Some(resolve_component_value_type(payload, types))
+              None => None
+            },
+          )
+        ResourceType(_, _, _, _) => Own(component_resource_identity(index))
+        FuncType(_) | ComponentType(_) | InstanceTypeEmpty | InstanceType(_) =>
+          raise InvalidContract("type[\{index}] is not a component value type")
+      }
+    }
+  }
+}
+
+///|
+fn resolve_component_func_type(
+  func_type : @model.FuncType,
+  types : Array[@model.TypeDef?],
+) -> ComponentFuncType raise ComponentRuntimeError {
+  let params = []
+  for param in func_type.params {
+    params.push(
+      ComponentParam(param.label, resolve_component_value_type(param.ty, types)),
+    )
+  }
+  let result = match func_type.result {
+    Some(result) => Some(resolve_component_value_type(result, types))
+    None => None
+  }
+  { is_async: func_type.is_async, params, result }
+}
+
+///|
+fn component_function_parts(
+  func : @runtime_impl.ComponentFunc,
+) -> (@model.FuncType, Array[@model.TypeDef?]) {
+  match func {
+    Host(func_type, types, _) | HostAsync(func_type, types, _) =>
+      (func_type, types)
+    Lifted(_, func_type, _, types, _, _, _, _) => (func_type, types)
+  }
+}
+
+///|
+pub fn ComponentInstance::bind(
+  self : ComponentInstance,
+  path : String,
+) -> ComponentFunction raise ComponentRuntimeError {
+  let segments = []
+  for segment in path.split("#") {
+    let segment = segment.to_owned()
+    if segment == "" {
+      raise InvalidExportPath(path)
+    }
+    segments.push(segment)
+  }
+  if segments.length() == 0 {
+    raise InvalidExportPath(path)
+  }
+  let mut current = self.inner
+  for i in 0..<(segments.length() - 1) {
+    match current.get_export(segments[i]) {
+      Some(Instance(instance)) => current = instance
+      Some(_) => raise ExportNotFunction(segments[i])
+      None => raise UnknownExport(segments[i])
+    }
+  }
+  let name = segments[segments.length() - 1]
+  match current.get_export(name) {
+    Some(Func(func)) => {
+      let (raw_type, raw_types) = component_function_parts(func)
+      let public_type = resolve_component_func_type(raw_type, raw_types)
+      { instance: current, name, public_type }
+    }
+    Some(_) => raise ExportNotFunction(path)
+    None => raise UnknownExport(path)
+  }
+}
+
+///|
+fn component_resource_types_compatible(
+  expected : ComponentResourceType,
+  actual : ComponentResourceType,
+  expected_to_actual : Map[String, String],
+  actual_to_expected : Map[String, String],
+) -> Bool {
+  match
+    (
+      expected_to_actual.get(expected.identity),
+      actual_to_expected.get(actual.identity),
+    ) {
+    (Some(bound_actual), Some(bound_expected)) =>
+      bound_actual == actual.identity && bound_expected == expected.identity
+    (Some(bound_actual), None) =>
+      if bound_actual == actual.identity {
+        actual_to_expected.set(actual.identity, expected.identity)
+        true
+      } else {
+        false
+      }
+    (None, Some(bound_expected)) =>
+      if bound_expected == expected.identity {
+        expected_to_actual.set(expected.identity, actual.identity)
+        true
+      } else {
+        false
+      }
+    (None, None) => {
+      expected_to_actual.set(expected.identity, actual.identity)
+      actual_to_expected.set(actual.identity, expected.identity)
+      true
+    }
+  }
+}
+
+///|
+fn component_value_types_compatible(
+  expected : ComponentValueType,
+  actual : ComponentValueType,
+  expected_to_actual : Map[String, String],
+  actual_to_expected : Map[String, String],
+) -> Bool {
+  match (expected, actual) {
+    (Bool, Bool)
+    | (S8, S8)
+    | (U8, U8)
+    | (S16, S16)
+    | (U16, U16)
+    | (S32, S32)
+    | (U32, U32)
+    | (S64, S64)
+    | (U64, U64)
+    | (F32, F32)
+    | (F64, F64)
+    | (Char, Char)
+    | (String, String)
+    | (ErrorContext, ErrorContext) => true
+    (List(expected), List(actual)) | (Option(expected), Option(actual)) =>
+      component_value_types_compatible(
+        expected, actual, expected_to_actual, actual_to_expected,
+      )
+    (Tuple(expected), Tuple(actual)) => {
+      if expected.length() != actual.length() {
+        return false
+      }
+      for index in 0..<expected.length() {
+        if !component_value_types_compatible(
+            expected[index],
+            actual[index],
+            expected_to_actual,
+            actual_to_expected,
+          ) {
+          return false
+        }
+      }
+      true
+    }
+    (Record(expected), Record(actual)) => {
+      if expected.length() != actual.length() {
+        return false
+      }
+      for index in 0..<expected.length() {
+        if expected[index].name != actual[index].name ||
+          !component_value_types_compatible(
+            expected[index].ty,
+            actual[index].ty,
+            expected_to_actual,
+            actual_to_expected,
+          ) {
+          return false
+        }
+      }
+      true
+    }
+    (Variant(expected), Variant(actual)) => {
+      if expected.length() != actual.length() {
+        return false
+      }
+      for index in 0..<expected.length() {
+        if expected[index].name != actual[index].name {
+          return false
+        }
+        match (expected[index].ty, actual[index].ty) {
+          (None, None) => ()
+          (Some(expected), Some(actual)) =>
+            if !component_value_types_compatible(
+                expected, actual, expected_to_actual, actual_to_expected,
+              ) {
+              return false
+            }
+          _ => return false
+        }
+      }
+      true
+    }
+    (Enum(expected), Enum(actual)) | (Flags(expected), Flags(actual)) =>
+      expected == actual
+    (Result(expected_ok, expected_err), Result(actual_ok, actual_err)) => {
+      let compatible_optional = fn(
+        expected : ComponentValueType?,
+        actual : ComponentValueType?,
+      ) -> Bool {
+        match (expected, actual) {
+          (None, None) => true
+          (Some(expected), Some(actual)) =>
+            component_value_types_compatible(
+              expected, actual, expected_to_actual, actual_to_expected,
+            )
+          _ => false
+        }
+      }
+      compatible_optional(expected_ok, actual_ok) &&
+      compatible_optional(expected_err, actual_err)
+    }
+    (Own(expected), Own(actual)) | (Borrow(expected), Borrow(actual)) =>
+      component_resource_types_compatible(
+        expected, actual, expected_to_actual, actual_to_expected,
+      )
+    (Stream(expected), Stream(actual)) | (Future(expected), Future(actual)) =>
+      match (expected, actual) {
+        (None, None) => true
+        (Some(expected), Some(actual)) =>
+          component_value_types_compatible(
+            expected, actual, expected_to_actual, actual_to_expected,
+          )
+        _ => false
+      }
+    _ => false
+  }
+}
+
+///|
+fn component_func_types_compatible(
+  expected : ComponentFuncType,
+  actual : ComponentFuncType,
+) -> Bool {
+  if expected.is_async != actual.is_async ||
+    expected.params.length() != actual.params.length() {
+    return false
+  }
+  let expected_to_actual : Map[String, String] = Map([])
+  let actual_to_expected : Map[String, String] = Map([])
+  for index in 0..<expected.params.length() {
+    if expected.params[index].name != actual.params[index].name ||
+      !component_value_types_compatible(
+        expected.params[index].ty,
+        actual.params[index].ty,
+        expected_to_actual,
+        actual_to_expected,
+      ) {
+      return false
+    }
+  }
+  match (expected.result, actual.result) {
+    (None, None) => true
+    (Some(expected), Some(actual)) =>
+      component_value_types_compatible(
+        expected, actual, expected_to_actual, actual_to_expected,
+      )
+    _ => false
+  }
+}
+
+///|
+pub fn ComponentInstance::bind_typed(
+  self : ComponentInstance,
+  path : String,
+  expected : ComponentFuncType,
+) -> ComponentFunction raise ComponentRuntimeError {
+  let function = self.bind(path)
+  if !component_func_types_compatible(expected, function.public_type) {
+    raise BindingTypeMismatch(path~, expected~, actual=function.public_type)
+  }
+  function
+}
+
+///|
+pub fn ComponentFunction::type_(self : ComponentFunction) -> ComponentFuncType {
+  self.public_type
+}
+
+///|
+fn component_value_kind(value : ComponentValue) -> String {
+  match value {
+    Bool(_) => "bool"
+    S8(_) => "s8"
+    U8(_) => "u8"
+    S16(_) => "s16"
+    U16(_) => "u16"
+    S32(_) => "s32"
+    U32(_) => "u32"
+    S64(_) => "s64"
+    U64(_) => "u64"
+    F32(_) => "f32"
+    F64(_) => "f64"
+    Char(_) => "char"
+    String(_) => "string"
+    ErrorContext(_) => "error-context"
+    List(_) => "list"
+    Tuple(_) => "tuple"
+    Record(_) => "record"
+    Variant(_, _) => "variant"
+    Enum(_) => "enum"
+    Flags(_) => "flags"
+    OptionNone => "option.none"
+    OptionSome(_) => "option.some"
+    ResultOk(_) => "result.ok"
+    ResultErr(_) => "result.err"
+    Resource(_) => "resource"
+  }
+}
+
+///|
+fn component_type_mismatch(
+  path : String,
+  expected : ComponentValueType,
+  value : ComponentValue,
+) -> ComponentRuntimeError {
+  TypeMismatch(path~, expected~, actual=component_value_kind(value))
+}
+
+///|
+fn find_component_field(
+  fields : Array[(String, ComponentValue)],
+  name : String,
+) -> ComponentValue? {
+  for field in fields {
+    if field.0 == name {
+      return Some(field.1)
+    }
+  }
+  None
+}
+
+///|
+fn component_case_index(cases : Array[ComponentCase], name : String) -> Int? {
+  for index, case in cases {
+    if case.name == name {
+      return Some(index)
+    }
+  }
+  None
+}
+
+///|
+fn component_label_index(labels : Array[String], name : String) -> Int? {
+  for index, label in labels {
+    if label == name {
+      return Some(index)
+    }
+  }
+  None
+}
+
+///|
+fn lower_component_value(
+  value : ComponentValue,
+  expected : ComponentValueType,
+  path : String,
+) -> @runtime_impl.ComponentValue raise ComponentRuntimeError {
+  match (expected, value) {
+    (Bool, Bool(value)) => Bool(value)
+    (S8, S8(value)) =>
+      if value >= -128 && value <= 127 {
+        S8(value)
+      } else {
+        raise TypeMismatch(path~, expected~, actual="out-of-range s8")
+      }
+    (U8, U8(value)) =>
+      if value >= 0 && value <= 255 {
+        U8(value)
+      } else {
+        raise TypeMismatch(path~, expected~, actual="out-of-range u8")
+      }
+    (S16, S16(value)) =>
+      if value >= -32768 && value <= 32767 {
+        S16(value)
+      } else {
+        raise TypeMismatch(path~, expected~, actual="out-of-range s16")
+      }
+    (U16, U16(value)) =>
+      if value >= 0 && value <= 65535 {
+        U16(value)
+      } else {
+        raise TypeMismatch(path~, expected~, actual="out-of-range u16")
+      }
+    (S32, S32(value)) => S32(value)
+    (U32, U32(value)) => U32(value.reinterpret_as_int())
+    (S64, S64(value)) => S64(value)
+    (U64, U64(value)) => U64(value.reinterpret_as_int64())
+    (F32, F32(value)) => F32(value)
+    (F64, F64(value)) => F64(value)
+    (Char, Char(value)) => Char(value)
+    (String, String(value)) => String(value)
+    (ErrorContext, ErrorContext(value)) => ErrorContext(value)
+    (List(element_type), List(values)) => {
+      let lowered = []
+      for index, element in values {
+        lowered.push(
+          lower_component_value(element, element_type, "\{path}[\{index}]"),
+        )
+      }
+      List(lowered)
+    }
+    (Tuple(element_types), Tuple(values)) => {
+      if element_types.length() != values.length() {
+        raise component_type_mismatch(path, expected, value)
+      }
+      let lowered = []
+      for index in 0..<values.length() {
+        lowered.push(
+          lower_component_value(
+            values[index],
+            element_types[index],
+            "\{path}[\{index}]",
+          ),
+        )
+      }
+      Tuple(lowered)
+    }
+    (Record(field_types), Record(fields)) => {
+      if field_types.length() != fields.length() {
+        raise component_type_mismatch(path, expected, value)
+      }
+      let lowered = []
+      for field in field_types {
+        guard find_component_field(fields, field.name) is Some(field_value) else {
+          raise TypeMismatch(
+            path="\{path}.\{field.name}",
+            expected=field.ty,
+            actual="missing",
+          )
+        }
+        lowered.push(
+          lower_component_value(field_value, field.ty, "\{path}.\{field.name}"),
+        )
+      }
+      Tuple(lowered)
+    }
+    (Variant(cases), Variant(case_name, payload)) => {
+      guard component_case_index(cases, case_name) is Some(index) else {
+        raise component_type_mismatch(path, expected, value)
+      }
+      let expected_payload = cases[index].ty
+      let lowered_payload = match (expected_payload, payload) {
+        (None, None) => None
+        (Some(payload_type), Some(payload)) =>
+          Some(
+            lower_component_value(payload, payload_type, "\{path}.\{case_name}"),
+          )
+        _ => raise component_type_mismatch(path, expected, value)
+      }
+      Variant(index, lowered_payload)
+    }
+    (Enum(labels), Enum(label)) => {
+      guard component_label_index(labels, label) is Some(index) else {
+        raise component_type_mismatch(path, expected, value)
+      }
+      U32(index)
+    }
+    (Flags(labels), Flags(selected)) => {
+      if labels.length() > 64 {
+        raise InvalidContract("flags with more than 64 labels are unsupported")
+      }
+      let mut bits = 0UL
+      for label in selected {
+        guard component_label_index(labels, label) is Some(index) else {
+          raise component_type_mismatch(path, expected, value)
+        }
+        bits = bits | (1UL << index)
+      }
+      if labels.length() <= 32 {
+        U32(bits.to_uint().reinterpret_as_int())
+      } else {
+        U64(bits.reinterpret_as_int64())
+      }
+    }
+    (Option(_), OptionNone) => Variant(0, None)
+    (Option(payload_type), OptionSome(payload)) =>
+      Variant(
+        1,
+        Some(lower_component_value(payload, payload_type, "\{path}.some")),
+      )
+    (Result(ok_type, _), ResultOk(payload)) => {
+      let lowered = match (ok_type, payload) {
+        (None, None) => None
+        (Some(payload_type), Some(payload)) =>
+          Some(lower_component_value(payload, payload_type, "\{path}.ok"))
+        _ => raise component_type_mismatch(path, expected, value)
+      }
+      Variant(0, lowered)
+    }
+    (Result(_, error_type), ResultErr(payload)) => {
+      let lowered = match (error_type, payload) {
+        (None, None) => None
+        (Some(payload_type), Some(payload)) =>
+          Some(lower_component_value(payload, payload_type, "\{path}.err"))
+        _ => raise component_type_mismatch(path, expected, value)
+      }
+      Variant(1, lowered)
+    }
+    (Own(identity), Resource(resource))
+    | (Borrow(identity), Resource(resource)) =>
+      if resource.type_ == identity {
+        ResourceValue(resource.handle)
+      } else {
+        raise component_type_mismatch(path, expected, value)
+      }
+    (Stream(_), Resource(resource)) =>
+      if resource.type_.identity == "stream" {
+        ResourceValue(resource.handle)
+      } else {
+        raise component_type_mismatch(path, expected, value)
+      }
+    (Future(_), Resource(resource)) =>
+      if resource.type_.identity == "future" {
+        ResourceValue(resource.handle)
+      } else {
+        raise component_type_mismatch(path, expected, value)
+      }
+    _ => raise component_type_mismatch(path, expected, value)
+  }
+}
+
+///|
+fn lift_component_value(
+  value : @runtime_impl.ComponentValue,
+  expected : ComponentValueType,
+  path : String,
+) -> ComponentValue raise ComponentRuntimeError {
+  match (expected, value) {
+    (Bool, Bool(value)) => Bool(value)
+    (S8, S8(value)) => S8(value)
+    (U8, U8(value)) => U8(value)
+    (S16, S16(value)) => S16(value)
+    (U16, U16(value)) => U16(value)
+    (S32, S32(value)) => S32(value)
+    (U32, U32(value)) => U32(value.reinterpret_as_uint())
+    (S64, S64(value)) => S64(value)
+    (U64, U64(value)) => U64(value.reinterpret_as_uint64())
+    (F32, F32(value)) => F32(value)
+    (F64, F64(value)) => F64(value)
+    (Char, Char(value)) => Char(value)
+    (String, String(value)) => String(value)
+    (ErrorContext, ErrorContext(value)) => ErrorContext(value)
+    (List(element_type), List(values)) => {
+      let lifted = []
+      for index, element in values {
+        lifted.push(
+          lift_component_value(element, element_type, "\{path}[\{index}]"),
+        )
+      }
+      List(lifted)
+    }
+    (Tuple(element_types), Tuple(values)) => {
+      if element_types.length() != values.length() {
+        raise InvocationFailed(
+          "component returned a malformed tuple at \{path}",
+        )
+      }
+      let lifted = []
+      for index in 0..<values.length() {
+        lifted.push(
+          lift_component_value(
+            values[index],
+            element_types[index],
+            "\{path}[\{index}]",
+          ),
+        )
+      }
+      Tuple(lifted)
+    }
+    (Record(field_types), Tuple(values)) => {
+      if field_types.length() != values.length() {
+        raise InvocationFailed(
+          "component returned a malformed record at \{path}",
+        )
+      }
+      let lifted = []
+      for index in 0..<values.length() {
+        lifted.push(
+          (
+            field_types[index].name,
+            lift_component_value(
+              values[index],
+              field_types[index].ty,
+              "\{path}.\{field_types[index].name}",
+            ),
+          ),
+        )
+      }
+      Record(lifted)
+    }
+    (Variant(cases), Variant(index, payload)) => {
+      guard index >= 0 && cases.get(index) is Some(case) else {
+        raise InvocationFailed(
+          "component returned an unknown variant tag at \{path}",
+        )
+      }
+      let lifted_payload = match (case.ty, payload) {
+        (None, None) => None
+        (Some(payload_type), Some(payload)) =>
+          Some(
+            lift_component_value(payload, payload_type, "\{path}.\{case.name}"),
+          )
+        _ =>
+          raise InvocationFailed(
+            "component returned a malformed variant payload at \{path}",
+          )
+      }
+      Variant(case.name, lifted_payload)
+    }
+    (Enum(labels), U32(index)) => {
+      guard index >= 0 && labels.get(index) is Some(label) else {
+        raise InvocationFailed(
+          "component returned an unknown enum tag at \{path}",
+        )
+      }
+      Enum(label)
+    }
+    (Flags(labels), U32(raw)) => {
+      let bits = raw.reinterpret_as_uint().to_uint64()
+      let selected = []
+      for index, label in labels {
+        if (bits & (1UL << index)) != 0UL {
+          selected.push(label)
+        }
+      }
+      Flags(selected)
+    }
+    (Flags(labels), U64(raw)) => {
+      let bits = raw.reinterpret_as_uint64()
+      let selected = []
+      for index, label in labels {
+        if (bits & (1UL << index)) != 0UL {
+          selected.push(label)
+        }
+      }
+      Flags(selected)
+    }
+    (Option(_), Variant(0, None)) => OptionNone
+    (Option(payload_type), Variant(1, Some(payload))) =>
+      OptionSome(lift_component_value(payload, payload_type, "\{path}.some"))
+    (Result(ok_type, _), Variant(0, payload)) =>
+      ResultOk(
+        match (ok_type, payload) {
+          (None, None) => None
+          (Some(payload_type), Some(payload)) =>
+            Some(lift_component_value(payload, payload_type, "\{path}.ok"))
+          _ =>
+            raise InvocationFailed(
+              "component returned a malformed result.ok at \{path}",
+            )
+        },
+      )
+    (Result(_, error_type), Variant(1, payload)) =>
+      ResultErr(
+        match (error_type, payload) {
+          (None, None) => None
+          (Some(payload_type), Some(payload)) =>
+            Some(lift_component_value(payload, payload_type, "\{path}.err"))
+          _ =>
+            raise InvocationFailed(
+              "component returned a malformed result.err at \{path}",
+            )
+        },
+      )
+    (Own(identity), ResourceValue(handle))
+    | (Borrow(identity), ResourceValue(handle)) =>
+      Resource({ handle, type_: identity })
+    (Stream(_), ResourceValue(handle)) =>
+      Resource({ handle, type_: { identity: "stream" } })
+    (Future(_), ResourceValue(handle)) =>
+      Resource({ handle, type_: { identity: "future" } })
+    _ =>
+      raise InvocationFailed(
+        "component returned a value incompatible with \{to_repr(expected)} at \{path}",
+      )
+  }
+}
+
+///|
+pub fn ComponentFunction::call(
+  self : ComponentFunction,
+  args : Array[ComponentValue],
+) -> Array[ComponentValue] raise ComponentRuntimeError {
+  if args.length() != self.public_type.params.length() {
+    raise ArgumentCountMismatch(
+      expected=self.public_type.params.length(),
+      actual=args.length(),
+    )
+  }
+  let lowered = []
+  for index in 0..<args.length() {
+    lowered.push(
+      lower_component_value(
+        args[index],
+        self.public_type.params[index].ty,
+        "argument[\{index}]",
+      ),
+    )
+  }
+  let raw_results = self.instance.call_exported_func(self.name, lowered) catch {
+    error => raise InvocationFailed(error.to_string())
+  }
+  match self.public_type.result {
+    None =>
+      if raw_results.length() == 0 {
+        []
+      } else {
+        raise InvocationFailed(
+          "component returned \{raw_results.length()} values for a function with no result",
+        )
+      }
+    Some(result_type) =>
+      if raw_results.length() == 1 {
+        [lift_component_value(raw_results[0], result_type, "result")]
+      } else {
+        raise InvocationFailed(
+          "component returned \{raw_results.length()} values for a single-result function",
+        )
+      }
+  }
+}
+
+///|
+fn component_json_integer_text(json : Json) -> String? {
+  match json {
+    Number(number, repr~) => Some(repr.unwrap_or_else(() => number.to_string()))
+    String(value) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn component_json_signed(
+  json : Json,
+  min : Int64,
+  max : Int64,
+  expected : String,
+) -> Int64 raise ComponentRuntimeError {
+  guard component_json_integer_text(json) is Some(text) else {
+    raise JsonValueError("expected \{expected} integer")
+  }
+  let value = @string.parse_int64(text) catch {
+    _ => raise JsonValueError("invalid \{expected} integer '\{text}'")
+  }
+  if value < min || value > max {
+    raise JsonValueError("\{expected} integer is out of range")
+  }
+  value
+}
+
+///|
+fn component_json_unsigned(
+  json : Json,
+  max : UInt64,
+  expected : String,
+) -> UInt64 raise ComponentRuntimeError {
+  guard component_json_integer_text(json) is Some(text) else {
+    raise JsonValueError("expected \{expected} integer")
+  }
+  let value = @string.parse_uint64(text) catch {
+    _ => raise JsonValueError("invalid \{expected} integer '\{text}'")
+  }
+  if value > max {
+    raise JsonValueError("\{expected} integer is out of range")
+  }
+  value
+}
+
+///|
+fn component_json_float(
+  json : Json,
+  expected : String,
+) -> Double raise ComponentRuntimeError {
+  match json {
+    Number(value, ..) => value
+    String(value) =>
+      match value {
+        "nan" => 0.0 / 0.0
+        "inf" => 1.0 / 0.0
+        "-inf" => -1.0 / 0.0
+        _ =>
+          @string.parse_double(value) catch {
+            _ => raise JsonValueError("invalid \{expected} value '\{value}'")
+          }
+      }
+    _ => raise JsonValueError("expected \{expected} number")
+  }
+}
+
+///|
+fn component_json_single_char(json : Json) -> Char raise ComponentRuntimeError {
+  guard json is String(value) else {
+    raise JsonValueError("expected char string")
+  }
+  let mut result : Char? = None
+  for char in value {
+    if result is Some(_) {
+      raise JsonValueError("expected exactly one Unicode scalar value")
+    }
+    result = Some(char)
+  }
+  result.unwrap_or_else(() => {
+    raise JsonValueError("expected exactly one Unicode scalar value")
+  })
+}
+
+///|
+fn component_json_payload(
+  object : Map[String, Json],
+  label : String,
+  payload_type : ComponentValueType?,
+) -> ComponentValue? raise ComponentRuntimeError {
+  match (payload_type, object.get("value")) {
+    (None, None) => None
+    (None, Some(Null)) => None
+    (Some(payload_type), Some(payload)) =>
+      Some(component_value_from_json(payload, payload_type))
+    (None, Some(_)) =>
+      raise JsonValueError("\{label} does not accept a payload")
+    (Some(_), None) => raise JsonValueError("\{label} requires a payload")
+  }
+}
+
+///|
+pub fn component_value_from_json(
+  json : Json,
+  expected : ComponentValueType,
+) -> ComponentValue raise ComponentRuntimeError {
+  match expected {
+    Bool =>
+      match json {
+        True => Bool(true)
+        False => Bool(false)
+        _ => raise JsonValueError("expected bool")
+      }
+    S8 => S8(component_json_signed(json, -128L, 127L, "s8").to_int())
+    U8 => U8(component_json_unsigned(json, 255UL, "u8").to_int())
+    S16 => S16(component_json_signed(json, -32768L, 32767L, "s16").to_int())
+    U16 => U16(component_json_unsigned(json, 65535UL, "u16").to_int())
+    S32 =>
+      S32(
+        component_json_signed(json, -2147483648L, 2147483647L, "s32").to_int(),
+      )
+    U32 => U32(component_json_unsigned(json, 4294967295UL, "u32").to_uint())
+    S64 =>
+      S64(
+        component_json_signed(
+          json,
+          -9223372036854775807L - 1L,
+          9223372036854775807L,
+          "s64",
+        ),
+      )
+    U64 => U64(component_json_unsigned(json, 18446744073709551615UL, "u64"))
+    F32 => F32(Float::from_double(component_json_float(json, "f32")))
+    F64 => F64(component_json_float(json, "f64"))
+    Char => Char(component_json_single_char(json))
+    String =>
+      match json {
+        String(value) => String(value)
+        _ => raise JsonValueError("expected string")
+      }
+    ErrorContext =>
+      match json {
+        String(value) => ErrorContext(value)
+        _ => raise JsonValueError("expected error-context string")
+      }
+    List(element_type) =>
+      match json {
+        Array(items) => {
+          let values = []
+          for item in items {
+            values.push(component_value_from_json(item, element_type))
+          }
+          List(values)
+        }
+        _ => raise JsonValueError("expected list array")
+      }
+    Tuple(element_types) =>
+      match json {
+        Array(items) => {
+          if items.length() != element_types.length() {
+            raise JsonValueError("tuple length mismatch")
+          }
+          let values = []
+          for index in 0..<items.length() {
+            values.push(
+              component_value_from_json(items[index], element_types[index]),
+            )
+          }
+          Tuple(values)
+        }
+        _ => raise JsonValueError("expected tuple array")
+      }
+    Record(field_types) =>
+      match json {
+        Object(object) => {
+          if object.length() != field_types.length() {
+            raise JsonValueError("record field count mismatch")
+          }
+          let fields = []
+          for field in field_types {
+            guard object.get(field.name) is Some(value) else {
+              raise JsonValueError("missing record field '\{field.name}'")
+            }
+            fields.push(
+              (field.name, component_value_from_json(value, field.ty)),
+            )
+          }
+          Record(fields)
+        }
+        _ => raise JsonValueError("expected record object")
+      }
+    Variant(cases) =>
+      match json {
+        Object(object) => {
+          guard object.get("case") is Some(String(case_name)) else {
+            raise JsonValueError("variant requires a string 'case'")
+          }
+          guard component_case_index(cases, case_name) is Some(index) else {
+            raise JsonValueError("unknown variant case '\{case_name}'")
+          }
+          Variant(
+            case_name,
+            component_json_payload(object, "variant case", cases[index].ty),
+          )
+        }
+        _ => raise JsonValueError("expected variant object")
+      }
+    Enum(labels) =>
+      match json {
+        String(label) =>
+          if component_label_index(labels, label) is Some(_) {
+            Enum(label)
+          } else {
+            raise JsonValueError("unknown enum case '\{label}'")
+          }
+        _ => raise JsonValueError("expected enum case string")
+      }
+    Flags(labels) =>
+      match json {
+        Array(items) => {
+          let selected = []
+          for item in items {
+            guard item is String(label) else {
+              raise JsonValueError("expected flag name string")
+            }
+            if component_label_index(labels, label) is None {
+              raise JsonValueError("unknown flag '\{label}'")
+            }
+            selected.push(label)
+          }
+          Flags(selected)
+        }
+        _ => raise JsonValueError("expected flags array")
+      }
+    Option(payload_type) =>
+      match json {
+        Null => OptionNone
+        Object(object) =>
+          match object.get("some") {
+            Some(payload) =>
+              OptionSome(component_value_from_json(payload, payload_type))
+            None => raise JsonValueError("option object requires 'some'")
+          }
+        _ => OptionSome(component_value_from_json(json, payload_type))
+      }
+    Result(ok_type, error_type) =>
+      match json {
+        Object(object) =>
+          match (object.get("ok"), object.get("err")) {
+            (Some(payload), None) =>
+              ResultOk(
+                match ok_type {
+                  None =>
+                    if payload is Null {
+                      None
+                    } else {
+                      raise JsonValueError("result.ok has no payload")
+                    }
+                  Some(payload_type) =>
+                    Some(component_value_from_json(payload, payload_type))
+                },
+              )
+            (None, Some(payload)) =>
+              ResultErr(
+                match error_type {
+                  None =>
+                    if payload is Null {
+                      None
+                    } else {
+                      raise JsonValueError("result.err has no payload")
+                    }
+                  Some(payload_type) =>
+                    Some(component_value_from_json(payload, payload_type))
+                },
+              )
+            _ =>
+              raise JsonValueError(
+                "result object requires exactly one of 'ok' or 'err'",
+              )
+          }
+        _ => raise JsonValueError("expected result object")
+      }
+    Own(_) | Borrow(_) | Stream(_) | Future(_) =>
+      raise JsonValueError("resource values cannot be created from JSON")
+  }
+}
+
+///|
+pub fn parse_component_value_json(
+  text : String,
+  expected : ComponentValueType,
+) -> ComponentValue raise ComponentRuntimeError {
+  let json = @json.parse(text) catch {
+    error => raise JsonValueError(error.to_string())
+  }
+  component_value_from_json(json, expected)
+}
+
+///|
+fn component_optional_json(value : ComponentValue?) -> Json {
+  match value {
+    Some(value) => component_value_to_json(value)
+    None => Json::null()
+  }
+}
+
+///|
+fn component_float_to_json(value : Double) -> Json {
+  if value.is_nan() {
+    Json::string("nan")
+  } else if value == 1.0 / 0.0 {
+    Json::string("inf")
+  } else if value == -1.0 / 0.0 {
+    Json::string("-inf")
+  } else {
+    Json::number(value)
+  }
+}
+
+///|
+pub fn component_value_to_json(value : ComponentValue) -> Json {
+  match value {
+    Bool(value) => Json::boolean(value)
+    S8(value) | U8(value) | S16(value) | U16(value) | S32(value) =>
+      Json::number(value.to_double(), repr=value.to_string())
+    U32(value) => Json::number(value.to_double(), repr=value.to_string())
+    S64(value) => Json::number(value.to_double(), repr=value.to_string())
+    U64(value) => Json::number(value.to_double(), repr=value.to_string())
+    F32(value) => component_float_to_json(value.to_double())
+    F64(value) => component_float_to_json(value)
+    Char(value) => Json::string(value.to_string())
+    String(value) | ErrorContext(value) => Json::string(value)
+    List(values) | Tuple(values) => {
+      let items = []
+      for value in values {
+        items.push(component_value_to_json(value))
+      }
+      Json::array(items)
+    }
+    Record(fields) => {
+      let object : Map[String, Json] = Map([])
+      for field in fields {
+        object.set(field.0, component_value_to_json(field.1))
+      }
+      Json::object(object)
+    }
+    Variant(case_name, payload) => {
+      let object : Map[String, Json] = Map([])
+      object.set("case", Json::string(case_name))
+      if payload is Some(payload) {
+        object.set("value", component_value_to_json(payload))
+      }
+      Json::object(object)
+    }
+    Enum(label) => Json::string(label)
+    Flags(labels) => {
+      let items = []
+      for label in labels {
+        items.push(Json::string(label))
+      }
+      Json::array(items)
+    }
+    OptionNone => Json::null()
+    OptionSome(payload) => {
+      let object : Map[String, Json] = Map([])
+      object.set("some", component_value_to_json(payload))
+      Json::object(object)
+    }
+    ResultOk(payload) => {
+      let object : Map[String, Json] = Map([])
+      object.set("ok", component_optional_json(payload))
+      Json::object(object)
+    }
+    ResultErr(payload) => {
+      let object : Map[String, Json] = Map([])
+      object.set("err", component_optional_json(payload))
+      Json::object(object)
+    }
+    Resource(resource) => {
+      let object : Map[String, Json] = Map([])
+      object.set("resource-type", Json::string(resource.type_.identity))
+      object.set(
+        "handle",
+        Json::number(
+          resource.handle.to_double(),
+          repr=resource.handle.to_string(),
+        ),
+      )
+      Json::object(object)
+    }
+  }
+}
+
+///|
+pub fn component_values_to_json(values : Array[ComponentValue]) -> Json {
+  let items = []
+  for value in values {
+    items.push(component_value_to_json(value))
+  }
+  Json::array(items)
+}

--- a/modules/wasmoon/component/runtime_impl/moon.pkg
+++ b/modules/wasmoon/component/runtime_impl/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "Milky2018/wasmoon/component",
+  "Milky2018/wasmoon/component/model" @component,
   "Milky2018/wasmoon/executor",
   "Milky2018/wasmoon/parser",
   "Milky2018/wasmoon/runtime",

--- a/modules/wasmoon/testsuite/component_runtime_facade_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_facade_test.mbt
@@ -1,0 +1,279 @@
+///|
+fn component_runtime_facade_fixture() -> Bytes raise @component_text.ComponentTextError {
+  @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (core module $m
+      #|    (func (export "increment") (param i32) (result i32)
+      #|      local.get 0
+      #|      i32.const 1
+      #|      i32.add))
+      #|  (core instance $i (instantiate $m))
+      #|  (func $increment (param "value" u32) (result u32)
+      #|    (canon lift (core func $i "increment")))
+      #|  (instance $math (export "increment" (func $increment)))
+      #|  (export "increment" (func $increment))
+      #|  (export "math" (instance $math))
+      #|  (export "dep:math/math@1.0.0" (instance $math)))
+      #|
+    ),
+  )
+}
+
+///|
+test "component runtime facade binds and invokes nested exports" {
+  let instance = @component.ComponentRuntime().instantiate(
+    "fixture",
+    component_runtime_facade_fixture(),
+  )
+  let function = instance.bind("math#increment")
+  debug_inspect(
+    function.type_(),
+    content=(
+      #|{
+      #|  is_async: false,
+      #|  params: [{ name: "value", ty: U32 }],
+      #|  result: Some(U32),
+      #|}
+    ),
+  )
+  debug_inspect(
+    function.call([U32(41U)]),
+    content=(
+      #|[U32(42)]
+    ),
+  )
+}
+
+///|
+test "component runtime facade reports stable path and arity errors" {
+  let instance = @component.ComponentRuntime().instantiate(
+    "fixture",
+    component_runtime_facade_fixture(),
+  )
+  inspect(
+    try instance.bind("math#missing") catch {
+      error => error
+    } noraise {
+      _ => fail("expected unknown export")
+    },
+    content=(
+      #|UnknownExport("math#missing")
+    ),
+  )
+  let function = instance.bind("math#increment")
+  inspect(
+    try function.call([]) catch {
+      error => error
+    } noraise {
+      _ => fail("expected argument count mismatch")
+    },
+    content=(
+      #|ArgumentCountMismatch(expected=1, actual=0)
+    ),
+  )
+}
+
+///|
+test "component runtime facade preserves WIT-shaped JSON values" {
+  let ty = @component.ComponentValueType::Record([
+    ComponentField("items", List(Option(U32))),
+    ComponentField(
+      "state",
+      Variant([
+        ComponentCase("ready", Some(String)),
+        ComponentCase("closed", None),
+      ]),
+    ),
+    ComponentField("permissions", Flags(["read", "write"])),
+  ])
+  let value = @component.parse_component_value_json(
+    (
+      #|{"items":[{"some":7},null],"state":{"case":"ready","value":"ok"},"permissions":["read"]}
+    ),
+    ty,
+  )
+  debug_inspect(
+    value,
+    content=(
+      #|Record(
+      #|  [
+      #|    ("items", List([OptionSome(U32(7)), OptionNone])),
+      #|    ("state", Variant("ready", Some(String("ok")))),
+      #|    ("permissions", Flags(["read"])),
+      #|  ],
+      #|)
+    ),
+  )
+  inspect(
+    @component.component_value_to_json(value).stringify(),
+    content=(
+      #|{"items":[{"some":7},null],"state":{"case":"ready","value":"ok"},"permissions":["read"]}
+    ),
+  )
+}
+
+///|
+test "component runtime facade rejects malformed JSON before invocation" {
+  inspect(
+    try
+      @component.parse_component_value_json(
+        "{\"wrong\":1}",
+        Record([ComponentField("expected", U32)]),
+      )
+    catch {
+      error => error
+    } noraise {
+      _ => fail("expected record validation failure")
+    },
+    content=(
+      #|JsonValueError("missing record field 'expected'")
+    ),
+  )
+}
+
+///|
+test "component JSON preserves non-finite floating-point values" {
+  inspect(
+    @component.component_values_to_json([
+      F64(0.0 / 0.0),
+      F64(1.0 / 0.0),
+      F32(Float::from_double(-1.0 / 0.0)),
+    ]).stringify(),
+    content=(
+      #|["nan","inf","-inf"]
+    ),
+  )
+  debug_inspect(
+    [
+      @component.parse_component_value_json("\"nan\"", F64),
+      @component.parse_component_value_json("\"inf\"", F32),
+    ],
+    content=(
+      #|[F64(NaN), F32(Infinity)]
+    ),
+  )
+}
+
+///|
+test "resolved WIT world binds and invokes a typed interface export" {
+  let instance = @component.ComponentRuntime().instantiate(
+    "fixture",
+    component_runtime_facade_fixture(),
+  )
+  let wit_package = @wit.parse_package(
+    (
+      #|package test:demo;
+      #|
+      #|interface math {
+      #|  increment: func(value: u32) -> u32;
+      #|}
+      #|
+      #|world demo {
+      #|  export math;
+      #|}
+      #|
+    ),
+  )
+  let bindings = @wit.resolve_package(wit_package, []).bind_world(
+    "demo", instance,
+  )
+  debug_inspect(bindings.paths(), content="[\"math#increment\"]")
+  debug_inspect(
+    bindings.function("math#increment").call([U32(9U)]),
+    content=(
+      #|[U32(10)]
+    ),
+  )
+}
+
+///|
+test "WIT binding rejects a mismatched export before invocation" {
+  let instance = @component.ComponentRuntime().instantiate(
+    "fixture",
+    component_runtime_facade_fixture(),
+  )
+  let wit_package = @wit.parse_package(
+    (
+      #|package test:demo;
+      #|
+      #|interface math {
+      #|  increment: func(value: u32) -> string;
+      #|}
+      #|
+      #|world demo {
+      #|  export math;
+      #|}
+      #|
+    ),
+  )
+  inspect(
+    try
+      @wit.resolve_package(wit_package, []).bind_world("demo", instance)
+    catch {
+      error => error
+    } noraise {
+      _ => fail("expected binding type mismatch")
+    },
+    content=(
+      #|RuntimeBindingFailed("BindingTypeMismatch(\n  path=\"math#increment\",\n  expected={\n    is_async: false,\n    params: [{ name: \"value\", ty: U32 }],\n    result: Some(String),\n  },\n  actual={\n    is_async: false,\n    params: [{ name: \"value\", ty: U32 }],\n    result: Some(U32),\n  },\n)")
+    ),
+  )
+}
+
+///|
+test "WIT binding covers direct and inline world exports" {
+  let instance = @component.ComponentRuntime().instantiate(
+    "fixture",
+    component_runtime_facade_fixture(),
+  )
+  let wit_package = @wit.parse_package(
+    (
+      #|package test:demo;
+      #|
+      #|world demo {
+      #|  export increment: func(value: u32) -> u32;
+      #|  export math: interface {
+      #|    increment: func(value: u32) -> u32;
+      #|  }
+      #|}
+      #|
+    ),
+  )
+  let bindings = @wit.resolve_package(wit_package, []).bind_world(
+    "demo", instance,
+  )
+  debug_inspect(bindings.paths(), content="[\"increment\", \"math#increment\"]")
+}
+
+///|
+test "WIT binding resolves referenced dependency interfaces" {
+  let instance = @component.ComponentRuntime().instantiate(
+    "fixture",
+    component_runtime_facade_fixture(),
+  )
+  let root = @wit.parse_package(
+    (
+      #|package test:demo;
+      #|
+      #|world demo {
+      #|  export dep:math/math@1.0.0;
+      #|}
+      #|
+    ),
+  )
+  let dependency = @wit.parse_package(
+    (
+      #|package dep:math@1.0.0;
+      #|
+      #|interface math {
+      #|  increment: func(value: u32) -> u32;
+      #|}
+      #|
+    ),
+  )
+  let bindings = @wit.resolve_package(root, [dependency]).bind_world(
+    "demo", instance,
+  )
+  debug_inspect(bindings.paths(), content="[\"dep:math/math@1.0.0#increment\"]")
+}

--- a/modules/wasmoon/testsuite/moon.pkg
+++ b/modules/wasmoon/testsuite/moon.pkg
@@ -21,6 +21,7 @@ import {
   "Milky2018/wasm_core/encoder",
   "Milky2018/wasmoon",
   "Milky2018/wasmoon/component",
+  "Milky2018/wasmoon/component/text_parser" @component_text,
   "Milky2018/wasmoon/component/runtime_impl",
   "Milky2018/wasmoon/validator/component_model",
   "Milky2018/wasmoon/wit",

--- a/modules/wasmoon/validator/component_model/moon.pkg
+++ b/modules/wasmoon/validator/component_model/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "Milky2018/wasmoon/component",
+  "Milky2018/wasmoon/component/model" @component,
   "Milky2018/wasmoon/parser",
   "Milky2018/wasm_core/types",
   "Milky2018/wasmoon/validator",

--- a/modules/wasmoon/wit/pkg.generated.mbti
+++ b/modules/wasmoon/wit/pkg.generated.mbti
@@ -1,6 +1,11 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "Milky2018/wasmoon/wit"
 
+import {
+  "Milky2018/wasmoon/component",
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn decode_wit_package_from_component(Bytes) -> Package raise WitError
 
@@ -27,6 +32,18 @@ pub fn parse_package(String) -> Package raise WitError
 pub fn resolve_package(Package, Array[Package]) -> ResolveResult raise WitError
 
 // Errors
+pub(all) suberror WitBindingError {
+  UnknownWorld(String)
+  UnknownInterface(String)
+  UnknownType(String)
+  RecursiveType(String)
+  InvalidType(String)
+  DuplicateFunction(String)
+  MissingFunction(String)
+  RuntimeBindingFailed(String)
+} derive(Eq, @debug.Debug)
+pub impl Show for WitBindingError
+
 pub(all) suberror WitError {
   Error(String)
 }
@@ -91,6 +108,7 @@ pub(all) struct ResolveResult {
   root : Package
   deps : Array[Package]
 }
+pub fn ResolveResult::bind_world(Self, String, @component.ComponentInstance) -> WitBindings raise WitBindingError
 
 pub(all) struct ResourceDecl {
   name : String
@@ -183,6 +201,10 @@ pub(all) struct VariantDecl {
   name : String
   cases : Array[VariantCase]
 }
+
+type WitBindings
+pub fn WitBindings::function(Self, String) -> @component.ComponentFunction raise WitBindingError
+pub fn WitBindings::paths(Self) -> Array[String]
 
 pub(all) struct World {
   name : String

--- a/modules/wasmoon/wit/runtime_bindings.mbt
+++ b/modules/wasmoon/wit/runtime_bindings.mbt
@@ -1,0 +1,566 @@
+///|
+/// Checked dynamic bindings from resolved WIT worlds to component instances.
+///
+/// This is the stable foundation for generated bindings: WIT names and type
+/// declarations are resolved once, every exported function is checked against
+/// the instantiated component, and callers receive the component facade's
+/// typed functions and WIT-semantic values.
+
+///|
+pub(all) suberror WitBindingError {
+  UnknownWorld(String)
+  UnknownInterface(String)
+  UnknownType(String)
+  RecursiveType(String)
+  InvalidType(String)
+  DuplicateFunction(String)
+  MissingFunction(String)
+  RuntimeBindingFailed(String)
+} derive(Debug, Eq)
+
+///|
+pub impl Show for WitBindingError with fn output(self, logger) {
+  logger.write_string(to_repr(self).to_string())
+}
+
+///|
+priv enum WitBindingTypeDecl {
+  Alias(TypeExpr)
+  RecordType(RecordDecl)
+  VariantType(VariantDecl)
+  FlagsType(FlagsDecl)
+  EnumType(EnumDecl)
+  ResourceType
+  ResolvedType(@component.ComponentValueType)
+}
+
+///|
+priv struct WitBindingScope {
+  declarations : Map[String, WitBindingTypeDecl]
+}
+
+///|
+struct WitBindings {
+  functions : Map[String, @component.ComponentFunction]
+  ordered_paths : Array[String]
+}
+
+///|
+pub fn WitBindings::paths(self : WitBindings) -> Array[String] {
+  self.ordered_paths.copy()
+}
+
+///|
+pub fn WitBindings::function(
+  self : WitBindings,
+  path : String,
+) -> @component.ComponentFunction raise WitBindingError {
+  self.functions.get(path).unwrap_or_else(() => raise MissingFunction(path))
+}
+
+///|
+fn wit_binding_packages(result : ResolveResult) -> Array[Package] {
+  [result.root] + result.deps
+}
+
+///|
+fn wit_package_interface_path(
+  pkg : Package,
+  interface_name : String,
+) -> String? {
+  guard pkg.name is Some(package_name) else { return None }
+  let base = "\{package_name}/\{interface_name}"
+  match pkg.version {
+    Some(version) => Some("\{base}@\{version}")
+    None => Some(base)
+  }
+}
+
+///|
+fn wit_interface_matches_path(
+  pkg : Package,
+  interface : Interface,
+  path : String,
+) -> Bool {
+  if path == interface.name {
+    return true
+  }
+  match wit_package_interface_path(pkg, interface.name) {
+    Some(full_path) =>
+      path == full_path ||
+      path == full_path.split("@").next().unwrap_or("").to_owned()
+    None => false
+  }
+}
+
+///|
+fn wit_find_interface(
+  result : ResolveResult,
+  path : String,
+) -> Interface raise WitBindingError {
+  for pkg in wit_binding_packages(result) {
+    for item in pkg.items {
+      if item is Interface(interface) &&
+        wit_interface_matches_path(pkg, interface, path) {
+        return interface
+      }
+    }
+  }
+  raise UnknownInterface(path)
+}
+
+///|
+fn wit_scope_add_interface_declarations(
+  scope : WitBindingScope,
+  interface : Interface,
+) -> Unit {
+  for item in interface.items {
+    match item {
+      TypeAlias(declaration) =>
+        scope.declarations.set(declaration.name, Alias(declaration.ty))
+      Record(declaration) =>
+        scope.declarations.set(declaration.name, RecordType(declaration))
+      Variant(declaration) =>
+        scope.declarations.set(declaration.name, VariantType(declaration))
+      Flags(declaration) =>
+        scope.declarations.set(declaration.name, FlagsType(declaration))
+      Enum(declaration) =>
+        scope.declarations.set(declaration.name, EnumType(declaration))
+      Resource(declaration) =>
+        scope.declarations.set(declaration.name, ResourceType)
+      Func(_) | Use(_) => ()
+    }
+  }
+}
+
+///|
+fn wit_scope_add_world_declarations(
+  scope : WitBindingScope,
+  world : World,
+) -> Unit {
+  for item in world.items {
+    match item {
+      TypeAlias(declaration) =>
+        scope.declarations.set(declaration.name, Alias(declaration.ty))
+      Record(declaration) =>
+        scope.declarations.set(declaration.name, RecordType(declaration))
+      Variant(declaration) =>
+        scope.declarations.set(declaration.name, VariantType(declaration))
+      Flags(declaration) =>
+        scope.declarations.set(declaration.name, FlagsType(declaration))
+      Enum(declaration) =>
+        scope.declarations.set(declaration.name, EnumType(declaration))
+      Resource(declaration) =>
+        scope.declarations.set(declaration.name, ResourceType)
+      _ => ()
+    }
+  }
+}
+
+///|
+fn wit_primitive_type(name : String) -> @component.ComponentValueType? {
+  match name {
+    "bool" => Some(Bool)
+    "s8" => Some(S8)
+    "u8" => Some(U8)
+    "s16" => Some(S16)
+    "u16" => Some(U16)
+    "s32" => Some(S32)
+    "u32" => Some(U32)
+    "s64" => Some(S64)
+    "u64" => Some(U64)
+    "f32" => Some(F32)
+    "f64" => Some(F64)
+    "char" => Some(Char)
+    "string" => Some(String)
+    "error-context" => Some(ErrorContext)
+    _ => None
+  }
+}
+
+///|
+fn wit_resolve_named_type(
+  name : String,
+  scope : WitBindingScope,
+  resolving : Map[String, Bool],
+) -> @component.ComponentValueType raise WitBindingError {
+  if wit_primitive_type(name) is Some(primitive) {
+    return primitive
+  }
+  if resolving.get(name) is Some(true) {
+    raise RecursiveType(name)
+  }
+  guard scope.declarations.get(name) is Some(declaration) else {
+    raise UnknownType(name)
+  }
+  resolving.set(name, true)
+  let resolved = match declaration {
+    Alias(expression) => wit_resolve_type(expression, scope, resolving)
+    RecordType(record) => {
+      let fields = []
+      for field in record.fields {
+        fields.push(
+          @component.ComponentField(
+            field.0,
+            wit_resolve_type(field.1, scope, resolving),
+          ),
+        )
+      }
+      Record(fields)
+    }
+    VariantType(variant) => {
+      let cases = []
+      for case in variant.cases {
+        cases.push(
+          @component.ComponentCase(
+            case.name,
+            match case.payload {
+              Some(payload) => Some(wit_resolve_type(payload, scope, resolving))
+              None => None
+            },
+          ),
+        )
+      }
+      Variant(cases)
+    }
+    FlagsType(flags) => Flags(flags.flags)
+    EnumType(enum_) => Enum(enum_.cases)
+    ResourceType => Own(@component.ComponentResourceType::named(name))
+    ResolvedType(type_) => type_
+  }
+  resolving.set(name, false)
+  resolved
+}
+
+///|
+fn wit_resource_identity(
+  expression : TypeExpr,
+  scope : WitBindingScope,
+  resolving : Map[String, Bool],
+) -> @component.ComponentResourceType raise WitBindingError {
+  match expression {
+    Id(name) =>
+      match scope.declarations.get(name) {
+        Some(ResourceType) => @component.ComponentResourceType::named(name)
+        Some(Alias(alias_expr)) =>
+          wit_resource_identity(alias_expr, scope, resolving)
+        Some(ResolvedType(Own(identity)))
+        | Some(ResolvedType(Borrow(identity))) => identity
+        _ => raise InvalidType("'\{name}' is not a resource type")
+      }
+    _ => raise InvalidType("resource handle requires a named resource type")
+  }
+}
+
+///|
+fn wit_resolve_optional_type(
+  expression : TypeExpr,
+  scope : WitBindingScope,
+  resolving : Map[String, Bool],
+) -> @component.ComponentValueType? raise WitBindingError {
+  if expression is Id("_") {
+    None
+  } else {
+    Some(wit_resolve_type(expression, scope, resolving))
+  }
+}
+
+///|
+fn wit_resolve_type(
+  expression : TypeExpr,
+  scope : WitBindingScope,
+  resolving : Map[String, Bool],
+) -> @component.ComponentValueType raise WitBindingError {
+  match expression {
+    Id(name) => wit_resolve_named_type(name, scope, resolving)
+    Record(fields) => {
+      let resolved = []
+      for field in fields {
+        resolved.push(
+          @component.ComponentField(
+            field.0,
+            wit_resolve_type(field.1, scope, resolving),
+          ),
+        )
+      }
+      Record(resolved)
+    }
+    Apply(type_constructor, arguments) =>
+      match type_constructor {
+        "list" =>
+          match arguments {
+            [element] => List(wit_resolve_type(element, scope, resolving))
+            _ => raise InvalidType("list expects one type argument")
+          }
+        "tuple" => {
+          let elements = []
+          for element in arguments {
+            elements.push(wit_resolve_type(element, scope, resolving))
+          }
+          Tuple(elements)
+        }
+        "option" =>
+          match arguments {
+            [payload] => Option(wit_resolve_type(payload, scope, resolving))
+            _ => raise InvalidType("option expects one type argument")
+          }
+        "result" =>
+          match arguments {
+            [] => Result(None, None)
+            [ok] =>
+              Result(wit_resolve_optional_type(ok, scope, resolving), None)
+            [ok, error] =>
+              Result(
+                wit_resolve_optional_type(ok, scope, resolving),
+                wit_resolve_optional_type(error, scope, resolving),
+              )
+            _ => raise InvalidType("result expects at most two type arguments")
+          }
+        "own" =>
+          match arguments {
+            [resource] => Own(wit_resource_identity(resource, scope, resolving))
+            _ => raise InvalidType("own expects one resource type")
+          }
+        "borrow" =>
+          match arguments {
+            [resource] =>
+              Borrow(wit_resource_identity(resource, scope, resolving))
+            _ => raise InvalidType("borrow expects one resource type")
+          }
+        "stream" =>
+          match arguments {
+            [] => Stream(None)
+            [payload] =>
+              Stream(Some(wit_resolve_type(payload, scope, resolving)))
+            _ => raise InvalidType("stream expects zero or one type argument")
+          }
+        "future" =>
+          match arguments {
+            [] => Future(None)
+            [payload] =>
+              Future(Some(wit_resolve_type(payload, scope, resolving)))
+            _ => raise InvalidType("future expects zero or one type argument")
+          }
+        _ => raise InvalidType("unknown type constructor '\{type_constructor}'")
+      }
+  }
+}
+
+///|
+fn wit_func_type(
+  declaration : FuncDecl,
+  scope : WitBindingScope,
+) -> @component.ComponentFuncType raise WitBindingError {
+  let params = []
+  for param in declaration.params {
+    params.push(
+      @component.ComponentParam(
+        param.0,
+        wit_resolve_type(param.1, scope, Map([])),
+      ),
+    )
+  }
+  let result = match declaration.results {
+    [] => None
+    [single] => Some(wit_resolve_type(single.1, scope, Map([])))
+    _ =>
+      raise InvalidType(
+        "function '\{declaration.name}' has more than one result",
+      )
+  }
+  ComponentFuncType(params, result, is_async=declaration.is_async)
+}
+
+///|
+fn wit_resource_method_type(
+  resource : ResourceDecl,
+  declaration : FuncDecl,
+  scope : WitBindingScope,
+) -> @component.ComponentFuncType raise WitBindingError {
+  let params = [
+    @component.ComponentParam(
+      "self",
+      Borrow(@component.ComponentResourceType::named(resource.name)),
+    ),
+  ]
+  for param in declaration.params {
+    params.push(
+      ComponentParam(param.0, wit_resolve_type(param.1, scope, Map([]))),
+    )
+  }
+  let result = match declaration.results {
+    [] => None
+    [single] => Some(wit_resolve_type(single.1, scope, Map([])))
+    _ =>
+      raise InvalidType(
+        "resource method '\{declaration.name}' has more than one result",
+      )
+  }
+  ComponentFuncType(params, result, is_async=declaration.is_async)
+}
+
+///|
+fn wit_import_used_types(
+  result : ResolveResult,
+  scope : WitBindingScope,
+  use_item : UseItem,
+) -> Unit raise WitBindingError {
+  let source = wit_find_interface(result, use_item.path.raw)
+  let source_scope = wit_interface_scope(result, source)
+  for name in use_item.names {
+    let source_name = name.0
+    let local_name = name.1.unwrap_or(source_name)
+    let resolved = wit_resolve_named_type(source_name, source_scope, Map([]))
+    scope.declarations.set(local_name, ResolvedType(resolved))
+  }
+}
+
+///|
+fn wit_interface_scope(
+  result : ResolveResult,
+  interface : Interface,
+) -> WitBindingScope raise WitBindingError {
+  let scope : WitBindingScope = { declarations: Map([]) }
+  wit_scope_add_interface_declarations(scope, interface)
+  for item in interface.items {
+    if item is Use(use_item) {
+      wit_import_used_types(result, scope, use_item)
+    }
+  }
+  scope
+}
+
+///|
+fn wit_world_scope(
+  result : ResolveResult,
+  world : World,
+) -> WitBindingScope raise WitBindingError {
+  let scope : WitBindingScope = { declarations: Map([]) }
+  wit_scope_add_world_declarations(scope, world)
+  for item in world.items {
+    if item is Use(use_item) {
+      wit_import_used_types(result, scope, use_item)
+    }
+  }
+  scope
+}
+
+///|
+fn wit_bind_function(
+  bindings : WitBindings,
+  instance : @component.ComponentInstance,
+  path : String,
+  declaration : FuncDecl,
+  scope : WitBindingScope,
+) -> Unit raise WitBindingError {
+  wit_bind_function_type(
+    bindings,
+    instance,
+    path,
+    wit_func_type(declaration, scope),
+  )
+}
+
+///|
+fn wit_bind_function_type(
+  bindings : WitBindings,
+  instance : @component.ComponentInstance,
+  path : String,
+  expected : @component.ComponentFuncType,
+) -> Unit raise WitBindingError {
+  if bindings.functions.get(path) is Some(_) {
+    raise DuplicateFunction(path)
+  }
+  let function = instance.bind_typed(path, expected) catch {
+    error => raise RuntimeBindingFailed(error.to_string())
+  }
+  bindings.functions.set(path, function)
+  bindings.ordered_paths.push(path)
+}
+
+///|
+fn wit_bind_interface(
+  result : ResolveResult,
+  bindings : WitBindings,
+  instance : @component.ComponentInstance,
+  export_name : String,
+  interface : Interface,
+) -> Unit raise WitBindingError {
+  let scope = wit_interface_scope(result, interface)
+  for item in interface.items {
+    match item {
+      Func(declaration) =>
+        wit_bind_function(
+          bindings,
+          instance,
+          "\{export_name}#\{declaration.name}",
+          declaration,
+          scope,
+        )
+      Resource(resource) =>
+        for resource_method in resource.methods {
+          wit_bind_function_type(
+            bindings,
+            instance,
+            "\{export_name}#\{resource_method.name}",
+            wit_resource_method_type(resource, resource_method, scope),
+          )
+        }
+      _ => ()
+    }
+  }
+}
+
+///|
+fn wit_bind_inline_interface(
+  result : ResolveResult,
+  bindings : WitBindings,
+  instance : @component.ComponentInstance,
+  export_name : String,
+  interface : InlineInterface,
+) -> Unit raise WitBindingError {
+  let materialized : Interface = { name: export_name, items: interface.items }
+  wit_bind_interface(result, bindings, instance, export_name, materialized)
+}
+
+///|
+pub fn ResolveResult::bind_world(
+  self : ResolveResult,
+  world_name : String,
+  instance : @component.ComponentInstance,
+) -> WitBindings raise WitBindingError {
+  let mut selected : World? = None
+  for item in self.root.items {
+    if item is World(world) && world.name == world_name {
+      selected = Some(world)
+      break
+    }
+  }
+  guard selected is Some(world) else { raise UnknownWorld(world_name) }
+  let bindings : WitBindings = { functions: Map([]), ordered_paths: [] }
+  let world_scope = wit_world_scope(self, world)
+  for item in world.items {
+    match item {
+      ExportFunc(declaration) =>
+        wit_bind_function(
+          bindings,
+          instance,
+          declaration.name,
+          declaration,
+          world_scope,
+        )
+      ExportInlineInterface(name, interface) =>
+        wit_bind_inline_interface(self, bindings, instance, name, interface)
+      Export(path) =>
+        wit_bind_interface(
+          self,
+          bindings,
+          instance,
+          path.raw,
+          wit_find_interface(self, path.raw),
+        )
+      _ => ()
+    }
+  }
+  bindings
+}


### PR DESCRIPTION
## Summary

- add `Milky2018/wasmoon/component` as the stable parse, validate, instantiate, bind, and invoke facade without exposing `component/runtime_impl` types
- add WIT-semantic public values, schema-directed JSON codecs, opaque resource identities, and structured runtime errors
- add `wasmoon component --invoke <export[#function]>` with repeated typed JSON `--arg` values and structured text/JSON failures
- add `ResolveResult::bind_world` and checked `WitBindings` for direct, inline, local, and dependency-package interface exports
- invert component model dependencies, document execution policy, and close ISS-286 through ISS-289

## Validation

- `moon info && moon fmt`
- `moon check --target native --warn-list +73` (no new warning 73; 16 pre-existing warning 20 diagnostics)
- `moon test --target native --warn-list +73` (2390/2390)
- `moon test -p Milky2018/wasmoon/testsuite --target native --warn-list +73` (520/520)
- `moon test -p Milky2018/wasmoon/cmd/wasmoon/commands --target native --warn-list +73` (28/28)
- `python3 scripts/audit_module_boundaries.py`
- `git diff --check`

## Stack

This PR is based on #444 because the facade consumes the component execution-engine and continuation work introduced there. At creation time, #444 still has an existing Ubuntu build failure and the derived manifest failure; all component-model matrix jobs on that parent are green.

## Tracking

- ISS-286
- ISS-287
- ISS-288
- ISS-289
