### PR TITLE
Release nested-component instance graphs at terminal linker close

### DIFF
--- a/issues/ISS-372.md
+++ b/issues/ISS-372.md
@@ -1,0 +1,113 @@
+# ISS-372: WASI component host leaks its interface type space
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 1
+- Labels: wasi, component-model, memory, sanitizers, ci, agent
+- Assignee: unassigned
+- Created: 2026-08-01
+- Updated: 2026-08-01
+- External ref: CI run on merge 86d96d93 (PR #448 head)
+
+## Description
+
+The first Linux AMD64 sanitizer run that reached the final covered test
+file reported:
+
+```text
+SUMMARY: AddressSanitizer: 180260 byte(s) leaked in 4857 allocation(s).
+  (representative stack)
+  Array::push[TypeDef]
+  -> HostInstanceBuilder::set_type_space  component/runtime_impl/host_instance.mbt:284
+  -> WasiComponentHost::prepare_preview3_interface  wasi_component/host.mbt:118
+  -> add_preview3_monotonic_clock  wasi_component/async_preview3.mbt:55
+  reached from testsuite/component_runtime_facade_test.mbt
+```
+
+This is not the ISS-366 linker/engine cycle (1992 bytes in 58 allocations,
+fixed and verified absent); it is a much larger retention rooted in the
+WASI component host's type-space arrays.
+
+The leak was invisible until now because the sanitizer step's previous
+40-minute budget expired before the gate reached
+`component_runtime_facade_test.mbt` (it runs at ~57 minutes under ASan).
+Raising the budget in ISS-368 exposed it; the gate is working as intended.
+
+It currently fails the Linux AMD64 leg for the base branch and every stack
+on it.
+
+## Root cause
+
+All 4857 leaked allocations are indirect with zero direct blocks: a pure
+reference cycle. Bisection (eight probe rungs in the x86_64 container, each
+under LeakSanitizer) narrowed it to instantiation of any component that
+defines a nested component; calls, engines, and the WASI world were each
+ruled out as necessary (a wasi-importing fixture without nested components
+closes cleanly).
+
+The cycle is structural. `env_instance_from_state`
+(runtime_impl/instantiate_helpers.mbt) builds the `alias outer` environment
+instance sharing the final instance's backing arrays, and every nested
+component definition pushes a `ComponentClosure` whose `outer_stack`
+contains that environment instance:
+
+```text
+instance -> .components (shared array) -> ComponentClosure.outer_stack
+        -> instance
+```
+
+`alias outer` resolution requires the enclosing scope when the nested
+component is later instantiated, so the cycle is semantically necessary
+while the linker is open. Nothing released it at close, so every such
+instance graph survived - dragging its imports, the WASI host functions
+resolved into them, and each host function's private copy of the interface
+type space (the `TypeDef` arrays that dominate the byte count).
+
+The WASI worlds in the gate's facade tests import into fixtures that define
+nested components, which is why the leak first surfaced there once ISS-368
+let the sanitizer gate reach that file.
+
+## Design
+
+Release the graph at the owning close boundary.
+`ComponentLinker::finish_close` walks every registered instance and every
+instance or component reachable from the import table, collects children
+first, clears each record's `components`, `instances`, `funcs`, `values`,
+and `exports`, then recurses; a visited set terminates on the cycles this
+exists to break. Collect-then-clear ordering matters: instances produced
+during one instantiation share backing arrays with their `alias outer`
+environment records, and clearing a shared map while iterating it crashes.
+No suppression; the gate stays authoritative.
+
+## Acceptance Criteria
+
+- [x] The leak reproduces in the container before the change (45,117 bytes
+      in 1,213 allocations for one verbatim facade test; 44,571/1,201 for
+      instantiate-only) and reports zero after, on the same probes in the
+      same environment.
+- [x] A regression test pins the release at the owning close boundary and
+      fails when the release is removed (mutation-verified).
+- [ ] The Linux AMD64 sanitizer step passes end to end (pending the next
+      CI run on the merged base).
+- [x] Component suites and the full gauntlet stay green.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-366, ISS-368
+- Discovered from: first full-length sanitizer run after ISS-368
+
+## Notes
+
+- 2026-08-01: The container environment shows a flaky SIGSEGV on the first
+  run after a fresh sanitizer compile (observed twice, before and after the
+  fix; deterministic reruns pass). Rosetta/ASan first-run artifact, not a
+  property of the change. Sanitizer repro containers need >=24GB memory:
+  the three final test binaries compile 39-77MB of generated C in parallel
+  and were OOM-killed at 8GB.
+
+## Close Notes
+- 2026-08-01: Released nested-component instance graphs at terminal linker
+  close with a collect-then-clear traversal. Container LSan: 45KB/1213 and
+  44.5KB/1201 before, zero after. Regression test mutation-verified.

--- a/modules/wasmoon/component/runtime_impl/component_api.mbt
+++ b/modules/wasmoon/component/runtime_impl/component_api.mbt
@@ -408,11 +408,87 @@ pub fn ComponentLinker::close(self : ComponentLinker) -> Unit {
 }
 
 ///|
+/// Release an instance graph at terminal close.
+///
+/// A component that defines a nested component stores a `ComponentClosure`
+/// whose `outer_stack` contains the enclosing instance itself — `alias outer`
+/// resolution requires the enclosing scope when the nested component is
+/// instantiated later. That is a deliberate reference cycle, and reference
+/// counting can never reclaim it: every instance graph with a nested
+/// component definition survives close intact, dragging its imports, host
+/// functions, and their per-function type-space copies along with it.
+///
+/// Terminal close is the owning boundary, so break the graph here: clear the
+/// closure and child arrays of every reachable instance. The visited set
+/// terminates on the cycles this exists to break.
+fn release_component_instance_graph(
+  instance : ComponentInstance,
+  visited : Array[ComponentInstance],
+) -> Unit {
+  for seen in visited {
+    if physical_equal(seen, instance) {
+      return
+    }
+  }
+  visited.push(instance)
+  // Instances produced during one instantiation share their backing arrays
+  // and export map — the `alias outer` environment records alias the final
+  // instance's storage. Collect every reachable child first, then clear this
+  // record's storage, and only then recurse: clearing while iterating a
+  // shared map would mutate the collection mid-walk, and a shared array
+  // visited again later is simply seen empty.
+  let children : Array[ComponentInstance] = []
+  for closure in instance.components {
+    for outer in closure.outer_stack {
+      children.push(outer)
+    }
+  }
+  for child in instance.instances {
+    children.push(child)
+  }
+  for entry in instance.exports {
+    let (_, ext) = entry
+    match ext {
+      Instance(child) => children.push(child)
+      Component(closure) =>
+        for outer in closure.outer_stack {
+          children.push(outer)
+        }
+      _ => ()
+    }
+  }
+  instance.components.clear()
+  instance.instances.clear()
+  instance.funcs.clear()
+  instance.values.clear()
+  instance.exports.clear()
+  for child in children {
+    release_component_instance_graph(child, visited)
+  }
+}
+
+///|
 fn ComponentLinker::finish_close(self : ComponentLinker) -> Unit {
   if self.close_complete.val {
     return
   }
   self.close_complete.val = true
+  let visited : Array[ComponentInstance] = []
+  for entry in self.components {
+    let (_, instance) = entry
+    release_component_instance_graph(instance, visited)
+  }
+  for entry in self.imports {
+    let (_, ext) = entry
+    match ext {
+      Instance(instance) => release_component_instance_graph(instance, visited)
+      Component(closure) =>
+        for outer in closure.outer_stack {
+          release_component_instance_graph(outer, visited)
+        }
+      _ => ()
+    }
+  }
   self.components.clear()
   self.imports.clear()
   self.host_runtime.val = None

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -559,3 +559,50 @@ test "component runtime: canon lower to core func" {
   }
   debug_inspect(results, content="[I32(42)]")
 }
+
+///|
+/// Regression test for ISS-372.
+///
+/// A component that defines a nested component stores a closure whose
+/// `outer_stack` contains the enclosing instance itself — required for
+/// `alias outer` resolution, and a deliberate reference cycle that reference
+/// counting can never reclaim. Terminal linker close must break the graph,
+/// or every such instance survives close along with its imports and their
+/// per-function type-space copies. LeakSanitizer measured 45KB retained per
+/// instantiation before the release was added.
+test "linker close releases nested-component instance graphs" {
+  let bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (component $inner
+      #|    (core module $m (func (export "f") (result i32) (i32.const 7)))
+      #|    (core instance $i (instantiate $m))
+      #|    (func (export "f") (result u32) (canon lift (core func $i "f"))))
+      #|  (instance $one (instantiate $inner))
+      #|  (alias export $one "f" (func $f))
+      #|  (export "f" (func $f)))
+      #|
+    ),
+  )
+  let component = @component.parse_component(bytes)
+  let validated = @component_model.validate_component_for_instantiation_with_config(
+    component,
+    @component_model.ComponentValidationConfig(false),
+  )
+  let linker = @runtime_impl.ComponentLinker::ComponentLinker()
+  let instance = linker.instantiate("nested", validated)
+  // The self-cycle exists while the linker is open: the instance's nested
+  // component closures carry the instance itself in their outer stacks.
+  debug_inspect(instance.components.length() > 0, content="true")
+  linker.close()
+  // Terminal close breaks the graph so reference counting can reclaim it.
+  debug_inspect(
+    (
+      instance.components.length(),
+      instance.instances.length(),
+      instance.funcs.length(),
+      instance.exports.size(),
+    ),
+    content="(0, 0, 0, 0)",
+  )
+}


### PR DESCRIPTION
Fixes ISS-372 — the 180KB leak that fails the Linux AMD64 sanitizer leg on the base branch. Stacked on #448.

## How it was found

The first sanitizer run to complete end-to-end (after #453 raised the gate budget past the old 40-minute kill point) reported 180,260 bytes in 4,857 allocations — **all indirect, zero direct**: the signature of a pure reference cycle, which the reference-counted native runtime can never reclaim.

## Diagnosis: eight-rung bisection under LeakSanitizer

Each rung ran in the x86_64 sanitizer container. Ruled out as *necessary*: the facade layer alone, the native engine, the interpreter engine, the WASI world install, plain instantiation, and sync/async calls — all clean in isolation. The discriminating pair:

- wasi-importing fixture **without** nested components: **clean**
- the real fixture **with** nested `(component ...)` definitions, instantiate-only, no calls: **44,571 B / 1,201 allocs leaked**

## Root cause

`env_instance_from_state` builds the `alias outer` environment instance **sharing the final instance's backing arrays**, and every nested component definition pushes a `ComponentClosure` whose `outer_stack` contains that environment instance:

```
instance → .components (shared array) → ComponentClosure.outer_stack → instance
```

The cycle is semantically necessary while the linker is open — `alias outer` resolution needs the enclosing scope when the nested component is instantiated later. The defect is that terminal close never released it. Every such instance graph survived close, dragging its imports, the WASI host functions resolved into them, and **each host function's private copy of the interface type space** (`add_func` stores `types.copy()` per function — the `TypeDef` arrays that dominate the byte count).

## Fix

`ComponentLinker::finish_close` walks every registered instance and everything reachable from the import table, **collects children first, clears each record's storage, then recurses**; a visited set terminates on the cycles this exists to break. The collect-then-clear ordering is load-bearing: instances share backing arrays with their environment records, and clearing a shared map mid-iteration crashes (found the hard way; the first draft segfaulted the facade suite).

No suppression, no compatibility path; after close an instance graph is empty.

## Verification

| | before | after |
| --- | --- | --- |
| container LSan, verbatim facade test | 45,117 B / 1,213 allocs | **zero report** |
| container LSan, instantiate-only | 44,571 B / 1,201 allocs | **zero report** |

Same probes, same environment, same binary layout. Plus: regression test pinning the release (fails when the release is removed — mutation-verified), runtime_impl 36/36, facade 26/26, workspace 983+1533, core WAST 258/258 both engines, all three component suites, corpus 70/70.

## Notes

- `issues/ISS-372.md` also lands in #456; this branch carries the updated (closed) version — resolve any merge overlap in favor of this one.
- Recorded in the ISS: the container shows a flaky first-run-after-compile SIGSEGV (observed before *and* after the fix; deterministic reruns pass) — a Rosetta/ASan artifact, not a property of this change. Also: sanitizer repro containers need ≥24GB memory; the three final test binaries compile 39–77MB of generated C in parallel and were OOM-killed at 8GB.
- With this and the previously-merged #450, the Linux AMD64 sanitizer leg should go green on the next base-branch CI run — the remaining red is macOS (ISS-367, upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
