### PR TITLE
Track the macOS UBSan sanitizer failure as an external blocker

### DIFF
--- a/issues/ISS-367.md
+++ b/issues/ISS-367.md
@@ -1,0 +1,147 @@
+# ISS-367: macOS UBSan aborts on a negative signal number from moonbitlang/async
+
+## Metadata
+- Type: bug
+- Status: deferred
+- Priority: 2
+- Labels: macos, sanitizers, ubsan, ci, dependency, external-blocker, agent
+- Assignee: unassigned
+- Created: 2026-07-31
+- Updated: 2026-07-31
+- External ref: moonbitlang/async@0.20.3
+
+## Description
+
+The macOS ARM64 `run native sanitizer checks` job aborts:
+
+```text
+/Applications/Xcode_26.6.app/.../MacOSX.sdk/usr/include/signal.h:122:13:
+runtime error: shift exponent -2 is negative
+    #0 moonbitlang_async_make_sigwait_job thread_pool.c:2752
+    #1 moonbitlang/async ... setup_signal_handler_unix signal.mbt:89
+    #2 coroutine spawn run / reschedule / EventLoop::run_forever
+    #6 run_async_main integration.mbt:23
+    #7 Milky2018/wasmoon/testsuite blackbox test driver
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior signal.h:122:13
+The test executable exited with signal: 6 (SIGABRT)
+```
+
+The defect is in the pinned `moonbitlang/async@0.20.3` dependency, not in
+Wasmoon code. Wasmoon cannot fix it at its own boundary.
+
+This is an **external blocker**: it fails the macOS leg of the sanitizer step
+on `milky/component-runtime-engine-async` and on every branch stacked on it,
+independently of the change under review.
+
+## Root cause
+
+An off-by-one between the signal-code table and the array built from it.
+
+`src/internal/event_loop/signal.mbt:25` requests four entries:
+
+```moonbit
+pub let all_signals : ReadOnlyArray[Int] = ReadOnlyArray::makei(
+  4, get_signal_by_index,
+)
+```
+
+but the POSIX `moonbitlang_async_get_signal_by_index` defines only three codes
+(`SIGINT_CODE = 0`, `SIGTERM_CODE = 1`, `SIGHUP_CODE = 2`) and falls through to
+`default: return -1`. So `all_signals` is `[SIGINT, SIGTERM, SIGHUP, -1]`.
+
+`thread_pool.c:2751` then feeds every element to `sigaddset`:
+
+```c
+for (int i = 0; i < Moonbit_array_length(signals); ++i)
+  sigaddset(&job->signals, signals[i]);   // last iteration passes -1
+```
+
+The macOS SDK helper guards zero and the upper bound but not negative values:
+
+```c
+__header_always_inline unsigned int
+__sigbits(int __signo)
+{
+	if (__signo == 0 || __signo > __DARWIN_NSIG)
+		return (0);
+	return (1U << (__signo - 1));
+}
+```
+
+so `__signo = -1` evaluates `1U << -2`, which is undefined behavior. UBSan with
+`halt_on_error=1` aborts the process.
+
+Linux is unaffected because glibc's `sigaddset` range-checks and returns
+`EINVAL` instead of performing an out-of-range shift. The Linux AMD64 failure in
+the same CI step had a different cause and is tracked in ISS-366.
+
+## Reproduction
+
+Independent of MoonBit, on macOS:
+
+```c
+#include <signal.h>
+int main(void) {
+  sigset_t s; sigemptyset(&s);
+  int signals[4] = {SIGINT, SIGTERM, SIGHUP, -1};
+  for (int i = 0; i < 4; ++i) sigaddset(&s, signals[i]);
+  return 0;
+}
+```
+
+```bash
+clang -fsanitize=undefined -g -O0 sigrepro.c -o sigrepro && ./sigrepro
+```
+
+reports the same `signal.h:122:13` shift-exponent error as CI.
+
+## Impact
+
+The demonstrated impact is that UBSan aborts the test binary, which is what
+blocks the macOS sanitizer gate.
+
+The semantic effect is not established. `1U << -2` is undefined; a plausible
+outcome is that the shift amount is reduced modulo the operand width and sets an
+unintended bit in the sigwait mask, which would make the signal-waiting task
+wait on a signal it was never asked to wait on. That has not been measured and
+should not be assumed.
+
+## Design
+
+The fix belongs upstream: either build `all_signals` with three entries, or skip
+non-positive values before calling `sigaddset`. Wasmoon options, in order of
+preference:
+
+1. Report upstream and bump the `moonbitlang/async` pin once a release carries
+   the fix. `0.20.3` is the newest version currently available.
+2. If the macOS gate must go green sooner, add a narrowly scoped UBSan
+   suppression for this one shift check, referencing this issue, and remove it
+   with the version bump. This weakens the sanitizer gate and is awkward to
+   target precisely because the offending code is an `always_inline` function in
+   an SDK header.
+
+Do not disable UBSan for the whole sanitizer step.
+
+## Acceptance Criteria
+
+- [ ] The defect is reported upstream to `moonbitlang/async`.
+- [ ] A released `moonbitlang/async` version no longer passes a negative signal
+      number to `sigaddset`.
+- [ ] The pin in `modules/wasmoon/moon.mod` is bumped to that version.
+- [ ] The macOS ARM64 sanitizer step passes without a suppression.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-366
+- Discovered from: CI run 30614164526
+
+## Notes
+
+- 2026-07-31: Deferred as an external blocker. Filing the upstream report is an
+  outward-facing action and has not been done yet; it needs a maintainer to send
+  it or to approve sending it.
+- 2026-07-31: This affects any MoonBit project running UBSan on macOS with the
+  async event loop, not only Wasmoon.
+
+## Close Notes


### PR DESCRIPTION
Records ISS-367. Documentation only — no code change.

The macOS ARM64 `run native sanitizer checks` job aborts under UBSan. The defect is in the pinned `moonbitlang/async@0.20.3` dependency, so it cannot be fixed at the Wasmoon boundary; this files the analysis rather than working around it.

## What fails

```
signal.h:122:13: runtime error: shift exponent -2 is negative
  #0 moonbitlang_async_make_sigwait_job thread_pool.c:2752
  #1 moonbitlang/async ... setup_signal_handler_unix signal.mbt:89
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior signal.h:122:13
The test executable exited with signal: 6 (SIGABRT)
```

## Root cause

An off-by-one between the signal-code table and the array built from it.

`signal.mbt:25` asks for four entries:

```moonbit
pub let all_signals : ReadOnlyArray[Int] = ReadOnlyArray::makei(4, get_signal_by_index)
```

but the POSIX `get_signal_by_index` defines only three codes (`SIGINT_CODE = 0`, `SIGTERM_CODE = 1`, `SIGHUP_CODE = 2`) and falls through to `default: return -1`. So `all_signals` is `[SIGINT, SIGTERM, SIGHUP, -1]`, and `make_sigwait_job` passes every element to `sigaddset`.

The macOS SDK helper guards zero and the upper bound but not negative values:

```c
if (__signo == 0 || __signo > __DARWIN_NSIG)
        return (0);
return (1U << (__signo - 1));
```

so `__signo = -1` evaluates `1U << -2` — undefined behavior, and UBSan with `halt_on_error=1` aborts.

Linux is unaffected: glibc's `sigaddset` range-checks and returns `EINVAL` instead of shifting. The Linux AMD64 failure in this same CI step had a different cause and is fixed in #450 / ISS-366.

## Reproduction

Dependency-free, on macOS:

```c
#include <signal.h>
int main(void) {
  sigset_t s; sigemptyset(&s);
  int signals[4] = {SIGINT, SIGTERM, SIGHUP, -1};
  for (int i = 0; i < 4; ++i) sigaddset(&s, signals[i]);
  return 0;
}
```

`clang -fsanitize=undefined -g -O0 sigrepro.c -o sigrepro && ./sigrepro` reports the same `signal.h:122:13` error as CI.

## Status

Deferred as an external blocker. The fix belongs upstream — build `all_signals` with three entries, or skip non-positive values before `sigaddset`. `0.20.3` is the newest version currently available, so the path is: report upstream, then bump the pin.

The issue also records a scoped-suppression option if the macOS gate must go green sooner, with the explicit caveat that it weakens the sanitizer gate and should be removed at the version bump. Disabling UBSan for the whole step is ruled out.

**Not done:** filing the upstream report. That is an outward-facing action and is left to a maintainer to send or approve.

The impact section deliberately separates what is demonstrated (UBSan aborts the binary, blocking the gate) from what is not (any semantic effect on the sigwait mask, which is plausible but unmeasured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
