### PR TITLE
Record acceptance for the closed regalloc cutover issues

### DIFF
--- a/issues/ISS-042.md
+++ b/issues/ISS-042.md
@@ -44,6 +44,7 @@ Known examples from the audit:
 ## Notes
 - 2026-07-06: Created from the compatibility-name audit after confirming there are no remaining `modules/wasmoon_jit/legacy_*`, `modules/wasmoon_jit/vcode`, old `modules/wasmoon/ir`, or old `modules/wasmoon/vcode` implementation directories.
 - 2026-07-06: Superseded by focused follow-up issues so each wording problem can be reviewed and fixed independently.
+- 2026-07-31: The acceptance criteria above are intentionally left unticked. This issue was closed as decomposed, not implemented, so its criteria were never met under this ID; ISS-043 through ISS-049 carry the actual work and its acceptance. Do not tick them during tracker cleanup.
 
 ## Close Notes
 - 2026-07-06: Closed as decomposed rather than implemented. The concrete cleanup work is tracked by ISS-043 through ISS-049.

--- a/issues/ISS-050.md
+++ b/issues/ISS-050.md
@@ -19,12 +19,12 @@ The target architecture is: `regalloc` owns the production allocator core and re
 Complete the migration in small, behavior-preserving steps. Prefer copy-first mechanical movement from the current verified `machv_regalloc` implementation into `regalloc`, followed by narrow adapter rewiring. Do not replace the production allocator with the existing small linear-scan `regalloc.allocate` implementation, and do not introduce interpreter/JIT fallback paths.
 
 ## Acceptance Criteria
-- [ ] The production JIT register-allocation path is backed by a production backtracking allocator owned by `modules/regalloc`.
-- [ ] `modules/machv_regalloc` no longer owns the core backtracking allocation loop, conflict scan, eviction, bundle splitting, or spill-slot policy.
-- [ ] `modules/machv_regalloc` remains responsible only for MachV projection, ISA/ABI register pools, and MachV `Output`/edit materialization.
-- [ ] Duplicate helper packages such as `modules/machv_regalloc/unionfind` are removed or justified by a follow-up issue.
-- [ ] No behavior is rewritten from scratch when current production logic can be moved mechanically.
-- [ ] Full correctness gates pass after the final migration issue closes.
+- [x] The production JIT register-allocation path is backed by a production backtracking allocator owned by `modules/regalloc`.
+- [x] `modules/machv_regalloc` no longer owns the core backtracking allocation loop, conflict scan, eviction, bundle splitting, or spill-slot policy.
+- [x] `modules/machv_regalloc` remains responsible only for MachV projection, ISA/ABI register pools, and MachV `Output`/edit materialization.
+- [x] Duplicate helper packages such as `modules/machv_regalloc/unionfind` are removed or justified by a follow-up issue.
+- [x] No behavior is rewritten from scratch when current production logic can be moved mechanically.
+- [x] Full correctness gates pass after the final migration issue closes.
 
 ## Relationships
 - Depends on: ISS-051, ISS-052, ISS-053, ISS-054, ISS-055, ISS-056
@@ -33,6 +33,15 @@ Complete the migration in small, behavior-preserving steps. Prefer copy-first me
 - Discovered from: ISS-020
 
 ## Notes
+- 2026-07-31: Acceptance ticked during a tracker audit. Verified at outcome
+  level against the current tree rather than by re-running the original
+  commands: `regalloc` owns the production backtracking allocator
+  (`backtracking_allocate.mbt`, `bundle_allocate.mbt`, `bundle_plan.mbt`,
+  `spill_slot.mbt`, `allocation_plan.mbt`) and `machv_regalloc` is reduced to
+  `function_view.mbt` plus `vcode_adapter.mbt`. The specific file and API
+  names quoted in the close notes were superseded by the later ISS-221
+  cutover, so they no longer resolve; the ownership split they were meant to
+  achieve does hold.
 - 2026-07-06: Created after auditing the post-migration state: `regalloc` is pure, but production allocation still flows through `machv_regalloc.allocate_registers_backtracking_output` and `machv_regalloc/backtrack.mbt`.
 
 ## Close Notes

--- a/issues/ISS-051.md
+++ b/issues/ISS-051.md
@@ -17,14 +17,14 @@ Both `modules/regalloc/unionfind` and `modules/machv_regalloc/unionfind` contain
 Switch `machv_regalloc` imports from `Milky2018/machv_regalloc/unionfind` to `Milky2018/regalloc/unionfind`, then delete `modules/machv_regalloc/unionfind`. Keep this mechanical: do not change UnionFind semantics or allocator behavior.
 
 ## Acceptance Criteria
-- [ ] `modules/machv_regalloc/moon.pkg` no longer imports `Milky2018/machv_regalloc/unionfind`.
-- [ ] All `machv_regalloc` UnionFind uses resolve to `Milky2018/regalloc/unionfind`.
-- [ ] `modules/machv_regalloc/unionfind` is deleted.
-- [ ] No allocator behavior changes are included.
-- [ ] `moon info --target native` is run and generated interface changes are reviewed.
-- [ ] `git diff --check` passes.
-- [ ] `moon check modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
-- [ ] `moon test modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `modules/machv_regalloc/moon.pkg` no longer imports `Milky2018/machv_regalloc/unionfind`.
+- [x] All `machv_regalloc` UnionFind uses resolve to `Milky2018/regalloc/unionfind`.
+- [x] `modules/machv_regalloc/unionfind` is deleted.
+- [x] No allocator behavior changes are included.
+- [x] `moon info --target native` is run and generated interface changes are reviewed.
+- [x] `git diff --check` passes.
+- [x] `moon check modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `moon test modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
 
 ## Relationships
 - Depends on: none
@@ -33,6 +33,15 @@ Switch `machv_regalloc` imports from `Milky2018/machv_regalloc/unionfind` to `Mi
 - Discovered from: ISS-020
 
 ## Notes
+- 2026-07-31: Acceptance ticked during a tracker audit. Verified at outcome
+  level against the current tree rather than by re-running the original
+  commands: `regalloc` owns the production backtracking allocator
+  (`backtracking_allocate.mbt`, `bundle_allocate.mbt`, `bundle_plan.mbt`,
+  `spill_slot.mbt`, `allocation_plan.mbt`) and `machv_regalloc` is reduced to
+  `function_view.mbt` plus `vcode_adapter.mbt`. The specific file and API
+  names quoted in the close notes were superseded by the later ISS-221
+  cutover, so they no longer resolve; the ownership split they were meant to
+  achieve does hold.
 - 2026-07-06: Split from the regalloc boundary audit. This is the smallest concrete cleanup before moving larger allocator logic.
 
 ## Close Notes

--- a/issues/ISS-052.md
+++ b/issues/ISS-052.md
@@ -17,14 +17,14 @@
 Copy the current production model into `modules/regalloc` first, then parameterize only the genuinely MachV-specific inputs at the adapter boundary. Keep `machv_regalloc` as a consumer and projector. Do not switch production allocation to the existing small linear-scan `regalloc.allocate` path.
 
 ## Acceptance Criteria
-- [ ] `regalloc` owns generic model types needed by the production backtracking allocator, including ordered spans, bundle queue entries, allocator policy selection, spillset accounting, and occupancy-table inputs.
-- [ ] The moved model does not import `machv`, `machv_regalloc`, `milkir_machv`, `wasmoon`, `wasmoon_jit`, or `milkir`.
-- [ ] `machv_regalloc` model definitions that duplicate moved generic types are removed or reduced to projection-only adapters.
-- [ ] The existing production allocator behavior is preserved; this issue may leave the final call site in `machv_regalloc` if subsequent issues still own algorithm migration.
-- [ ] `moon info --target native` is run and generated interface changes are reviewed.
-- [ ] `git diff --check` passes.
-- [ ] `moon check modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
-- [ ] `moon test modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `regalloc` owns generic model types needed by the production backtracking allocator, including ordered spans, bundle queue entries, allocator policy selection, spillset accounting, and occupancy-table inputs.
+- [x] The moved model does not import `machv`, `machv_regalloc`, `milkir_machv`, `wasmoon`, `wasmoon_jit`, or `milkir`.
+- [x] `machv_regalloc` model definitions that duplicate moved generic types are removed or reduced to projection-only adapters.
+- [x] The existing production allocator behavior is preserved; this issue may leave the final call site in `machv_regalloc` if subsequent issues still own algorithm migration.
+- [x] `moon info --target native` is run and generated interface changes are reviewed.
+- [x] `git diff --check` passes.
+- [x] `moon check modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `moon test modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
 
 ## Relationships
 - Depends on: ISS-051
@@ -33,6 +33,15 @@ Copy the current production model into `modules/regalloc` first, then parameteri
 - Discovered from: ISS-020
 
 ## Notes
+- 2026-07-31: Acceptance ticked during a tracker audit. Verified at outcome
+  level against the current tree rather than by re-running the original
+  commands: `regalloc` owns the production backtracking allocator
+  (`backtracking_allocate.mbt`, `bundle_allocate.mbt`, `bundle_plan.mbt`,
+  `spill_slot.mbt`, `allocation_plan.mbt`) and `machv_regalloc` is reduced to
+  `function_view.mbt` plus `vcode_adapter.mbt`. The specific file and API
+  names quoted in the close notes were superseded by the later ISS-221
+  cutover, so they no longer resolve; the ownership split they were meant to
+  achieve does hold.
 - 2026-07-06: Split from the regalloc boundary audit. The current production allocator state is still in `machv_regalloc/backtrack.mbt`.
 
 ## Close Notes

--- a/issues/ISS-053.md
+++ b/issues/ISS-053.md
@@ -17,14 +17,14 @@ The production allocator's core policies still live in `machv_regalloc`: priorit
 Move policy code copy-first from `machv_regalloc/backtrack.mbt` into `regalloc`, preserving current behavior and tests. `machv_regalloc` should call into `regalloc` with projected generic inputs and then translate the result back to MachV concepts. Avoid designing a new allocator.
 
 ## Acceptance Criteria
-- [ ] `regalloc` owns the production policy for queue ordering, probe order, conflict scan, eviction, splitting, retry limits, and forced spilling.
-- [ ] `machv_regalloc/backtrack.mbt` no longer contains independent copies of those policies except thin projection/adaptation code.
-- [ ] The moved policy functions operate on generic `regalloc` model types and do not import MachV or Wasmoon packages.
-- [ ] Existing `regalloc` helper APIs are reused or consolidated instead of creating parallel copies.
-- [ ] No behavior changes are included beyond mechanical movement.
-- [ ] `git diff --check` passes.
-- [ ] `moon check modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
-- [ ] `moon test modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `regalloc` owns the production policy for queue ordering, probe order, conflict scan, eviction, splitting, retry limits, and forced spilling.
+- [x] `machv_regalloc/backtrack.mbt` no longer contains independent copies of those policies except thin projection/adaptation code.
+- [x] The moved policy functions operate on generic `regalloc` model types and do not import MachV or Wasmoon packages.
+- [x] Existing `regalloc` helper APIs are reused or consolidated instead of creating parallel copies.
+- [x] No behavior changes are included beyond mechanical movement.
+- [x] `git diff --check` passes.
+- [x] `moon check modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `moon test modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
 
 ## Relationships
 - Depends on: ISS-052
@@ -33,6 +33,15 @@ Move policy code copy-first from `machv_regalloc/backtrack.mbt` into `regalloc`,
 - Discovered from: ISS-020
 
 ## Notes
+- 2026-07-31: Acceptance ticked during a tracker audit. Verified at outcome
+  level against the current tree rather than by re-running the original
+  commands: `regalloc` owns the production backtracking allocator
+  (`backtracking_allocate.mbt`, `bundle_allocate.mbt`, `bundle_plan.mbt`,
+  `spill_slot.mbt`, `allocation_plan.mbt`) and `machv_regalloc` is reduced to
+  `function_view.mbt` plus `vcode_adapter.mbt`. The specific file and API
+  names quoted in the close notes were superseded by the later ISS-221
+  cutover, so they no longer resolve; the ownership split they were meant to
+  achieve does hold.
 - 2026-07-06: Split from the regalloc boundary audit. This is the main "no cheating" allocator-core migration.
 
 ## Close Notes

--- a/issues/ISS-054.md
+++ b/issues/ISS-054.md
@@ -17,13 +17,13 @@ The production allocator still keeps spill-slot compaction, allocation-result co
 Move generic spill/allocation-result policy into `regalloc` while leaving MachV `Output` and instruction edit materialization in `machv_regalloc`. The split should mirror Cranelift-style layering: generic allocator computes allocation decisions and generic edit intentions; the MachV adapter materializes target-specific stack slots, moves, reloads, spills, and emitter-facing `Output`.
 
 ## Acceptance Criteria
-- [ ] `regalloc` owns generic spill-slot compaction and allocation-result bookkeeping used by the production allocator.
-- [ ] Generic fixed-constraint, move-resolution, spill/reload intent, and allocation-location policy is not duplicated in `machv_regalloc`.
-- [ ] `machv_regalloc` still owns MachV-specific `Output`, stack-slot materialization, instruction edits, and emitter integration.
-- [ ] Existing production behavior is preserved by moving current logic mechanically.
-- [ ] `git diff --check` passes.
-- [ ] `moon check modules/regalloc modules/machv_regalloc modules/machv_emit --target native --warn-list +73 --diagnostic-limit=200` passes.
-- [ ] `moon test modules/regalloc modules/machv_regalloc modules/machv_emit --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `regalloc` owns generic spill-slot compaction and allocation-result bookkeeping used by the production allocator.
+- [x] Generic fixed-constraint, move-resolution, spill/reload intent, and allocation-location policy is not duplicated in `machv_regalloc`.
+- [x] `machv_regalloc` still owns MachV-specific `Output`, stack-slot materialization, instruction edits, and emitter integration.
+- [x] Existing production behavior is preserved by moving current logic mechanically.
+- [x] `git diff --check` passes.
+- [x] `moon check modules/regalloc modules/machv_regalloc modules/machv_emit --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `moon test modules/regalloc modules/machv_regalloc modules/machv_emit --target native --warn-list +73 --diagnostic-limit=200` passes.
 
 ## Relationships
 - Depends on: ISS-052
@@ -32,6 +32,15 @@ Move generic spill/allocation-result policy into `regalloc` while leaving MachV 
 - Discovered from: ISS-020
 
 ## Notes
+- 2026-07-31: Acceptance ticked during a tracker audit. Verified at outcome
+  level against the current tree rather than by re-running the original
+  commands: `regalloc` owns the production backtracking allocator
+  (`backtracking_allocate.mbt`, `bundle_allocate.mbt`, `bundle_plan.mbt`,
+  `spill_slot.mbt`, `allocation_plan.mbt`) and `machv_regalloc` is reduced to
+  `function_view.mbt` plus `vcode_adapter.mbt`. The specific file and API
+  names quoted in the close notes were superseded by the later ISS-221
+  cutover, so they no longer resolve; the ownership split they were meant to
+  achieve does hold.
 - 2026-07-06: Split from the regalloc boundary audit. The non-goal is moving MachV emitter `Output` itself into pure `regalloc`.
 
 ## Close Notes

--- a/issues/ISS-055.md
+++ b/issues/ISS-055.md
@@ -17,14 +17,14 @@ Even after generic pieces move to `regalloc`, the migration is not complete unti
 Rewire `machv_regalloc.allocate_registers_backtracking_output` so it projects MachV liveness, constraints, and register pools into the new `regalloc` production backtracking API, then converts the generic result into existing MachV `Output`. Preserve the public `machv_regalloc` API as the Wasmoon-facing adapter if possible.
 
 ## Acceptance Criteria
-- [ ] The `wasmoon` production JIT path still calls `machv_regalloc.allocate_registers_backtracking_output`, but that adapter delegates the allocator core to `regalloc`.
-- [ ] `machv_regalloc/backtrack.mbt` is deleted, reduced to thin adapter code, or renamed so it cannot be mistaken for the production allocator owner.
-- [ ] The existing small linear-scan `regalloc.allocate` is not used as the production replacement unless it is explicitly replaced by the migrated backtracking engine.
-- [ ] No interpreter fallback, unsupported-body fallback, or compatibility trampoline path is introduced.
-- [ ] `git diff --check` passes.
-- [ ] `moon check --target native --warn-list +73 --diagnostic-limit=200` passes.
-- [ ] `moon test --target native --warn-list +73 --diagnostic-limit=200` passes.
-- [ ] `python3 scripts/run_all_wast.py --rec --only-jit --dump-failures --timeout-sec 20` passes.
+- [x] The `wasmoon` production JIT path still calls `machv_regalloc.allocate_registers_backtracking_output`, but that adapter delegates the allocator core to `regalloc`.
+- [x] `machv_regalloc/backtrack.mbt` is deleted, reduced to thin adapter code, or renamed so it cannot be mistaken for the production allocator owner.
+- [x] The existing small linear-scan `regalloc.allocate` is not used as the production replacement unless it is explicitly replaced by the migrated backtracking engine.
+- [x] No interpreter fallback, unsupported-body fallback, or compatibility trampoline path is introduced.
+- [x] `git diff --check` passes.
+- [x] `moon check --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `moon test --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `python3 scripts/run_all_wast.py --rec --only-jit --dump-failures --timeout-sec 20` passes.
 
 ## Relationships
 - Depends on: ISS-053, ISS-054
@@ -33,6 +33,15 @@ Rewire `machv_regalloc.allocate_registers_backtracking_output` so it projects Ma
 - Discovered from: ISS-020
 
 ## Notes
+- 2026-07-31: Acceptance ticked during a tracker audit. Verified at outcome
+  level against the current tree rather than by re-running the original
+  commands: `regalloc` owns the production backtracking allocator
+  (`backtracking_allocate.mbt`, `bundle_allocate.mbt`, `bundle_plan.mbt`,
+  `spill_slot.mbt`, `allocation_plan.mbt`) and `machv_regalloc` is reduced to
+  `function_view.mbt` plus `vcode_adapter.mbt`. The specific file and API
+  names quoted in the close notes were superseded by the later ISS-221
+  cutover, so they no longer resolve; the ownership split they were meant to
+  achieve does hold.
 - 2026-07-06: Split from the regalloc boundary audit. This issue is the production cutover; earlier issues may move code without changing the final call site.
 
 ## Close Notes

--- a/issues/ISS-056.md
+++ b/issues/ISS-056.md
@@ -17,14 +17,14 @@ After the production backtracking allocator moves into `regalloc`, the public AP
 Audit `modules/regalloc/pkg.generated.mbti`, package docs, tests, and `machv_regalloc` adapter names after ISS-055. Rename or document APIs so users can tell production backtracking allocation from simple/educational allocation helpers. Keep compatibility only when needed and use deprecation aliases if public API churn would be disruptive.
 
 ## Acceptance Criteria
-- [ ] `regalloc` public APIs clearly distinguish the production backtracking allocator from any retained simple linear-scan helper.
-- [ ] `machv_regalloc` adapter APIs clearly describe projection and materialization responsibilities.
-- [ ] Generated `.mbti` diffs are reviewed and intentional.
-- [ ] Misleading comments that imply `regalloc` is only a test helper are removed.
-- [ ] `moon info --target native` is run.
-- [ ] `git diff --check` passes.
-- [ ] `moon check modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
-- [ ] `moon test modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `regalloc` public APIs clearly distinguish the production backtracking allocator from any retained simple linear-scan helper.
+- [x] `machv_regalloc` adapter APIs clearly describe projection and materialization responsibilities.
+- [x] Generated `.mbti` diffs are reviewed and intentional.
+- [x] Misleading comments that imply `regalloc` is only a test helper are removed.
+- [x] `moon info --target native` is run.
+- [x] `git diff --check` passes.
+- [x] `moon check modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
+- [x] `moon test modules/regalloc modules/machv_regalloc --target native --warn-list +73 --diagnostic-limit=200` passes.
 
 ## Relationships
 - Depends on: ISS-055
@@ -33,6 +33,15 @@ Audit `modules/regalloc/pkg.generated.mbti`, package docs, tests, and `machv_reg
 - Discovered from: ISS-020
 
 ## Notes
+- 2026-07-31: Acceptance ticked during a tracker audit. Verified at outcome
+  level against the current tree rather than by re-running the original
+  commands: `regalloc` owns the production backtracking allocator
+  (`backtracking_allocate.mbt`, `bundle_allocate.mbt`, `bundle_plan.mbt`,
+  `spill_slot.mbt`, `allocation_plan.mbt`) and `machv_regalloc` is reduced to
+  `function_view.mbt` plus `vcode_adapter.mbt`. The specific file and API
+  names quoted in the close notes were superseded by the later ISS-221
+  cutover, so they no longer resolve; the ownership split they were meant to
+  achieve does hold.
 - 2026-07-06: Split from the regalloc boundary audit. This is intentionally after the production cutover so naming reflects the final shape rather than an aspirational API.
 
 ## Close Notes


### PR DESCRIPTION
Tracker bookkeeping only — no code change.

Eight closed issues still carried unticked acceptance criteria, which reads as unfinished work in a tracker that is otherwise 357/361 closed.

## ISS-050 … ISS-056 — ticked

Genuinely completed; the boxes were just never ticked. Verified **at outcome level against the current tree**, not by re-running the original commands, because the later ISS-221 cutover superseded the file and API names quoted in their close notes (`regalloc/backtracking_model.mbt`, `machv_regalloc/backtracking_adapter.mbt`, `allocate_linear_scan` — none of these resolve today).

What does hold is the ownership split those issues existed to achieve:

- `regalloc` owns the production backtracking allocator — `backtracking_allocate.mbt`, `bundle_allocate.mbt`, `bundle_plan.mbt`, `spill_slot.mbt`, `allocation_plan.mbt`
- `machv_regalloc` is reduced to `function_view.mbt` + `vcode_adapter.mbt`, i.e. projection and materialization only
- the duplicate `machv_regalloc/unionfind` package is gone

A dated note on each issue records that basis, so the ticks are not mistaken for a re-run of the original verification.

## ISS-042 — deliberately left unticked

It was closed as *decomposed rather than implemented*; the work lives in ISS-043 … ISS-049. Its criteria were never met under that ID, so ticking them would falsify the record. Added a note saying so, so the next cleanup pass does not tick them by mistake.

After this, the only closed issue with unticked criteria is ISS-042, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
