### PR TITLE
Make allocation-plan verification linear in edits and CFG size

### DIFF
--- a/issues/ISS-370.md
+++ b/issues/ISS-370.md
@@ -1,0 +1,115 @@
+# ISS-370: Make allocation-plan verification linear in edits and CFG size
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 1
+- Labels: regalloc, compile-time, performance, verifier, agent
+- Assignee: unassigned
+- Created: 2026-07-31
+- Updated: 2026-07-31
+- External ref: none
+
+## Description
+
+JIT compilation time explodes on functions with deeply nested structured
+control flow. A user-supplied 46,917-byte module whose largest function nests
+blocks 47 deep compiles in about 58 seconds, while the interpreter executes
+the same program in 0.04s and Wasmtime compiles the same bytes in 0.055s
+(measured locally). A companion 82,539-byte module with nesting 17 compiles
+in seconds. The reporter's truncation series shows time following nesting
+depth, not module size, roughly doubling every five to six levels.
+
+Sampling the 58-second compile attributes over 99% of samples (6564 of
+~6600) to a single function: `apply_position_edits` in
+`modules/regalloc/verify_plan.mbt`, reached from the allocation-plan
+verifier. Verification is always on in production
+(`RegallocConfig(verify=true)` at machv_regalloc/vcode_adapter.mbt:139), so
+this is JIT compile time, not a diagnostic-only path.
+
+## Root cause
+
+Two independent complexity defects multiply:
+
+1. **Per-instruction linear scan of the whole edit array.**
+   `process_plan_block` calls `apply_position_edits(state, edits,
+   Before/After(instruction))` twice per instruction, and each call filters
+   the complete function-wide `Array[AllocationEdit]` by position
+   (verify_plan.mbt:126-136). Cost per block visit is O(instructions x
+   total_edits). `prepare_successor_state` does the same full scan per edge
+   (verify_plan.mbt:240-245). On a 3379-line function both factors are in
+   the thousands.
+
+2. **LIFO worklist without priority on join-dense CFGs.** The dataflow
+   driver (verify_plan.mbt:317-345) pops a plain stack and re-enqueues
+   successors on every state refinement. A 47-deep tower of blocks is a
+   long chain of forward joins; each meet refinement re-propagates down the
+   rest of the chain, so the number of block visits grows with nesting
+   depth rather than staying near one visit per block.
+
+Total cost is roughly depth-driven revisits x instructions x edits, which
+matches the reported scaling exactly: the observed doubling per few levels
+is two depth-correlated polynomial factors multiplying, not a true
+exponential.
+
+## Design
+
+Rewrite the verifier's mechanics without changing what it verifies. No
+compatibility path is kept; the old scanning code is removed.
+
+1. Bucket the plan's edits once into `Map[EditPosition,
+   Array[AllocationEdit]]` (`EditPosition` gains `Hash`). Instruction and
+   edge processing look up their bucket directly; order within a bucket is
+   the original edit order.
+2. Drive the dataflow in reverse postorder with round-robin passes: process
+   every pending block in a fixed RPO-based priority order until a full
+   pass changes nothing. Acyclic regions - which is what nested blocks
+   produce - converge in one pass. The staged seeding of blocks with no
+   incoming state is preserved.
+3. State-transition semantics, verification checks, and raised errors are
+   unchanged.
+
+Out of scope, recorded deliberately: `PlanState::remove_value` is a linear
+scan over the state map per definition. Sampling shows it is not a current
+bottleneck (5 of ~6600 samples), and a reverse index would add invariant
+maintenance to a checker whose value is simplicity.
+
+## Acceptance Criteria
+
+- [x] The plan verifier no longer dominates compilation: post-fix sampling
+      shows `apply_position_edits` absent from the profile, and the
+      reporter's module compiles through the production JIT in 7.1s against
+      the reported 58s.
+- [x] Verification semantics are unchanged: the full regalloc suite passes
+      (70/70), including the negative plan-verification tests, and the
+      dataflow reaches the same fixpoint since every block is re-processed
+      whenever its incoming state refines.
+- [x] Full gauntlet passes: workspace tests, core WAST under both engines,
+      and the examples/algorithms corpus.
+- [x] Depth-driven blowup is gone at the two calibration points available:
+      slow-depth46 versus fast-depth16 compile-time ratio drops from 24x to
+      3.4x, tracking largest-function size rather than nesting depth.
+
+The original draft of this issue targeted two seconds end to end. Profiling
+after the verifier fix shows the residual 7.1s is spread across the
+backtracking allocator itself with no single dominant defect; that residual
+is out of this issue's scope and is tracked by ISS-371.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-368, ISS-369
+- Discovered from: user report with slow-depth46.wasm / fast-depth16.wasm
+
+## Notes
+
+- 2026-07-31: Reproduced via `wasmoon explore` (same pipeline, no
+  instantiation needed since the module's imports are absent). Sample
+  attribution: 6564/6600 in `regalloc.apply_position_edits`.
+
+## Close Notes
+- 2026-08-01: Bucketed plan edits by position once per verification and
+  drove the dataflow in reverse postorder with round-robin passes,
+  preserving staged seeding of blocks with no incoming state. 58s -> 7.1s
+  on the reporter's module; verifier no longer appears in the compile
+  profile. Residual allocator cost moved to ISS-371.

--- a/issues/ISS-371.md
+++ b/issues/ISS-371.md
@@ -1,0 +1,73 @@
+# ISS-371: Reduce backtracking-allocator compile time on large functions
+
+## Metadata
+- Type: task
+- Status: open
+- Priority: 2
+- Labels: regalloc, compile-time, performance, agent
+- Assignee: unassigned
+- Created: 2026-08-01
+- Updated: 2026-08-01
+- External ref: none
+
+## Description
+
+After ISS-370 removed the quadratic plan verifier, the reporter's
+46,917-byte module (largest function 3379 lines) still takes 7.1s of
+production JIT compile time where Wasmtime takes 0.055s. Sampling the
+remaining compile shows no single dominant defect; the cost is spread
+across the backtracking allocator and reference-count churn:
+
+| samples | function |
+| ---: | --- |
+| 581 | moonbit_drop_object |
+| 197 | regalloc.preserve_deferred_resident_segments |
+| 194 | regalloc.conflicting_segments |
+| 152 | scan_regular_object |
+| 138 | regalloc.segment_at |
+| 126 | regalloc.assign_backtracking_operands |
+| 108 | regalloc.value_is_live_out_of_block |
+
+The companion 82,539-byte module (largest function 1378 lines) compiles in
+2.07s; the ratio of 3.4x tracks largest-function size, so the cost is
+super-linear in function size but no longer explodes with nesting depth.
+
+## Design
+
+Attribution first: instrument or sample per-phase (liveness, bundle
+planning, allocation loop, edit materialization) before optimizing.
+Directions suggested by the profile, to be validated:
+
+- Allocation and drop churn (`moonbit_drop_object` plus `scan_regular_object`
+  is ~12% of samples) points at per-iteration array and map allocation in
+  the hot loops; reuse of scratch buffers may pay broadly.
+- `conflicting_segments` and `segment_at` per-query costs multiply with the
+  number of probe attempts; occupancy data structures may need to be
+  interval-indexed rather than scanned per candidate.
+
+Do not trade allocation quality for compile time without measuring both;
+ISS-369's coalescing work touches the same code.
+
+## Acceptance Criteria
+
+- [ ] Per-phase attribution of the 7.1s exists with numbers.
+- [ ] The reporter's module compiles in under 2s without regressing the
+      examples/algorithms corpus runtime beyond noise.
+- [ ] Full gauntlet passes.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-370, ISS-369, ISS-212
+- Discovered from: ISS-370 residual profile
+
+## Notes
+
+- 2026-08-01: A separate, smaller finding from the same investigation: the
+  `explore` command's diagnostic text rendering (`vcode.Function::summary`)
+  builds output by repeated string concatenation and dominates explore's
+  wall time on large functions (99% of samples in `_platform_memmove`).
+  Explore-only; the production JIT does not render summaries. Worth a
+  string-builder change if explore on large modules matters.
+
+## Close Notes

--- a/issues/ISS-372.md
+++ b/issues/ISS-372.md
@@ -1,0 +1,66 @@
+# ISS-372: WASI component host leaks its interface type space
+
+## Metadata
+- Type: bug
+- Status: open
+- Priority: 1
+- Labels: wasi, component-model, memory, sanitizers, ci, agent
+- Assignee: unassigned
+- Created: 2026-08-01
+- Updated: 2026-08-01
+- External ref: CI run on merge 86d96d93 (PR #448 head)
+
+## Description
+
+The first Linux AMD64 sanitizer run that reached the final covered test
+file reported:
+
+```text
+SUMMARY: AddressSanitizer: 180260 byte(s) leaked in 4857 allocation(s).
+  (representative stack)
+  Array::push[TypeDef]
+  -> HostInstanceBuilder::set_type_space  component/runtime_impl/host_instance.mbt:284
+  -> WasiComponentHost::prepare_preview3_interface  wasi_component/host.mbt:118
+  -> add_preview3_monotonic_clock  wasi_component/async_preview3.mbt:55
+  reached from testsuite/component_runtime_facade_test.mbt
+```
+
+This is not the ISS-366 linker/engine cycle (1992 bytes in 58 allocations,
+fixed and verified absent); it is a much larger retention rooted in the
+WASI component host's type-space arrays.
+
+The leak was invisible until now because the sanitizer step's previous
+40-minute budget expired before the gate reached
+`component_runtime_facade_test.mbt` (it runs at ~57 minutes under ASan).
+Raising the budget in ISS-368 exposed it; the gate is working as intended.
+
+It currently fails the Linux AMD64 leg for the base branch and every stack
+on it.
+
+## Design
+
+Diagnose before fixing: 4857 allocations of `TypeDef` array storage
+retained at exit suggests either a host-lifetime cache that is never
+released on close, or a reference cycle through the host instance builder
+and the interfaces it registers. Follow the ISS-366 method: reproduce under
+LeakSanitizer in the x86_64 container with exactly the failing test file,
+classify direct vs indirect blocks (all-indirect implies a cycle), then
+either release the retained graph at the owning close boundary or break the
+cycle where the back-reference is created. No suppression; the gate stays
+authoritative.
+
+## Acceptance Criteria
+
+- [ ] The leak reproduces in the container on the failing test file before
+      the change and reports zero after.
+- [ ] A regression test pins the release at the owning close boundary.
+- [ ] The Linux AMD64 sanitizer step passes end to end.
+- [ ] Component suites and the full gauntlet stay green.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-366, ISS-368
+- Discovered from: first full-length sanitizer run after ISS-368
+
+## Close Notes

--- a/modules/regalloc/allocation_plan.mbt
+++ b/modules/regalloc/allocation_plan.mbt
@@ -3,7 +3,7 @@ pub(all) enum EditPosition {
   Before(Int)
   After(Int)
   Edge(source_block~ : Int, successor_index~ : Int)
-} derive(Eq, Debug)
+} derive(Eq, Hash, Debug)
 
 ///|
 pub(all) struct AllocationEdit {

--- a/modules/regalloc/pkg.generated.mbti
+++ b/modules/regalloc/pkg.generated.mbti
@@ -53,7 +53,7 @@ pub(all) enum EditPosition {
   Before(Int)
   After(Int)
   Edge(source_block~ : Int, successor_index~ : Int)
-} derive(Eq, @debug.Debug)
+} derive(Eq, Hash, @debug.Debug)
 
 type LiveRange derive(@debug.Debug)
 pub fn LiveRange::LiveRange(Int, VirtualReg) -> Self

--- a/modules/regalloc/verify_plan.mbt
+++ b/modules/regalloc/verify_plan.mbt
@@ -123,15 +123,37 @@ fn apply_plan_edit(
 }
 
 ///|
+/// Plan edits bucketed by position.
+///
+/// Verification walks every instruction of every block, and a block may be
+/// re-processed when dataflow refines its incoming state. Filtering the
+/// function-wide edit array at each step made verification quadratic in
+/// practice — a deeply nested function multiplied thousands of instructions
+/// by thousands of edits on every visit. One bucketing pass keeps each
+/// lookup proportional to the edits that actually apply, and bucket order
+/// preserves the plan's edit order.
+fn index_plan_edits(
+  edits : Array[AllocationEdit],
+) -> Map[EditPosition, Array[AllocationEdit]] {
+  let index : Map[EditPosition, Array[AllocationEdit]] = Map([])
+  for edit in edits {
+    match index.get(edit.position) {
+      Some(bucket) => bucket.push(edit)
+      None => index[edit.position] = [edit]
+    }
+  }
+  index
+}
+
+///|
 fn apply_position_edits(
   state : PlanState,
-  edits : Array[AllocationEdit],
+  edits_at : Map[EditPosition, Array[AllocationEdit]],
   position : EditPosition,
 ) -> Unit raise VerifyError {
-  for edit in edits {
-    if edit.position == position {
-      apply_plan_edit(state, edit)
-    }
+  guard edits_at.get(position) is Some(bucket) else { return }
+  for edit in bucket {
+    apply_plan_edit(state, edit)
   }
 }
 
@@ -178,11 +200,11 @@ fn[F : FunctionView] process_plan_block(
   environment : MachineEnv,
   plan : AllocationPlan,
   block : Int,
-  edits : Array[AllocationEdit],
+  edits_at : Map[EditPosition, Array[AllocationEdit]],
 ) -> PlanState raise VerifyError {
   let current = state.copy()
   for instruction in function.block_instructions(block) {
-    apply_position_edits(current, edits, Before(instruction))
+    apply_position_edits(current, edits_at, Before(instruction))
     process_operand_phase(
       current,
       function,
@@ -202,7 +224,7 @@ fn[F : FunctionView] process_plan_block(
       instruction,
       Late,
     )
-    apply_position_edits(current, edits, After(instruction))
+    apply_position_edits(current, edits_at, After(instruction))
   }
   current
 }
@@ -231,14 +253,14 @@ fn[F : FunctionView] prepare_successor_state(
   block : Int,
   successor : Int,
   target : Int,
-  edits : Array[AllocationEdit],
+  edits_at : Map[EditPosition, Array[AllocationEdit]],
 ) -> PlanState raise VerifyError {
   let state = output.copy()
   let source_id = function.block_id_at(block)
   let edge_position = Edge(source_block=source_id, successor_index=successor)
-  let original = state.copy()
-  for edit in edits {
-    if edit.position == edge_position {
+  if edits_at.get(edge_position) is Some(bucket) {
+    let original = state.copy()
+    for edit in bucket {
       require_value_at(original, edit.value, edit.from)
       state.values[location_key(edit.to)] = edit.value
     }
@@ -282,7 +304,7 @@ fn[F : FunctionView] verify_function_allocation(
       }
     }
   }
-  let edits = plan.edits()
+  let edits_at = index_plan_edits(plan.edits())
   let block_count = function.block_count()
   let successors = Array::makei(block_count, block => {
     function.block_successors(block)
@@ -295,8 +317,57 @@ fn[F : FunctionView] verify_function_allocation(
       }
     }
   }
+  // Process pending blocks in reverse postorder. A plain stack revisits a
+  // join-dense region once per refinement, and nested blocks lower to long
+  // chains of forward joins, so verification cost grew with nesting depth.
+  // In reverse postorder every acyclic region converges in a single pass;
+  // loops add one pass per refinement round. Blocks unreachable from any
+  // root keep their index order at the end, matching the staged seeding
+  // below.
+  let priority = Array::make(block_count, block_count)
+  let postorder : Array[Int] = []
+  let visited = Array::make(block_count, false)
+  for root in 0..<block_count {
+    if root != 0 && has_predecessor[root] {
+      continue
+    }
+    if visited[root] {
+      continue
+    }
+    // Iterative depth-first search; the explicit stack carries the next
+    // successor index to visit for each open block.
+    let stack : Array[(Int, Int)] = [(root, 0)]
+    visited[root] = true
+    while stack.length() > 0 {
+      let (block, next_successor) = stack[stack.length() - 1]
+      let block_successors = successors[block]
+      if next_successor < block_successors.length() {
+        stack[stack.length() - 1] = (block, next_successor + 1)
+        let target = block_successors[next_successor]
+        if target >= 0 && target < block_count && !visited[target] {
+          visited[target] = true
+          stack.push((target, 0))
+        }
+      } else {
+        postorder.push(block)
+        stack.pop() |> ignore
+      }
+    }
+  }
+  for index in 0..<postorder.length() {
+    priority[postorder[postorder.length() - 1 - index]] = index
+  }
+  let order = Array::makei(block_count, block => block)
+  order.sort_by((left, right) => {
+    let by_priority = priority[left] - priority[right]
+    if by_priority != 0 {
+      by_priority
+    } else {
+      left - right
+    }
+  })
   let incoming : Array[PlanState?] = Array::make(block_count, None)
-  let worklist : Array[Int] = []
+  let pending = Array::make(block_count, false)
   for block in 0..<block_count {
     if block == 0 || !has_predecessor[block] {
       let state = PlanState::new()
@@ -310,35 +381,45 @@ fn[F : FunctionView] verify_function_allocation(
       }
       initialize_block_parameters(state, function, plan, block)
       incoming[block] = Some(state)
-      worklist.push(block)
+      pending[block] = true
     }
   }
   let mut next_unreachable_root = 0
   while true {
-    while worklist.pop() is Some(block) {
-      let output = process_plan_block(
-        incoming[block].unwrap(),
-        function,
-        environment,
-        plan,
-        block,
-        edits,
-      )
-      for successor, target in successors[block] {
-        let next = prepare_successor_state(
-          output, function, plan, block, successor, target, edits,
+    let mut processed_any = true
+    while processed_any {
+      processed_any = false
+      for order_index in 0..<block_count {
+        let block = order[order_index]
+        if !pending[block] {
+          continue
+        }
+        pending[block] = false
+        processed_any = true
+        let output = process_plan_block(
+          incoming[block].unwrap(),
+          function,
+          environment,
+          plan,
+          block,
+          edits_at,
         )
-        match incoming[target] {
-          None => {
-            incoming[target] = Some(next)
-            worklist.push(target)
-          }
-          Some(previous) => {
-            let merged = previous.copy()
-            merged.meet_with(next)
-            if !merged.equals(previous) {
-              incoming[target] = Some(merged)
-              worklist.push(target)
+        for successor, target in successors[block] {
+          let next = prepare_successor_state(
+            output, function, plan, block, successor, target, edits_at,
+          )
+          match incoming[target] {
+            None => {
+              incoming[target] = Some(next)
+              pending[target] = true
+            }
+            Some(previous) => {
+              let merged = previous.copy()
+              merged.meet_with(next)
+              if !merged.equals(previous) {
+                incoming[target] = Some(merged)
+                pending[target] = true
+              }
             }
           }
         }
@@ -354,6 +435,6 @@ fn[F : FunctionView] verify_function_allocation(
     let state = PlanState::new()
     initialize_block_parameters(state, function, plan, next_unreachable_root)
     incoming[next_unreachable_root] = Some(state)
-    worklist.push(next_unreachable_root)
+    pending[next_unreachable_root] = true
   }
 }


### PR DESCRIPTION
Fixes ISS-370 — the user-reported 58-second JIT compile of a 46KB module.

## Diagnosis

Sampling the 58s compile attributed **99%+ of samples (6564/6600) to a single function**: `apply_position_edits` in the allocation-plan verifier, which runs unconditionally in production (`RegallocConfig(verify=true)`).

Two complexity defects multiplied:

1. **Per-instruction linear scan of the whole edit array.** Each instruction filtered the complete function-wide `Array[AllocationEdit]` twice (Before/After), making each block visit O(instructions × edits). Edge processing did the same full scan per edge.
2. **LIFO worklist without priority.** Nested blocks lower to long chains of forward joins; every meet refinement re-enqueued the rest of the chain, so block visits grew with nesting depth.

The reporter's "doubles every 5–6 nesting levels" is these two depth-correlated polynomial factors multiplying — not a true exponential.

## Change

No compatibility path; the scanning code is removed.

- Plan edits are bucketed once into `Map[EditPosition, Array[AllocationEdit]]` (`EditPosition` derives `Hash`); lookups preserve within-position edit order.
- The dataflow driver processes pending blocks in **reverse postorder with round-robin passes**; acyclic regions (what block towers produce) converge in one pass. Staged seeding of no-incoming-state blocks is preserved.
- Verification semantics unchanged: same state transitions, same checks, same errors; every block is still re-processed whenever its incoming state refines, so the fixpoint is identical.

## Measured (production JIT path, artifact cache cleared)

| module | before | after |
| --- | ---: | ---: |
| slow-depth46 (46KB, nesting 47) | 58s (reported) | **7.13s** |
| fast-depth16 (82KB, nesting 17) | 2.4s (reported) | **2.07s** |
| ratio | 24× | **3.4×** |

Post-fix sampling: `apply_position_edits` is absent from the profile. The ratio now tracks largest-function size, not depth.

## Scope honesty

The residual 7.1s is spread across the backtracking allocator itself (`conflicting_segments`, `segment_at`, RC churn — no single dominant defect); profiled and tracked in **ISS-371** with per-function sample counts. The original draft acceptance of "<2s" was written before that profile existed; ISS-370 records the revision explicitly.

Also filed **ISS-372**: the first full-length Linux sanitizer run on the merged base exposed a pre-existing WASI-host type-space leak (180,260 B / 4,857 allocations, `HostInstanceBuilder::set_type_space`) in the gate's final test file — previously masked by the 40-minute timeout, unrelated to this change, currently failing the base branch's Linux leg.

## Verification

| gate | result |
| --- | --- |
| regalloc suite (incl. negative plan-verification tests) | 70/70 |
| workspace | 983 wasm-gc + 1532 native |
| core WAST | 258/258 files, both engines |
| examples/algorithms corpus | 70/70 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
