### PR TITLE
Forward zero pointer offsets instead of emitting add of zero

### DIFF
--- a/modules/aarch64_target/lower.mbt
+++ b/modules/aarch64_target/lower.mbt
@@ -1662,6 +1662,42 @@ fn analyze_lowering(function : @semantic.Function) -> LoweringAnalysis {
       }
     }
   }
+  // `pointer.offset p, 0` is `p`, and both sides are Ptr64.
+  //
+  // The register-offset selector above deliberately matches a zero
+  // `pointer.offset` as the tail of a foldable address, so this pass runs last
+  // and claims only what that selector left behind. Those would otherwise
+  // become `add xD, xN, #0`. A WebAssembly access with no static offset emits
+  // one per address, and a base-relative access has no `add` underneath for the
+  // register-offset form to match, so nothing else removes it.
+  for block in function.blocks() {
+    for instruction in function.block_instructions(block) {
+      guard function.instruction_operation(instruction) is Some(PointerOffset) else {
+        continue
+      }
+      guard function.instruction_results(instruction) is [result] else {
+        continue
+      }
+      guard function.instruction_operands(instruction) is [input, constant] else {
+        continue
+      }
+      let result_index = function.value_index(result).unwrap()
+      if skip_results[result_index] ||
+        environment_aliases[result_index] is Some(_) {
+        continue
+      }
+      if constants[function.value_index(constant).unwrap()] != Some(0UL) {
+        continue
+      }
+      // Forwarding drops this instruction, so it must not carry roots.
+      let metadata = function.instruction_metadata(instruction).unwrap()
+      if !metadata.live_gc_roots.is_empty() {
+        continue
+      }
+      environment_aliases[result_index] = Some(input)
+      address_immediates[result_index] = None
+    }
+  }
   {
     uses,
     immediates,


### PR DESCRIPTION
Investigation work for ISS-364. **Code-quality change, not a measured speedup** — see the honest result below.

## What was found

Profiling `aead_aegis256` (sampling the live process, not static guesswork) put **88% of runtime within ±512 bytes of one address**, which turned out to be a 368-byte inner loop in function 35. Two things that issue suspected were ruled out:

- **Not SIMD** — the module contains zero SIMD instructions; it is scalar software AES.
- **Not register allocation** — stack traffic is only 11% of the hot loop.

The loop was 93 instructions, of which **10 were `add xD, xN, #0`**.

## Why they were there

A WebAssembly access with no static offset lowers to `pointer.offset p, 0`, which is `p` since both sides are Ptr64. The AArch64 register-offset selector deliberately matches that zero offset as the *tail* of a foldable address, so when it fires the offset is free. When it does not fire, the fallback emits an add of zero.

The selector cannot fire for a base-relative access: it requires an `IntBinary(Add)` beneath the pointer bitcast to supply base and index. AEGIS reaches guest memory that way throughout its hot loop, so every access paid the add.

## Change

A final analysis pass forwards the result of a zero `pointer.offset` to its input. It runs **after** register-offset selection and claims only what that selector left behind, so the foldable shape is untouched. Instructions carrying live GC roots are excluded, since forwarding drops the instruction.

| | before | after |
| --- | --- | --- |
| hot loop instructions | 93 | **82** |
| hot loop bytes | 368 | **324** |
| function 35 bytes | 3768 | **3512** |
| `add reg, reg, #0` in the function | 10 | **0** |

No `mov` traffic replaced them.

## A failed attempt, recorded

My first attempt did the same simplification in the target-neutral `machv` cleanup pass (`pointer.offset p, 0 → p` as an alias). It made things **worse**: function 35 grew to 4496 bytes and the hot loop went to 95 instructions, because that zero offset is the anchor the register-offset selector matches on — removing it early broke folding for the accesses where it *did* work. Measured, reverted.

The lesson is in the code comment: the zero offset is not dead weight, it is a pattern anchor, and only the target knows which ones it still needs.

## No performance claim

Repeated runs on an idle machine:

```
aead_aegis256   1.3586, 1.3450, 1.3102
aead_aegis128l  1.3785, 1.3542, 2.0632
```

The spread is wider than any effect this change has, so **no speedup is claimed**. Removing 12% of the hot loop's instructions produced no measurable change, which is itself the useful finding: **AEGIS is not instruction-count bound.** The loop is latency bound, most plausibly on the T-table load dependency chain. Attacking instruction count — at milkir, machv, or regalloc — is the wrong axis for ISS-364.

## Verification

- `aarch64_target` 207/207
- workspace 977 wasm-gc + 1531 native
- core WAST 258/258 files, 62563 assertions, JIT and interpreter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
