### PR TITLE
Release the core execution engine when a component linker closes

### DIFF
--- a/issues/ISS-366.md
+++ b/issues/ISS-366.md
@@ -1,0 +1,107 @@
+# ISS-366: Release the core execution engine when a component linker closes
+
+## Metadata
+- Type: bug
+- Status: open
+- Priority: 1
+- Labels: component-model, lifecycle, teardown, memory, sanitizers, agent
+- Assignee: unassigned
+- Created: 2026-07-31
+- Updated: 2026-07-31
+- External ref: CI run 30614164526
+
+## Description
+
+The Linux AMD64 `run native sanitizer checks` job fails with a LeakSanitizer
+report:
+
+```text
+SUMMARY: AddressSanitizer: 1992 byte(s) leaked in 58 allocation(s).
+  ComponentLinker::with_core_execution_engine  component_api.mbt:339 / :361
+    -> Linker::Linker  linker.mbt:11  -> Store::Store  store.mbt:116
+  reached from runtime_cleanup_wbtest.mbt:139
+```
+
+All 58 blocks are reported as *Indirect* and none as *Direct*: every leaked
+block is reachable from another leaked block, with no external root. That is
+the signature of a reference cycle, which the reference-counted native runtime
+never reclaims.
+
+The failure predates this issue and is not platform-specific in origin; only
+Linux enables `detect_leaks=1`, so only that leg reports it.
+
+## Root cause
+
+`ComponentLinker::finish_close` already releases every retained graph it can:
+it clears `components`, `imports`, and `host_runtime`. It could not release
+`core_engine`, because that was an immutable struct field. The engine is the
+graph most likely to hold embedder-supplied closures and native session state.
+
+When an embedder callback reachable from the engine refers back to its own
+linker, the result is a cycle that survives terminal close:
+
+```text
+linker --core_engine--> managed engine --> engine --invoke closure-->
+  embedder ref --> fn() { linker.close() } --> linker
+```
+
+`runtime_cleanup_wbtest.mbt:122` builds exactly that shape to exercise close
+ordering. Of the two tests in that file that create a linker, only the one with
+the back-reference appears in the leak traces.
+
+Production engines do not create this cycle on their own:
+`interpreter_core_execution_engine` and `CoreExecutionEngine::with_lifecycle`
+capture only the inner engine and the lifecycle, and the engine is constructed
+before the linker exists. The cycle requires an embedder to wire a back
+reference — closing the linker from an engine callback, for example — which is
+a reasonable thing for an embedder to do and should not leak.
+
+## Design
+
+Make the engine releasable and drop it at terminal close, consistent with the
+three graphs `finish_close` already releases.
+
+- Store it as `core_engine_slot : Ref[CoreExecutionEngine?]`.
+- Read it through a `ComponentLinker::core_engine` accessor. After close the
+  accessor reports a closed engine that raises the structured `Cancelled`
+  rather than resurrecting the released one.
+- `finish_close` clears the slot before calling `close()` on the engine it took,
+  so a re-entrant close observes the closed engine instead of recursing.
+
+Do not weaken close ordering, continuation leases, or cancellation semantics.
+
+## Acceptance Criteria
+
+- [x] The leak reproduces under LeakSanitizer on Linux AMD64 before the change.
+- [x] The same run reports no leaks after the change.
+- [x] A regression test asserts the linker drops its engine at terminal close
+      and that repeated close stays terminal.
+- [x] Component suites and the full workspace test suite still pass.
+- [ ] The Linux AMD64 sanitizer CI step passes.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-361
+- Discovered from: CI run 30614164526
+
+## Notes
+
+- 2026-07-31: Measured on x86_64 Linux with the CI sanitizer wrapper and
+  `ASAN_OPTIONS=detect_leaks=1`, running
+  `moon test modules/wasmoon/component/runtime_impl/runtime_cleanup_wbtest.mbt`.
+  Before the change: exit 255, `1992 byte(s) leaked in 58 allocation(s)`, 58
+  indirect entries and no direct entry. After the change: exit 0, no
+  LeakSanitizer report, zero indirect entries, 7/7 tests passing.
+- 2026-07-31: A second, latent path of the same class remains.
+  `CoreExecutionLifecycle::close_when_idle` stores `fn() { self.finish_close() }`,
+  which captures the linker, while the linker holds the lifecycle. `leave()`
+  clears the slot before invoking it, so the cycle resolves on every path
+  exercised today. A linker closed with leases that never drain would retain it.
+  That shape is not currently reproducible and is left untouched rather than
+  changed speculatively.
+- 2026-07-31: The macOS ARM64 leg of the same CI step fails for an unrelated
+  reason — UBSan reports a negative shift exponent inside the macOS SDK
+  `signal.h` reached from `moonbitlang/async` signal setup. Tracked separately.
+
+## Close Notes

--- a/modules/wasmoon/component/runtime_impl/component_api.mbt
+++ b/modules/wasmoon/component/runtime_impl/component_api.mbt
@@ -312,7 +312,12 @@ pub fn ComponentInstance::get_core_instance(
 ///|
 struct ComponentLinker {
   core_linker : @runtime.Linker
-  core_engine : CoreExecutionEngine
+  // Released by `finish_close`, like every other retained graph below. The
+  // engine can reach embedder-supplied closures and native session state, and
+  // an embedder callback that refers back to its linker would otherwise form a
+  // reference cycle that outlives terminal close. Read it through
+  // `ComponentLinker::core_engine`.
+  core_engine_slot : Ref[CoreExecutionEngine?]
   core_execution_lifecycle : CoreExecutionLifecycle
   components : Array[(String, ComponentInstance)]
   imports : Map[String, ComponentExtern]
@@ -342,7 +347,7 @@ pub fn ComponentLinker::with_core_execution_engine(
   managed_core_engine.prepare_store(core_linker.get_store())
   {
     core_linker,
-    core_engine: managed_core_engine,
+    core_engine_slot: Ref(Some(managed_core_engine)),
     core_execution_lifecycle,
     components: [],
     imports: Map([]),
@@ -350,6 +355,19 @@ pub fn ComponentLinker::with_core_execution_engine(
     closed: Ref(false),
     close_complete: Ref(false),
     resource_id_counter: [0],
+  }
+}
+
+///|
+/// The core execution engine backing this linker.
+///
+/// After terminal close the engine is released, and this reports a closed
+/// engine that rejects further work instead of resurrecting the released one.
+/// Every caller below reaches the engine while the linker is still open.
+fn ComponentLinker::core_engine(self : ComponentLinker) -> CoreExecutionEngine {
+  match self.core_engine_slot.val {
+    Some(engine) => engine
+    None => closed_core_execution_engine()
   }
 }
 
@@ -398,7 +416,16 @@ fn ComponentLinker::finish_close(self : ComponentLinker) -> Unit {
   self.components.clear()
   self.imports.clear()
   self.host_runtime.val = None
-  self.core_engine.close()
+  // Close the engine, then drop it. Holding it past terminal close would keep
+  // embedder state alive for the lifetime of the linker, and would make an
+  // embedder callback that refers back to this linker an uncollectable cycle.
+  match self.core_engine_slot.val {
+    Some(engine) => {
+      self.core_engine_slot.val = None
+      engine.close()
+    }
+    None => ()
+  }
   self.core_linker.close()
 }
 

--- a/modules/wasmoon/component/runtime_impl/core_engine.mbt
+++ b/modules/wasmoon/component/runtime_impl/core_engine.mbt
@@ -125,6 +125,31 @@ struct CoreExecutionEngine {
 }
 
 ///|
+/// An engine that accepts no further work.
+///
+/// Reported by a linker whose engine has already been released at terminal
+/// close, so a late caller gets the same structured `Cancelled` it would get
+/// from a closing lifecycle rather than reaching a closed engine.
+fn closed_core_execution_engine() -> CoreExecutionEngine {
+  CoreExecutionEngine(
+    fn(_store, _module, _instance) raise ComponentRuntimeError {
+      raise Cancelled
+    },
+    fn(
+      _store,
+      _instance,
+      _func_idx,
+      _args,
+      _request,
+    ) raise ComponentRuntimeError {
+      raise Cancelled
+    },
+    prepare_store=fn(_store) { () },
+    close=fn() { () },
+  )
+}
+
+///|
 priv struct CoreExecutionLifecycle {
   active_leases : Ref[Int]
   closing : Ref[Bool]

--- a/modules/wasmoon/component/runtime_impl/host_instance.mbt
+++ b/modules/wasmoon/component/runtime_impl/host_instance.mbt
@@ -43,7 +43,7 @@ pub fn ComponentLinker::host_runtime_state(
     Some(runtime) => runtime
     None => {
       let runtime = HostRuntimeState::with_core_execution_engine(
-        self.core_engine,
+        self.core_engine(),
       )
       self.host_runtime.val = Some(runtime)
       runtime

--- a/modules/wasmoon/component/runtime_impl/instantiate.mbt
+++ b/modules/wasmoon/component/runtime_impl/instantiate.mbt
@@ -19,7 +19,7 @@ fn instantiate_component(
   } else {
     match linker.host_runtime.val {
       Some(runtime) => runtime.async_state
-      None => AsyncState(stream_table, core_engine=linker.core_engine)
+      None => AsyncState(stream_table, core_engine=linker.core_engine())
     }
   }
   let state = BuildState::BuildState(stream_table, async_state)
@@ -91,11 +91,11 @@ fn instantiate_component(
               linker.core_linker.register(module_name, instance) catch {
                 error => raise CoreModuleInstantiateError(error.to_string())
               }
-              linker.core_engine.register_instance(store, mod_, instance)
+              linker.core_engine().register_instance(store, mod_, instance)
               state.core_instances.push(
                 core_instance_from_module(
                   instance,
-                  linker.core_engine,
+                  linker.core_engine(),
                   may_suspend,
                   native_eligible,
                 ),

--- a/modules/wasmoon/component/runtime_impl/runtime_cleanup_wbtest.mbt
+++ b/modules/wasmoon/component/runtime_impl/runtime_cleanup_wbtest.mbt
@@ -143,7 +143,9 @@ test "linker close cannot overtake in-flight continuation ownership" {
     fn(_arguments) { [] },
   )
   let result = try {
-    linker.core_engine.invoke(
+    linker
+    .core_engine()
+    .invoke(
       linker.get_store(),
       core_func.instance,
       0,
@@ -185,13 +187,15 @@ test "published continuation lease delays linker teardown" {
     { params: [], results: [] },
     fn(_arguments) { [] },
   )
-  let outcome = linker.core_engine.invoke(
-    linker.get_store(),
-    core_func.instance,
-    0,
-    [],
-    CoreExecutionRequest(CallbackStep, PreferNative, Resumable),
-  )
+  let outcome = linker
+    .core_engine()
+    .invoke(
+      linker.get_store(),
+      core_func.instance,
+      0,
+      [],
+      CoreExecutionRequest(CallbackStep, PreferNative, Resumable),
+    )
   guard outcome is Suspended(_, continuation) else {
     return fail("expected a suspended managed execution")
   }
@@ -199,4 +203,34 @@ test "published continuation lease delays linker teardown" {
   debug_inspect(events, content="[]")
   continuation.cancel()
   debug_inspect(events, content="[\"continuation\", \"engine\"]")
+}
+
+///|
+/// Terminal close must drop the linker's reference to its execution engine.
+///
+/// The engine can reach embedder-supplied closures and native session state.
+/// An embedder callback that refers back to its own linker — closing it from
+/// inside an engine callback, for example — would otherwise leave a reference
+/// cycle that survives close, which reference counting never reclaims.
+/// LeakSanitizer caught exactly that shape as an all-indirect leak.
+test "terminal close releases the linker's core execution engine" {
+  let events : Array[String] = []
+  let engine = CoreExecutionEngine(
+    fn(_store, _module, _instance) { () },
+    fn(_store, _instance, _function_index, _arguments, _request) {
+      Returned([])
+    },
+    close=fn() { events.push("engine") },
+  )
+  let linker = ComponentLinker::with_core_execution_engine(engine)
+  debug_inspect(linker.core_engine_slot.val is Some(_), content="true")
+  linker.close()
+  // Engine closed exactly once, and no longer retained by the linker.
+  debug_inspect(
+    (events, linker.core_engine_slot.val is None),
+    content="([\"engine\"], true)",
+  )
+  // Repeated close stays terminal and does not close the engine again.
+  linker.close()
+  debug_inspect(events, content="[\"engine\"]")
 }


### PR DESCRIPTION
Fixes the LeakSanitizer failure in the Linux AMD64 `run native sanitizer checks` job, tracked in ISS-366.

Stacked on #448, so this targets `milky/component-runtime-engine-async` rather than `main`.

## Root cause

CI reported:

```
SUMMARY: AddressSanitizer: 1992 byte(s) leaked in 58 allocation(s).
  ComponentLinker::with_core_execution_engine  component_api.mbt:339 / :361
    -> Linker::Linker  linker.mbt:11  -> Store::Store  store.mbt:116
  reached from runtime_cleanup_wbtest.mbt:139
```

Every one of the 58 blocks was reported as an **indirect** leak and **none as a direct leak** — each leaked block was reachable from another leaked block with no external root. That is the signature of a reference cycle, which the reference-counted native runtime never reclaims.

`ComponentLinker::finish_close` already released every retained graph it could: it clears `components`, `imports`, and `host_runtime`. It could not release `core_engine`, because that was an immutable struct field — and the engine is the graph most likely to hold embedder-supplied closures and native session state. When something reachable from the engine refers back to its own linker, the cycle survives terminal close:

```
linker --core_engine--> managed engine --> engine --invoke closure-->
  embedder ref --> fn() { linker.close() } --> linker
```

Two things confirm this rather than merely fit it:

- Two tests in `runtime_cleanup_wbtest.mbt` create a linker (lines 138 and 182), but only the one wiring `linker.close()` back into the engine appears in the leak traces.
- Production engines never build the cycle themselves. `interpreter_core_execution_engine` and `CoreExecutionEngine::with_lifecycle` capture only the inner engine and the lifecycle, and the engine is constructed before its linker exists. It takes an embedder wiring a back reference — closing the linker from inside an engine callback — which is a reasonable thing to do and should not leak.

## Approach

Make the engine releasable and drop it at terminal close, consistent with the three graphs `finish_close` already releases.

- Store it as `core_engine_slot : Ref[CoreExecutionEngine?]`.
- Read it through a `ComponentLinker::core_engine` accessor. After close it reports an engine that raises the structured `Cancelled` rather than resurrecting the released one.
- Clear the slot *before* closing the engine that was taken, so a re-entrant close observes the closed engine instead of recursing.

Close ordering, continuation leases, and cancellation semantics are unchanged. `moon info` produces no `.mbti` diff — the slot and accessor are package-private, so no public interface moved.

## Verification

Measured on x86_64 Linux under the CI sanitizer wrapper with `ASAN_OPTIONS=detect_leaks=1`, running the same test file CI runs:

| | before | after |
| --- | --- | --- |
| exit code | 255 | **0** |
| LeakSanitizer | `1992 byte(s) leaked in 58 allocation(s)` | **no report** |
| indirect leak entries | 58 | **0** |
| tests | — | 7/7 passed |

The before number reproduces CI byte for byte.

| Check | Result |
| --- | --- |
| `runtime_impl` tests | 36/36 |
| Full workspace `moon test` | 977 wasm-gc + 1531 native |
| Component suites (stable-0.2, async-0.3, future-gated) | 1385 commands |
| New regression test catches removal of the release | confirmed by reverting |

## Left alone deliberately

`CoreExecutionLifecycle::close_when_idle` stores `fn() { self.finish_close() }`, which captures the linker while the linker holds the lifecycle — the same cycle class. `leave()` clears that slot before invoking it, so it resolves on every path exercised today, and I could not construct a case that leaks it. Recorded as a note on ISS-366 rather than changed speculatively.

The macOS ARM64 leg of this same CI step fails for an unrelated pre-existing reason: UBSan reports a negative shift exponent inside the macOS SDK `signal.h`, reached from `moonbitlang/async` signal setup. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
