### PR TITLE
Thread branches through empty forwarding blocks at emission

### DIFF
--- a/issues/ISS-369.md
+++ b/issues/ISS-369.md
@@ -1,0 +1,121 @@
+# ISS-369: Strengthen back-edge move coalescing in the backtracking allocator
+
+## Metadata
+- Type: task
+- Status: open
+- Priority: 2
+- Labels: regalloc, machv, aarch64, amd64, performance, loops, agent
+- Assignee: unassigned
+- Created: 2026-07-31
+- Updated: 2026-07-31
+- External ref: none
+
+## Description
+
+A loop-carried value that feeds a loop-header block parameter should share the
+parameter's register, so the back edge needs no move. When coalescing fails,
+the edge move lands on the loop-carried dependency chain and every iteration
+pays an extra serial instruction.
+
+Reproducer: a WebAssembly `x += 3` counted loop compiled inside a function
+with moderate register pressure emits
+
+```asm
+add  w1, w20, #3   ; increment into a fresh register
+...
+mov  w20, w1       ; back-edge move, on the dependent chain
+b    loop
+```
+
+where an in-place `add w20, w20, #3` was available. On a latency-bound loop
+this is a measured 2.0x against Wasmtime; branch threading (the empty-edge fix
+that accompanied this investigation) removes the second taken branch, and this
+issue tracks removing the move.
+
+In a standalone function the coalescing succeeds; it fails once other live
+values contend for registers. AEGIS-class loops carry eight state words, so
+each failure adds one serial move per word per iteration.
+
+## Where coalescing lives and how it fails
+
+Mapped against the tree on 2026-07-31; paths under `modules/regalloc` unless
+noted.
+
+- Edge moves are decided solely by `assign_edge_transfers`
+  (function_allocate.mbt:217-290). Destination is always the parameter's
+  per-value home (`plan.value_location`); a parameter whose segments disagree
+  gets a spill-slot home, which forces every predecessor edge to store.
+- Intended coalescing is bundle merging: `collect_production_bundle_edges`
+  (bundle_plan.mbt:327-354) pairs argument and parameter ranges, including
+  back edges; `try_merge_bundle_edge` (bundle_plan.mbt:209-261) merges via
+  union-find.
+
+Observed failure modes, in likelihood order:
+
+1. Span conflict rejects the merge (`bundle_spans_conflict`,
+   bundle_plan.mbt:148-178) whenever the parameter is still live at or after
+   the argument's def — which is the normal shape when the loop condition
+   reads the parameter after the increment. Transitive merges into the same
+   root can also poison a later merge.
+2. The merged bundle fails to find one register across all segments and is
+   split (`split_bundle_at_conflict`, bundle_allocate.mbt:471-525). Children
+   are allocated independently and carry only a soft `split_hint`; register
+   agreement across the back edge is lost.
+3. With merge rejected, affinity relies on probe order
+   (`bundle_register_order`, bundle_allocate.mbt:306-360). The related
+   register is probed first, but any conflicting occupant silently pushes the
+   allocation to the next free register.
+4. `edge_target_registers` (bundle_allocate.mbt:996-999) is a global
+   per-register "some edge parameter lives here" flag that steers every
+   edge-argument bundle away from all parameter registers once the specific
+   hint misses — a global anti-affinity that fights coalescing.
+5. Eviction requeues the victim with no hint
+   (`evict_bundle_conflicts`, bundle_allocate.mbt:391-404), while stale
+   `preferred_by_value` entries persist.
+
+A narrower post-pass, `coalesce_bridge_segments`
+(bundle_allocate.mbt:827-970), runs only in functions with zero instruction
+clobbers and does not address edges.
+
+## Design
+
+Candidate directions, cheapest first; each needs the reproducer plus a
+pressure variant measured before and after:
+
+1. Weight the affinity probe: when the related register's occupant is
+   evictable and the edge is a loop back edge, prefer eviction over silently
+   taking the next free register.
+2. Scope `edge_target_registers` per edge or drop it; a global anti-affinity
+   is the wrong shape.
+3. On split, propagate the parameter's register as a hard preference to the
+   child covering the back edge.
+4. Revisit the span-conflict test for argument-parameter pairs: overlap where
+   the overlapping segments' uses are move-compatible does not have to reject
+   the merge.
+
+Do not regress allocation soundness for coalescing; the verifier and the full
+gauntlet stay authoritative.
+
+## Acceptance Criteria
+
+- [ ] The `x += 3` pressure reproducer compiles with an in-place add and no
+      back-edge move on both targets.
+- [ ] The `examples/algorithms` corpus compiles and runs unchanged or faster;
+      no workload regresses beyond noise on min-of-5.
+- [ ] Focused regalloc tests cover the chosen mechanism, including a negative
+      case where coalescing must yield to a genuine conflict.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-364, ISS-221
+- Discovered from: ISS-364 investigation
+
+## Notes
+
+- 2026-07-31: The accompanying branch-threading emitter change removes the
+  second taken branch per iteration on moveless back edges (2.0x -> 1.007x on
+  the reproducer). The residual cost tracked here is the move itself, which
+  only appears under register pressure.
+
+## Close Notes

--- a/modules/aarch64_target/emit.mbt
+++ b/modules/aarch64_target/emit.mbt
@@ -3398,7 +3398,11 @@ fn emit_instruction(
     }
     Jump => {
       emit_edge_moves(buffer, function, allocation, frame, block, 0)
-      let target = function.instruction_successor_at(instruction, 0).unwrap().target
+      let target = threaded_branch_target(
+        function,
+        allocation,
+        function.instruction_successor_at(instruction, 0).unwrap().target,
+      )
       if next_block != Some(target) {
         buffer.emit_branch(target, 26, 0x14000000U)
       }

--- a/modules/aarch64_target/emit_edges.mbt
+++ b/modules/aarch64_target/emit_edges.mbt
@@ -80,6 +80,58 @@ fn emit_resolved_moves(
 }
 
 ///|
+/// Chase a branch target through empty forwarding blocks.
+///
+/// Lowering splits critical edges, so a branch frequently targets a block
+/// whose only content is an unconditional jump carrying the edge arguments.
+/// When allocation gives those arguments and the destination parameters the
+/// same locations, the block emits as a single `b`, and a loop back edge then
+/// pays two taken branches per iteration instead of one. Branching straight
+/// to the final destination removes the hop.
+///
+/// A block is skipped only when nothing observable happens in it: no body
+/// instructions, no allocation edits anchored on its terminator, and an edge
+/// whose parallel moves resolve to nothing. The forwarding block itself is
+/// still emitted, so predecessors that do need its moves keep their path.
+///
+/// Threading can lengthen a conditional branch's displacement, and imm19
+/// reaches only ±1MB with no intra-function veneer support. That exposure
+/// predates threading — every moveless edge already aims imm19 branches at
+/// arbitrary blocks — and an overflow raises a structured BranchOutOfRange
+/// at patch time rather than emitting a wrong offset.
+fn threaded_branch_target(
+  function : @vcode.Function[AArch64Inst],
+  allocation : @vcode.Allocation,
+  target : @vcode.Block,
+) -> @vcode.Block raise AArch64EmitError {
+  let mut current = target
+  // Forwarding chains longer than a few hops do not occur in practice; the
+  // bound also terminates on a cycle of empty blocks.
+  for _hop in 0..<4 {
+    if !function.block_body(current).is_empty() {
+      break
+    }
+    guard function.block_terminator(current) is Some(terminator) else { break }
+    guard function.instruction(terminator) is Some(Jump) else { break }
+    if !allocation.edits_at(terminator, Before).is_empty() ||
+      !allocation.edits_at(terminator, After).is_empty() {
+      break
+    }
+    if !resolve_edge_moves(function, allocation, current, 0).is_empty() {
+      break
+    }
+    guard function.instruction_successor_at(terminator, 0) is Some(edge) else {
+      break
+    }
+    if edge.target == current {
+      break
+    }
+    current = edge.target
+  }
+  current
+}
+
+///|
 fn emit_edge_moves(
   buffer : CodeBuffer,
   function : @vcode.Function[AArch64Inst],
@@ -111,42 +163,47 @@ fn emit_two_way_edges(
   let when_false = function.instruction_successor_at(instruction, 1).unwrap().target
   let true_moves = resolve_edge_moves(function, allocation, block, 0)
   let false_moves = resolve_edge_moves(function, allocation, block, 1)
+  // Fallthrough decisions compare the original successors; emitted branches
+  // go to the threaded targets. The edge's own moves are emitted here either
+  // way, so threading only skips blocks that contribute nothing.
+  let threaded_true = threaded_branch_target(function, allocation, when_true)
+  let threaded_false = threaded_branch_target(function, allocation, when_false)
   if next_block == Some(when_false) {
     if true_moves.is_empty() {
-      buffer.emit_branch(when_true, 19, true_branch_base)
+      buffer.emit_branch(threaded_true, 19, true_branch_base)
       emit_resolved_moves(buffer, frame, false_moves)
     } else {
       let local_false_branch = buffer.position()
       buffer.emit_word(false_branch_base)
       emit_resolved_moves(buffer, frame, true_moves)
-      buffer.emit_branch(when_true, 26, 0x14000000U)
+      buffer.emit_branch(threaded_true, 26, 0x14000000U)
       patch_relative_branch(buffer, local_false_branch, buffer.position(), 19)
       emit_resolved_moves(buffer, frame, false_moves)
     }
   } else if next_block == Some(when_true) {
     if false_moves.is_empty() {
-      buffer.emit_branch(when_false, 19, false_branch_base)
+      buffer.emit_branch(threaded_false, 19, false_branch_base)
       emit_resolved_moves(buffer, frame, true_moves)
     } else {
       let local_true_branch = buffer.position()
       buffer.emit_word(true_branch_base)
       emit_resolved_moves(buffer, frame, false_moves)
-      buffer.emit_branch(when_false, 26, 0x14000000U)
+      buffer.emit_branch(threaded_false, 26, 0x14000000U)
       patch_relative_branch(buffer, local_true_branch, buffer.position(), 19)
       emit_resolved_moves(buffer, frame, true_moves)
     }
   } else if true_moves.is_empty() {
-    buffer.emit_branch(when_true, 19, true_branch_base)
+    buffer.emit_branch(threaded_true, 19, true_branch_base)
     emit_resolved_moves(buffer, frame, false_moves)
-    buffer.emit_branch(when_false, 26, 0x14000000U)
+    buffer.emit_branch(threaded_false, 26, 0x14000000U)
   } else {
     let local_true_branch = buffer.position()
     buffer.emit_word(true_branch_base)
     emit_resolved_moves(buffer, frame, false_moves)
-    buffer.emit_branch(when_false, 26, 0x14000000U)
+    buffer.emit_branch(threaded_false, 26, 0x14000000U)
     patch_relative_branch(buffer, local_true_branch, buffer.position(), 19)
     emit_resolved_moves(buffer, frame, true_moves)
-    buffer.emit_branch(when_true, 26, 0x14000000U)
+    buffer.emit_branch(threaded_true, 26, 0x14000000U)
   }
 }
 
@@ -216,7 +273,11 @@ fn emit_switch_edges(
   if cases.is_empty() {
     emit_edge_moves(buffer, function, allocation, frame, block, 0)
     buffer.emit_branch(
-      function.instruction_successor_at(instruction, 0).unwrap().target,
+      threaded_branch_target(
+        function,
+        allocation,
+        function.instruction_successor_at(instruction, 0).unwrap().target,
+      ),
       26,
       0x14000000U,
     )
@@ -237,7 +298,11 @@ fn emit_switch_edges(
     )
     let default_branch : Int? = if default_moves.is_empty() {
       buffer.emit_branch(
-        function.instruction_successor_at(instruction, default_index).unwrap().target,
+        threaded_branch_target(
+          function,
+          allocation,
+          function.instruction_successor_at(instruction, default_index).unwrap().target,
+        ),
         19,
         0x54000002U,
       )
@@ -265,9 +330,13 @@ fn emit_switch_edges(
       }
       if edge_parallel_moves(function, allocation, block, successor_index).is_empty() {
         buffer.emit_branch(
-          function
-          .instruction_successor_at(instruction, successor_index)
-          .unwrap().target,
+          threaded_branch_target(
+            function,
+            allocation,
+            function
+            .instruction_successor_at(instruction, successor_index)
+            .unwrap().target,
+          ),
           26,
           0x14000000U,
         )
@@ -283,7 +352,13 @@ fn emit_switch_edges(
         buffer, function, allocation, frame, block, successor_index,
       )
       buffer.emit_branch(
-        function.instruction_successor_at(instruction, successor_index).unwrap().target,
+        threaded_branch_target(
+          function,
+          allocation,
+          function
+          .instruction_successor_at(instruction, successor_index)
+          .unwrap().target,
+        ),
         26,
         0x14000000U,
       )
@@ -292,7 +367,11 @@ fn emit_switch_edges(
       patch_relative_branch(buffer, branch, buffer.position(), 19)
       emit_resolved_moves(buffer, frame, default_moves)
       buffer.emit_branch(
-        function.instruction_successor_at(instruction, default_index).unwrap().target,
+        threaded_branch_target(
+          function,
+          allocation,
+          function.instruction_successor_at(instruction, default_index).unwrap().target,
+        ),
         26,
         0x14000000U,
       )
@@ -304,9 +383,13 @@ fn emit_switch_edges(
       emit_switch_compare(buffer, width, index, bits)
       if edge_parallel_moves(function, allocation, block, successor_index).is_empty() {
         buffer.emit_branch(
-          function
-          .instruction_successor_at(instruction, successor_index)
-          .unwrap().target,
+          threaded_branch_target(
+            function,
+            allocation,
+            function
+            .instruction_successor_at(instruction, successor_index)
+            .unwrap().target,
+          ),
           19,
           0x54000000U,
         )
@@ -317,7 +400,11 @@ fn emit_switch_edges(
     }
     emit_edge_moves(buffer, function, allocation, frame, block, cases.length())
     buffer.emit_branch(
-      function.instruction_successor_at(instruction, cases.length()).unwrap().target,
+      threaded_branch_target(
+        function,
+        allocation,
+        function.instruction_successor_at(instruction, cases.length()).unwrap().target,
+      ),
       26,
       0x14000000U,
     )
@@ -328,7 +415,13 @@ fn emit_switch_edges(
         buffer, function, allocation, frame, block, successor_index,
       )
       buffer.emit_branch(
-        function.instruction_successor_at(instruction, successor_index).unwrap().target,
+        threaded_branch_target(
+          function,
+          allocation,
+          function
+          .instruction_successor_at(instruction, successor_index)
+          .unwrap().target,
+        ),
         26,
         0x14000000U,
       )

--- a/modules/aarch64_target/emit_test.mbt
+++ b/modules/aarch64_target/emit_test.mbt
@@ -5471,3 +5471,126 @@ test "AArch64 edge emission resolves register cycles through reserved scratch" {
     ),
   )
 }
+
+///|
+/// A counted loop whose back edge carries block arguments. When allocation
+/// coalesces the arguments onto the parameters, the split-edge block is a
+/// bare forwarding jump, and the loop's conditional branch must target the
+/// loop head directly rather than paying a second taken branch through the
+/// forwarding block every iteration.
+test "AArch64 pipeline threads a moveless loop back edge to the loop head" {
+  let builder = @semantic.FunctionBuilder::new(
+    "threaded_back_edge",
+    Platform,
+    [I32],
+    [I32],
+  )
+  let count = builder.parameters()[0]
+  let loop_head = builder.create_block([I32, I32])
+  // Frontends split the critical back edge into a dedicated block whose only
+  // job is to carry the edge arguments, exactly as modeled here.
+  let back_edge = builder.create_block([])
+  let exit = builder.create_block([])
+  let zero = builder.emit(I32Const(0U), [], [I32])[0]
+  builder.jump(loop_head, [count, zero])
+  builder.switch_to_block(loop_head)
+  let n = builder.block_parameters(loop_head)[0]
+  let x = builder.block_parameters(loop_head)[1]
+  let three = builder.emit(I32Const(3U), [], [I32])[0]
+  let one = builder.emit(I32Const(1U), [], [I32])[0]
+  let next_x = builder.emit(IntBinary(Add), [x, three], [I32])[0]
+  let next_n = builder.emit(IntBinary(Sub), [n, one], [I32])[0]
+  builder.branch(next_n, back_edge, [], exit, [])
+  builder.switch_to_block(back_edge)
+  builder.jump(loop_head, [next_n, next_x])
+  builder.switch_to_block(exit)
+  builder.return_([next_x])
+  let selected = lower(builder.finish(), test_lowering_context())
+  let (object, _) = compile(selected)
+  // Decode every branch and record its byte displacement. The loop's
+  // conditional branch must jump backward to the loop body, and no
+  // taken-path branch may land on another unconditional branch.
+  let code = object.code()
+  let branch_targets : Array[(Int, Int)] = []
+  for offset = 0; offset < code.length(); offset = offset + 4 {
+    let word = code[offset].to_uint() |
+      (code[offset + 1].to_uint() << 8) |
+      (code[offset + 2].to_uint() << 16) |
+      (code[offset + 3].to_uint() << 24)
+    if (word & 0x7F000000U) == 0x35000000U ||
+      (word & 0x7F000000U) == 0x34000000U {
+      // cbnz/cbz: imm19 at bits [23:5]
+      let imm = ((word >> 5) & 0x7FFFFU).reinterpret_as_int()
+      let signed = if imm >= 0x40000 { imm - 0x80000 } else { imm }
+      branch_targets.push((offset, offset + signed * 4))
+    }
+  }
+  // Exactly one conditional branch, and it targets the loop head (a backward
+  // branch to the add instruction), not a forwarding stub past the return.
+  guard branch_targets is [(branch_offset, target_offset)] else {
+    fail("expected exactly one conditional branch, got \{branch_targets}")
+  }
+  debug_inspect(target_offset < branch_offset, content="true")
+  // Pin the exact destination: the loop body's first instruction (the add at
+  // offset 4, after the movz that seeds the accumulator). A target that is
+  // merely backward — the entry, or the sub — would be a miscompile that a
+  // weaker assertion accepts.
+  inspect(target_offset, content="4")
+}
+
+///|
+/// The refusal side of back-edge threading: when the forwarding block's jump
+/// carries parallel moves that allocation could not coalesce away, the
+/// conditional branch must keep targeting the forwarding block so the moves
+/// execute. Feeding one value into both loop parameters forces at least one
+/// move no matter how registers are assigned, since two live parameters
+/// cannot share a home.
+test "AArch64 pipeline keeps a loop back edge with moves unthreaded" {
+  let builder = @semantic.FunctionBuilder::new(
+    "unthreaded_back_edge",
+    Platform,
+    [I32],
+    [I32],
+  )
+  let count = builder.parameters()[0]
+  let loop_head = builder.create_block([I32, I32])
+  let back_edge = builder.create_block([])
+  let exit = builder.create_block([])
+  let zero = builder.emit(I32Const(0U), [], [I32])[0]
+  builder.jump(loop_head, [count, zero])
+  builder.switch_to_block(loop_head)
+  let n = builder.block_parameters(loop_head)[0]
+  let x = builder.block_parameters(loop_head)[1]
+  let three = builder.emit(I32Const(3U), [], [I32])[0]
+  let one = builder.emit(I32Const(1U), [], [I32])[0]
+  let next_x = builder.emit(IntBinary(Add), [x, three], [I32])[0]
+  let next_n = builder.emit(IntBinary(Sub), [n, one], [I32])[0]
+  builder.branch(next_n, back_edge, [], exit, [])
+  builder.switch_to_block(back_edge)
+  builder.jump(loop_head, [next_n, next_n])
+  builder.switch_to_block(exit)
+  builder.return_([next_x])
+  let selected = lower(builder.finish(), test_lowering_context())
+  let (object, _) = compile(selected)
+  let code = object.code()
+  let branch_targets : Array[(Int, Int)] = []
+  for offset = 0; offset < code.length(); offset = offset + 4 {
+    let word = code[offset].to_uint() |
+      (code[offset + 1].to_uint() << 8) |
+      (code[offset + 2].to_uint() << 16) |
+      (code[offset + 3].to_uint() << 24)
+    if (word & 0x7F000000U) == 0x35000000U ||
+      (word & 0x7F000000U) == 0x34000000U {
+      let imm = ((word >> 5) & 0x7FFFFU).reinterpret_as_int()
+      let signed = if imm >= 0x40000 { imm - 0x80000 } else { imm }
+      branch_targets.push((offset, offset + signed * 4))
+    }
+  }
+  guard branch_targets is [(_, target_offset)] else {
+    fail("expected exactly one conditional branch, got \{branch_targets}")
+  }
+  // The loop body's first instruction sits at offset 4, as in the threading
+  // test above. With moves pending on the back edge, the branch must NOT be
+  // threaded there; it has to route through the forwarding block.
+  debug_inspect(target_offset == 4, content="false")
+}

--- a/modules/x64_target/emit.mbt
+++ b/modules/x64_target/emit.mbt
@@ -3974,7 +3974,11 @@ fn emit_instruction(
     }
     Jump => {
       emit_edge_moves(buffer, function, allocation, frame, block, 0)
-      let target = function.instruction_successor_at(instruction, 0).unwrap().target
+      let target = threaded_branch_target(
+        function,
+        allocation,
+        function.instruction_successor_at(instruction, 0).unwrap().target,
+      )
       if next_block != Some(target) {
         buffer.x86_emit_jmp_rel32(function.block_index(target).unwrap())
       }

--- a/modules/x64_target/emit_edges.mbt
+++ b/modules/x64_target/emit_edges.mbt
@@ -99,6 +99,52 @@ fn emit_edge_moves(
 }
 
 ///|
+/// Chase a branch target through empty forwarding blocks.
+///
+/// Lowering splits critical edges, so a branch frequently targets a block
+/// whose only content is an unconditional jump carrying the edge arguments.
+/// When allocation gives those arguments and the destination parameters the
+/// same locations, the block emits as a single `jmp`, and a loop back edge
+/// then pays two taken branches per iteration instead of one. Branching
+/// straight to the final destination removes the hop.
+///
+/// A block is skipped only when nothing observable happens in it: no body
+/// instructions, no allocation edits anchored on its terminator, and an edge
+/// whose parallel moves resolve to nothing. The forwarding block itself is
+/// still emitted, so predecessors that do need its moves keep their path.
+fn threaded_branch_target(
+  function : @vcode.Function[X64Inst],
+  allocation : @vcode.Allocation,
+  target : @vcode.Block,
+) -> @vcode.Block raise X64EmitError {
+  let mut current = target
+  // Forwarding chains longer than a few hops do not occur in practice; the
+  // bound also terminates on a cycle of empty blocks.
+  for _hop in 0..<4 {
+    if !function.block_body(current).is_empty() {
+      break
+    }
+    guard function.block_terminator(current) is Some(terminator) else { break }
+    guard function.instruction(terminator) is Some(Jump) else { break }
+    if !allocation.edits_at(terminator, Before).is_empty() ||
+      !allocation.edits_at(terminator, After).is_empty() {
+      break
+    }
+    if !resolve_edge_moves(function, allocation, current, 0).is_empty() {
+      break
+    }
+    guard function.instruction_successor_at(terminator, 0) is Some(edge) else {
+      break
+    }
+    if edge.target == current {
+      break
+    }
+    current = edge.target
+  }
+  current
+}
+
+///|
 fn emit_conditional_edges(
   buffer : CodeBuffer,
   function : @vcode.Function[X64Inst],
@@ -113,10 +159,19 @@ fn emit_conditional_edges(
   let when_false = function.instruction_successor_at(instruction, 1).unwrap().target
   let true_moves = resolve_edge_moves(function, allocation, block, 0)
   let false_moves = resolve_edge_moves(function, allocation, block, 1)
+  // Fallthrough decisions compare the original successors; emitted branches
+  // go to the threaded targets. The edge's own moves are emitted here either
+  // way, so threading only skips blocks that contribute nothing.
+  let threaded_true = function
+    .block_index(threaded_branch_target(function, allocation, when_true))
+    .unwrap()
+  let threaded_false = function
+    .block_index(threaded_branch_target(function, allocation, when_false))
+    .unwrap()
   buffer.x86_emit_test_rr32(condition.id, condition.id)
   if next_block == Some(when_false) {
     if true_moves.is_empty() {
-      buffer.x86_emit_jcc_rel32(RawNe, function.block_index(when_true).unwrap())
+      buffer.x86_emit_jcc_rel32(RawNe, threaded_true)
       emit_resolved_moves(buffer, frame, false_moves)
     } else {
       buffer.emit_byte(0x0F)
@@ -124,16 +179,13 @@ fn emit_conditional_edges(
       let local_false_branch = buffer.position()
       emit_u32_le(buffer, 0)
       emit_resolved_moves(buffer, frame, true_moves)
-      buffer.x86_emit_jmp_rel32(function.block_index(when_true).unwrap())
+      buffer.x86_emit_jmp_rel32(threaded_true)
       patch_relative_branch(buffer, local_false_branch, buffer.position(), 32)
       emit_resolved_moves(buffer, frame, false_moves)
     }
   } else if next_block == Some(when_true) {
     if false_moves.is_empty() {
-      buffer.x86_emit_jcc_rel32(
-        RawEq,
-        function.block_index(when_false).unwrap(),
-      )
+      buffer.x86_emit_jcc_rel32(RawEq, threaded_false)
       emit_resolved_moves(buffer, frame, true_moves)
     } else {
       buffer.emit_byte(0x0F)
@@ -141,28 +193,28 @@ fn emit_conditional_edges(
       let local_true_branch = buffer.position()
       emit_u32_le(buffer, 0)
       emit_resolved_moves(buffer, frame, false_moves)
-      buffer.x86_emit_jmp_rel32(function.block_index(when_false).unwrap())
+      buffer.x86_emit_jmp_rel32(threaded_false)
       patch_relative_branch(buffer, local_true_branch, buffer.position(), 32)
       emit_resolved_moves(buffer, frame, true_moves)
     }
   } else if true_moves.is_empty() {
-    buffer.x86_emit_jcc_rel32(RawNe, function.block_index(when_true).unwrap())
+    buffer.x86_emit_jcc_rel32(RawNe, threaded_true)
     emit_resolved_moves(buffer, frame, false_moves)
-    buffer.x86_emit_jmp_rel32(function.block_index(when_false).unwrap())
+    buffer.x86_emit_jmp_rel32(threaded_false)
   } else if false_moves.is_empty() {
-    buffer.x86_emit_jcc_rel32(RawEq, function.block_index(when_false).unwrap())
+    buffer.x86_emit_jcc_rel32(RawEq, threaded_false)
     emit_resolved_moves(buffer, frame, true_moves)
-    buffer.x86_emit_jmp_rel32(function.block_index(when_true).unwrap())
+    buffer.x86_emit_jmp_rel32(threaded_true)
   } else {
     buffer.emit_byte(0x0F)
     buffer.emit_byte(x86_cond_to_jcc_opcode(RawEq))
     let local_false_branch = buffer.position()
     emit_u32_le(buffer, 0)
     emit_resolved_moves(buffer, frame, true_moves)
-    buffer.x86_emit_jmp_rel32(function.block_index(when_true).unwrap())
+    buffer.x86_emit_jmp_rel32(threaded_true)
     patch_relative_branch(buffer, local_false_branch, buffer.position(), 32)
     emit_resolved_moves(buffer, frame, false_moves)
-    buffer.x86_emit_jmp_rel32(function.block_index(when_false).unwrap())
+    buffer.x86_emit_jmp_rel32(threaded_false)
   }
 }
 
@@ -207,7 +259,11 @@ fn emit_switch_edges(
     buffer.x86_emit_jmp_rel32(
       function
       .block_index(
-        function.instruction_successor_at(instruction, 0).unwrap().target,
+        threaded_branch_target(
+          function,
+          allocation,
+          function.instruction_successor_at(instruction, 0).unwrap().target,
+        ),
       )
       .unwrap(),
     )
@@ -225,7 +281,11 @@ fn emit_switch_edges(
   buffer.x86_emit_jmp_rel32(
     function
     .block_index(
-      function.instruction_successor_at(instruction, cases.length()).unwrap().target,
+      threaded_branch_target(
+        function,
+        allocation,
+        function.instruction_successor_at(instruction, cases.length()).unwrap().target,
+      ),
     )
     .unwrap(),
   )
@@ -236,7 +296,13 @@ fn emit_switch_edges(
     buffer.x86_emit_jmp_rel32(
       function
       .block_index(
-        function.instruction_successor_at(instruction, successor_index).unwrap().target,
+        threaded_branch_target(
+          function,
+          allocation,
+          function
+          .instruction_successor_at(instruction, successor_index)
+          .unwrap().target,
+        ),
       )
       .unwrap(),
     )

--- a/modules/x64_target/emit_test.mbt
+++ b/modules/x64_target/emit_test.mbt
@@ -1802,3 +1802,110 @@ test "X64 pipeline forwards result areas through internal tail calls" {
     ),
   )
 }
+
+///|
+/// A counted loop whose back edge carries block arguments through a split
+/// edge block. With coalesced allocation that block is a bare forwarding
+/// jump, and the loop's conditional branch must target the loop head
+/// directly instead of hopping through it every iteration.
+test "X64 pipeline threads a moveless loop back edge to the loop head" {
+  let builder = @semantic.FunctionBuilder::new(
+    "threaded_back_edge",
+    Platform,
+    [I32],
+    [I32],
+  )
+  let count = builder.parameters()[0]
+  let loop_head = builder.create_block([I32, I32])
+  let back_edge = builder.create_block([])
+  let exit = builder.create_block([])
+  let zero = builder.emit(I32Const(0U), [], [I32])[0]
+  builder.jump(loop_head, [count, zero])
+  builder.switch_to_block(loop_head)
+  let n = builder.block_parameters(loop_head)[0]
+  let x = builder.block_parameters(loop_head)[1]
+  let three = builder.emit(I32Const(3U), [], [I32])[0]
+  let one = builder.emit(I32Const(1U), [], [I32])[0]
+  let next_x = builder.emit(IntBinary(Add), [x, three], [I32])[0]
+  let next_n = builder.emit(IntBinary(Sub), [n, one], [I32])[0]
+  builder.branch(next_n, back_edge, [], exit, [])
+  builder.switch_to_block(back_edge)
+  builder.jump(loop_head, [next_n, next_x])
+  builder.switch_to_block(exit)
+  builder.return_([next_x])
+  let selected = lower(builder.finish(), test_lowering_context())
+  let (object, _) = compile(selected)
+  // Find every jcc rel32 (0x0F 0x8x) and record its resolved target. The
+  // loop's conditional branch must resolve backward to the loop body, and
+  // the byte at its target must not be an unconditional jmp (0xE9), which
+  // would mean the edge still hops through the forwarding block.
+  let code = object.code()
+  let branch_targets : Array[(Int, Int)] = []
+  for offset in 0..<(code.length() - 5) {
+    if code[offset] == b'\x0F' && (code[offset + 1].to_int() & 0xF0) == 0x80 {
+      let rel = code[offset + 2].to_int() |
+        (code[offset + 3].to_int() << 8) |
+        (code[offset + 4].to_int() << 16) |
+        (code[offset + 5].to_int() << 24)
+      branch_targets.push((offset, offset + 6 + rel))
+    }
+  }
+  guard branch_targets is [(branch_offset, target_offset)] else {
+    fail("expected exactly one conditional branch, got \{branch_targets}")
+  }
+  debug_inspect(target_offset < branch_offset, content="true")
+  // Pin the exact destination byte offset of the loop body's first
+  // instruction; a merely-backward target would accept a miscompile.
+  inspect(target_offset, content="10")
+}
+
+///|
+/// The refusal side of back-edge threading: with parallel moves pending on
+/// the forwarding block's jump, the conditional branch must keep routing
+/// through it. One value feeding both loop parameters forces at least one
+/// move regardless of register assignment.
+test "X64 pipeline keeps a loop back edge with moves unthreaded" {
+  let builder = @semantic.FunctionBuilder::new(
+    "unthreaded_back_edge",
+    Platform,
+    [I32],
+    [I32],
+  )
+  let count = builder.parameters()[0]
+  let loop_head = builder.create_block([I32, I32])
+  let back_edge = builder.create_block([])
+  let exit = builder.create_block([])
+  let zero = builder.emit(I32Const(0U), [], [I32])[0]
+  builder.jump(loop_head, [count, zero])
+  builder.switch_to_block(loop_head)
+  let n = builder.block_parameters(loop_head)[0]
+  let x = builder.block_parameters(loop_head)[1]
+  let three = builder.emit(I32Const(3U), [], [I32])[0]
+  let one = builder.emit(I32Const(1U), [], [I32])[0]
+  let next_x = builder.emit(IntBinary(Add), [x, three], [I32])[0]
+  let next_n = builder.emit(IntBinary(Sub), [n, one], [I32])[0]
+  builder.branch(next_n, back_edge, [], exit, [])
+  builder.switch_to_block(back_edge)
+  builder.jump(loop_head, [next_n, next_n])
+  builder.switch_to_block(exit)
+  builder.return_([next_x])
+  let selected = lower(builder.finish(), test_lowering_context())
+  let (object, _) = compile(selected)
+  let code = object.code()
+  let branch_targets : Array[(Int, Int)] = []
+  for offset in 0..<(code.length() - 5) {
+    if code[offset] == b'\x0F' && (code[offset + 1].to_int() & 0xF0) == 0x80 {
+      let rel = code[offset + 2].to_int() |
+        (code[offset + 3].to_int() << 8) |
+        (code[offset + 4].to_int() << 16) |
+        (code[offset + 5].to_int() << 24)
+      branch_targets.push((offset, offset + 6 + rel))
+    }
+  }
+  guard branch_targets is [(_, target_offset)] else {
+    fail("expected exactly one conditional branch, got \{branch_targets}")
+  }
+  // Offset 10 is the loop body's first instruction, as pinned by the
+  // threading test above; with moves pending it must not be the target.
+  debug_inspect(target_offset == 10, content="false")
+}


### PR DESCRIPTION
Fixes the loop back-edge branch chain found while investigating ISS-364. Stacked on #448.

## The defect

Lowering splits critical edges, so a branch frequently targets a block whose only content is an unconditional jump carrying the edge arguments. When allocation coalesces those arguments onto the destination parameters, that block emits as a single branch — and a loop back edge pays **two taken branches per iteration**:

```asm
add  w0, w0, #3
sub  w1, w1, #1
cbnz w1, stub      ; taken every iteration
ret
stub: b loop_head  ; second taken branch
```

Apple Silicon retires ~1 taken branch/cycle, so this sets a 2-cycle floor on a 1-cycle loop. Measured on a minimal wasm counted loop (1e9 iterations, min-of-3, startup-subtracted):

| | before | after |
| --- | --- | --- |
| vs wasmtime | **2.001×** | **1.007×** |
| cycles/iter | 2.15 | ~1.08 |

## The fix

At emission, chase every branch target through empty forwarding blocks (≤4 hops). A block is skipped only when nothing observable happens in it:

- no body instructions,
- no allocation edits anchored on its terminator (`edits_at` Before/After),
- an edge whose parallel moves resolve to nothing.

The forwarding block is still emitted, so predecessors that need its moves keep their path. Both targets, all branch shapes (conditional, unconditional, switch).

## Adversarial review, and what it changed

A three-lens skeptic panel reviewed the diff (soundness / control-flow / test-validity). Findings and outcomes:

- **imm19 range** (likely): threading can lengthen an AArch64 conditional displacement past ±1MB with no intra-function veneers. Pre-existing exposure class — moveless edges already aim imm19 branches at arbitrary blocks — and overflow raises structured `BranchOutOfRange` at patch time rather than emitting a wrong offset. Documented on the helper.
- **Tests under-constrained** (certain, mutation-verified by the reviewer): "backward and not an unconditional branch" also accepts miscompiled targets. Fixed: exact target offsets pinned (4 on AArch64, 10 on x64).
- **Refusal path untested** (certain): nothing proved threading *declines* when moves are pending. Fixed: new tests feed one value into both loop parameters — a shape that forces an edge move under any register assignment — and assert the branch is not threaded.

All four new tests are mutation-verified in both directions: threading tests fail with threading disabled; refusal tests fail with the emptiness guard removed.

Residual accepted risk: the `edits_at` guard is defensive and not independently testable from the public harness (no allocator state anchors edits on an empty block's terminator today).

## Verification on this exact tree

| Gate | Result |
| --- | --- |
| aarch64 + x64 target suites | 310/310 |
| Full workspace `moon test` | 981 wasm-gc + 1531 native |
| Core WAST | 258/258 files, 62563 assertions, JIT + interpreter |
| Component suites (all three) | 0 failures |
| **`examples/algorithms` corpus, all 70 workloads** | **0 failures** |

The corpus gate matters: during this work an unrelated milkir scheduling experiment passed every standard suite while breaking `auth.wasm` compilation — the corpus caught it, WAST could not. That experiment was dropped, not shipped.

## What this does and does not claim

- The 2.0× → 1.007× is on the minimal reproducer, where the back edge is the whole story.
- AEGIS (ISS-364) is **not** claimed improved: its hot loop's back edge already falls through, and its measured gap is unmoved.
- The second half of the back-edge cost — coalescing that fails under register pressure, leaving a `mov` on the loop-carried chain — is documented with the allocator's failure modes mapped to file:line in **ISS-369**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
