### PR TITLE
Raise the native sanitizer gate budget so it can finish

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,9 @@ jobs:
   native-platform:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    # About 11 minutes of checks, tests, and suites run before the sanitizer
+    # gate, which now carries a 75-minute budget of its own.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -137,8 +139,15 @@ jobs:
             --suite future-gated --dump-failures --no-jit || status=$?
           exit "$status"
 
+      # This gate rebuilds each covered package with sanitizers from scratch and
+      # has grown with every test file added to it: 2m20s on 2026-07-28, 32m25s
+      # on 07-29, 33m18s on 07-30, then past the old 40-minute budget. A run
+      # that reaches the last covered file needs roughly 55 minutes, most of it
+      # spent compiling large packages under ASan rather than running tests. The
+      # budget below is measured headroom, not an estimate; ISS-368 tracks
+      # bringing the cost itself down.
       - name: run native sanitizer checks
-        timeout-minutes: 40
+        timeout-minutes: 75
         env:
           MOONBIT_NEW_NATIVE: 0
           ASAN_OPTIONS: ${{ matrix.asan_options }}

--- a/issues/ISS-368.md
+++ b/issues/ISS-368.md
@@ -1,0 +1,95 @@
+# ISS-368: Bring down the cost of the native sanitizer gate
+
+## Metadata
+- Type: task
+- Status: open
+- Priority: 2
+- Labels: ci, sanitizers, build-time, agent
+- Assignee: unassigned
+- Created: 2026-07-31
+- Updated: 2026-07-31
+- External ref: CI run 30619504623
+
+## Description
+
+The `run native sanitizer checks` step has grown until it exceeded its budget
+and began failing on wall time rather than on any sanitizer finding.
+
+Measured duration of the step on the Linux AMD64 leg:
+
+| Date | Result | Duration |
+| --- | --- | --- |
+| 2026-07-28 | success | 2m20s |
+| 2026-07-29 | success | 32m25s |
+| 2026-07-30 02:16 | success | 33m18s |
+| 2026-07-30 14:11 | failure (leak, exit 255) | 38m36s |
+| 2026-07-31 09:30 | failure (timed out) | 40m13s |
+
+The budget was raised from 40 to 75 minutes so the gate can finish and report
+what it finds. That is a stopgap: the trend above is the actual problem, and the
+next few files added to the gate will consume the new headroom too.
+
+## Root cause
+
+Almost all of the time is compilation, not test execution. The step rebuilds
+every covered package with ASan/UBSan into a fresh target directory, and the
+covered files sit in large packages.
+
+From the 2026-07-31 run, measured from step start at 09:30:09:
+
+| Elapsed | Event |
+| --- | --- |
+| +16m46s | first result: `wasmoon_jit/native_continuation_test.mbt`, 12 tests |
+| +33m38s | second result: `wasmoon/testsuite/jit_resumable_lifecycle_test.mbt`, 2 tests |
+| +33m45s | `wasmoon_jit/callback_ownership_test.mbt`, 1 test |
+| +36m27s | `wasmoon/async_native/reactor_wbtest.mbt`, 8 tests |
+| +38m24s | `wasmoon/wasi_component/async_preview3_wbtest.mbt`, 8 tests |
+| +38m24s | `component/runtime_impl/runtime_cleanup_wbtest.mbt`, 7 tests |
+| +38m24s | `component/runtime_impl/entry_state_wbtest.mbt`, 2 tests |
+| killed | still compiling the next package |
+
+Two invocations account for about 33 of the 40 minutes. The second one costs
+roughly 17 minutes to compile `modules/wasmoon/testsuite` — a package of about
+16k lines — in order to run two tests.
+
+## Design
+
+Reduce compiled volume rather than raising the budget again. Options worth
+measuring, cheapest first:
+
+1. Move the sanitizer-covered tests that live in very large packages
+   (`wasmoon/testsuite`, `cmd/wasmoon/commands`) into small dedicated packages,
+   so the gate compiles only what it exercises.
+2. Cache or reuse the sanitizer target directory across steps or runs, if the
+   sanitizer wrapper makes that sound.
+3. Only if neither is workable, split the gate into independently budgeted
+   steps.
+
+Do not reduce coverage to save time: the covered files were chosen because they
+exercise continuation ownership, callback ownership, reactor lifecycle, and
+component teardown, which is where use-after-free and leak regressions land.
+
+## Acceptance Criteria
+
+- [ ] The dominant compile costs are attributed per package with measurements.
+- [ ] The gate completes well inside its budget without dropping covered files.
+- [ ] The step budget is lowered again once the cost is reduced.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-366, ISS-367
+- Discovered from: CI run 30619504623
+
+## Notes
+
+- 2026-07-31: Raising the budget to 75 minutes was necessary to see the gate's
+  result at all. Before that, the timeout masked the outcome: the 2026-07-30
+  base-branch run failed on a genuine leak at 38m36s with exit 255, while the
+  following two runs were killed at the 40-minute mark, one of them 0.3 seconds
+  after emitting the same leak report. A gate that cannot finish cannot be
+  trusted to distinguish a real finding from a clock.
+- 2026-07-31: The job-level budget went from 90 to 120 minutes to accommodate
+  the step, since roughly 11 minutes of other work precedes it.
+
+## Close Notes

--- a/scripts/tests/test_cutover_gate.py
+++ b/scripts/tests/test_cutover_gate.py
@@ -537,7 +537,10 @@ class GateManifestTests(unittest.TestCase):
             1,
         )
         self.assertEqual(workflow.count('export MOON_AR="$(command -v ar)"'), 1)
-        self.assertEqual(workflow.count("timeout-minutes: 40"), 1)
+        # The sanitizer gate's budget is measured headroom: the step needs
+        # roughly 55 minutes to reach its last covered file (ISS-368 tracks
+        # reducing the underlying compile cost and lowering this again).
+        self.assertEqual(workflow.count("timeout-minutes: 75"), 1)
         self.assertEqual(
             workflow.count(
                 "python3 scripts/find_gc_bugs.py --dir spec/gc --timeout 30"


### PR DESCRIPTION
Records ISS-368. The `run native sanitizer checks` step has been failing on wall time rather than on anything it found.

## The trend

Measured duration of the step on the Linux AMD64 leg:

| Date | Result | Duration |
| --- | --- | --- |
| 2026-07-28 | success | 2m20s |
| 2026-07-29 | success | 32m25s |
| 2026-07-30 02:16 | success | 33m18s |
| 2026-07-30 14:11 | failure — leak, exit 255 | 38m36s |
| 2026-07-31 09:30 | failure — **timed out** | 40m13s |

## Why this matters beyond slow CI

A timeout is indistinguishable from a finding. The three most recent failures on this step were:

- base branch, 38m36s → `exit code 255`, a **genuine leak** (fixed in #450)
- #449, 40m09s → `timed out`, with the same leak report emitted **0.3 seconds before the kill**
- #450, 40m13s → `timed out`, **no leak at all**

I initially read the middle one as a leak failure and had to correct myself after checking the step's exit mode. A gate that cannot finish cannot be trusted to tell a real result from the clock — that ambiguity is the actual defect here, not the minutes.

## Change

- step budget 40 → 75 minutes
- job budget 90 → 120 minutes, since ~11 minutes of other work precedes the gate

Both are measured headroom, not estimates: a run that reaches the last covered file needs roughly 55 minutes.

## This is a stopgap

Almost all the time is compilation, not test execution. From the 2026-07-31 run, two invocations account for ~33 of the 40 minutes, and one of them spends roughly **17 minutes compiling the ~16k-line `modules/wasmoon/testsuite` package under ASan in order to run two tests**.

ISS-368 records the per-invocation breakdown and the options for reducing compiled volume — moving covered tests out of very large packages, or caching the sanitizer target directory — plus lowering the budget again afterwards. Coverage is unchanged here; the covered files were chosen for continuation ownership, callback ownership, reactor lifecycle, and component teardown, which is where this class of regression lands.

## Merge order

#450 will keep timing out until this lands and #450 picks it up, since each PR runs its own copy of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
