### PR TITLE
fix: seal remaining ISS-357 instantiation boundary gaps

### DIFF
--- a/issues/ISS-357.md
+++ b/issues/ISS-357.md
@@ -7,7 +7,7 @@
 - Labels: component-model, security-audit, validation, tooling, tests, agent
 - Assignee: codex
 - Created: 2026-07-30
-- Updated: 2026-07-30
+- Updated: 2026-08-02
 - External ref: none
 
 ## Description
@@ -61,3 +61,35 @@ black-box facade regression verifies that a parsed but invalid component
 returns structured `ValidationFailed` before instantiation. Validation passed:
 the component security audit, all 59 Python gate tests, 5 validator tests, and
 all 540 tests in `Milky2018/wasmoon/testsuite`.
+
+Reopened on 2026-08-02: review found two paths that defeated the boundary.
+
+1. `ComponentLinker::add_component` still accepted a raw `Component`. An
+   imported component is instantiated by the instance sections of whichever
+   component imports it (`resolve_import` pushes the closure into
+   `state.components`, and `Instantiate` runs it), so a host-registered
+   component reached full instantiation without ever passing validation.
+   `ComponentClosure` was also `pub(all)`, so external code could forge a
+   `Component(closure)` extern around an unchecked component and hand it to
+   `add_import` directly.
+2. `ValidatedComponent` wrapped the same reference the caller retained.
+   `Component` exposes mutable arrays (including `binary.sections`, the source
+   both validation and instantiation actually read), so the evidence could be
+   invalidated by mutating the raw component after validation.
+
+Final fix: `Component::isolated_copy` rebuilds a component from a copy of its
+immutable binary sections; `validate_component_for_instantiation_with_config`
+validates that snapshot and the evidence holds only the snapshot, so no
+reference the caller retains can reach validated content. `add_component` now
+requires `ValidatedComponent`, and `ComponentClosure` is abstract, so a
+closure cannot be forged. Defense in depth: the validator independently
+rejects root-level component imports and requires nested component imports to
+be satisfied by explicit instantiate arguments, so the linker's component
+import fallback is unreachable from validated components — the hardened
+boundary matters if either rule is ever relaxed. The audit's
+validate-before-instantiate check now also pins the `add_component` signature
+and non-constructibility of `ComponentClosure`, with negative gate tests for
+both. Regression tests prove evidence survives full mutation of the raw
+component and that import registration requires evidence. Validation: 1535
+native + 983 wasm-gc tests, all three component spec suites (23/23, 24/24,
+12/12 files), component security audit, and 21 audit gate tests all pass.

--- a/issues/ISS-367.md
+++ b/issues/ISS-367.md
@@ -124,7 +124,7 @@ Do not disable UBSan for the whole sanitizer step.
 
 ## Acceptance Criteria
 
-- [ ] The defect is reported upstream to `moonbitlang/async`.
+- [x] The defect is reported upstream to `moonbitlang/async`.
 - [ ] A released `moonbitlang/async` version no longer passes a negative signal
       number to `sigaddset`.
 - [ ] The pin in `modules/wasmoon/moon.mod` is bumped to that version.
@@ -141,6 +141,9 @@ Do not disable UBSan for the whole sanitizer step.
 - 2026-07-31: Deferred as an external blocker. Filing the upstream report is an
   outward-facing action and has not been done yet; it needs a maintainer to send
   it or to approve sending it.
+- 2026-08-01: The maintainer reported the defect to the `moonbitlang/async`
+  developers directly. Remaining work is only the pin bump once a fixed release
+  exists, then confirming the macOS ARM64 sanitizer step goes green.
 - 2026-07-31: This affects any MoonBit project running UBSan on macOS with the
   async event loop, not only Wasmoon.
 

--- a/issues/ISS-370.md
+++ b/issues/ISS-370.md
@@ -106,6 +106,15 @@ is out of this issue's scope and is tracked by ISS-371.
 - 2026-07-31: Reproduced via `wasmoon explore` (same pipeline, no
   instantiation needed since the module's imports are absent). Sample
   attribution: 6564/6600 in `regalloc.apply_position_edits`.
+- 2026-08-02: Review noted the fix lacked targeted regressions, so two
+  whitebox tests now lock its invariants. "plan verifier applies
+  same-position edits in plan order" chains three dependent moves at one
+  `EditPosition` — any bucket reordering fails with `IncorrectValue`
+  (mutation-verified by reversing bucket iteration). "plan verifier
+  processes a deep diamond join chain once per block" counts
+  `block_instructions` calls over a join-dense CFG whose right arms publish
+  per-level extra registers, asserting exactly one visit per block
+  (mutation-verified: restoring a naive LIFO worklist fails the count).
 
 ## Close Notes
 - 2026-08-01: Bucketed plan edits by position once per verification and

--- a/issues/ISS-373.md
+++ b/issues/ISS-373.md
@@ -88,6 +88,13 @@ contract at its own boundary:
   merely dropping references to imported or outer objects without touching
   their state. It is therefore safe on an open linker and runs on every
   abort, including a `register` refusal.
+- 2026-08-02: Review found one more retaining mutator outside the guarded
+  set: `ComponentLinker::host_runtime_state` lazily installed a
+  `HostRuntimeState` into the runtime slot after close (repeated closes
+  return early, so it would never be released). It now raises `Cancelled`
+  on a closed linker, completing terminal coverage of every public mutator
+  that retains state. `new_host_resource_type` stays non-raising by design:
+  it only bumps an id counter and retains nothing.
 - 2026-08-02: The frame's resource-table entry in the shared `async_state`
   map intentionally survives an abort: nested instances that completed and
   registered before the abort may still resolve it through their ancestor

--- a/issues/ISS-373.md
+++ b/issues/ISS-373.md
@@ -1,0 +1,103 @@
+# ISS-373: Instantiation runs outside the core execution lifecycle
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 1
+- Labels: component-model, lifecycle, runtime, tests, agent
+- Assignee: claude
+- Created: 2026-08-02
+- Updated: 2026-08-02
+- External ref: none
+
+## Description
+The core execution lifecycle introduced for ISS-366 leased only `invoke`.
+`CoreExecutionEngine::with_lifecycle` passed `register_instance` straight
+through, and `ComponentLinker::instantiate` held no lease at all.
+
+An engine registration callback that calls `linker.close()` therefore
+observed the order register → engine-close → register-return: with zero
+active leases, `request_close` ran `finish_close` immediately — releasing
+the engine and clearing the linker's imports while instantiation was still
+iterating them — and instantiation then returned success and committed the
+new instance into the closed linker's component list, where nothing would
+ever release it.
+
+Two adjacent holes shared the root cause:
+
+- A closed linker still accepted `instantiate` for a component with no core
+  sections (no engine call ever raised `Cancelled`), committing an instance
+  graph after terminal close.
+- `ComponentLinker::register` committed unconditionally, so any path that
+  reached it after close resurrected state.
+
+## Design
+Instantiation is a compound operation on the linker, so the linker's
+lifecycle must cover it as a unit, with the engine seam enforcing the same
+contract at its own boundary:
+
+- `ComponentLinker::instantiate` holds a lifecycle lease for the whole
+  instantiation. Entry on a closing linker raises `Cancelled`; a close that
+  begins mid-flight defers teardown until this frame unwinds, so no section
+  ever observes a released engine or cleared imports.
+- The managed engine's `register_instance` takes a lease like `invoke` and
+  refuses to commit a registration once the lifecycle is closing, so a close
+  issued inside the callback surfaces as `Cancelled` at the registration
+  boundary.
+- `ComponentLinker::register` raises `Cancelled` on a closed linker: the
+  commit point itself rejects post-close results.
+- An instantiation aborted while the linker is closing releases its partial
+  instance graph (`release_component_instance_graph` over the build state)
+  before the error unwinds — the graph was never registered, so terminal
+  close cannot see it, and its `alias outer` cycles would otherwise leak.
+
+## Acceptance Criteria
+- [x] `linker.close()` inside an engine registration callback cancels the
+      instantiation instead of committing it.
+- [x] A closed linker refuses instantiation at entry, including for
+      components with no core sections.
+- [x] The commit point (`ComponentLinker::register`) rejects a closed linker.
+- [x] The partial instance graph of an instantiation aborted during close is
+      released, keeping the native sanitizer leg leak-free.
+- [x] Full test suites, component spec suites, and the component security
+      audit pass.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-366, ISS-372
+- Discovered from: review of the ISS-366 lifecycle
+
+## Notes
+- 2026-08-02: A residual, separate gap stays open by design here:
+  `add_import` and the other non-raising registration APIs still accept
+  entries after terminal close (they resurrect only import externs, not
+  instance graphs committed by instantiation). Guarding them means a raising
+  signature cascade across the non-raising `add_*` API family; track
+  separately if it becomes observable.
+- 2026-08-02: Partial-graph release on abort is deliberately limited to the
+  closing case. On an open linker a failed instantiation's build state may
+  reference live imported instances (`add_instance` externs), and a blanket
+  release would clear graphs the linker still owns; distinguishing owned
+  from imported children needs ownership tracking in the build state.
+
+## Close Notes
+
+Fixed in `modules/wasmoon/component/runtime_impl/core_engine.mbt`
+(`with_lifecycle` now leases `register_instance` and refuses commits while
+closing), `component_api.mbt` (`ComponentLinker::instantiate` holds a
+whole-instantiation lease and converts mid-flight close into `Cancelled`;
+`ComponentLinker::register` rejects a closed linker), and `instantiate.mbt`
+(the section loop moved to `run_component_sections`; an abort while closing
+releases the partial graph via `env_instance_from_state` +
+`release_component_instance_graph`).
+
+Regression tests: "close during engine registration cancels instantiation"
+(engine callback closes the linker; instantiation surfaces `Cancelled`, the
+registration count stays at one, and the closed linker retains nothing) and
+"closed linker refuses instantiation at entry" (coreless component). Both
+previously reproduced the defect: the first returned success after
+engine-close, the second registered into the closed linker.
+
+Validation: 1537 native + 983 wasm-gc tests, component spec suites 23/23,
+24/24, 12/12 files, component security audit, and audit gate tests all pass.

--- a/issues/ISS-373.md
+++ b/issues/ISS-373.md
@@ -59,6 +59,10 @@ contract at its own boundary:
 - [x] The commit point (`ComponentLinker::register`) rejects a closed linker.
 - [x] The partial instance graph of an instantiation aborted during close is
       released, keeping the native sanitizer leg leak-free.
+- [x] The partial graph of an instantiation that fails on an open linker is
+      released without touching imported or outer objects, and the linker
+      stays fully usable.
+- [x] The `add_*` registration family rejects a terminally closed linker.
 - [x] Full test suites, component spec suites, and the component security
       audit pass.
 
@@ -69,17 +73,25 @@ contract at its own boundary:
 - Discovered from: review of the ISS-366 lifecycle
 
 ## Notes
-- 2026-08-02: A residual, separate gap stays open by design here:
-  `add_import` and the other non-raising registration APIs still accept
-  entries after terminal close (they resurrect only import externs, not
-  instance graphs committed by instantiation). Guarding them means a raising
-  signature cascade across the non-raising `add_*` API family; track
-  separately if it becomes observable.
-- 2026-08-02: Partial-graph release on abort is deliberately limited to the
-  closing case. On an open linker a failed instantiation's build state may
-  reference live imported instances (`add_instance` externs), and a blanket
-  release would clear graphs the linker still owns; distinguishing owned
-  from imported children needs ownership tracking in the build state.
+- 2026-08-02: Both residuals recorded in the first fix round are now
+  resolved in this issue rather than tracked separately.
+- 2026-08-02: `add_import` (and through it the whole `add_*` family) raises
+  `Cancelled` on a terminally closed linker. The raising cascade proved
+  shallow: `install_command_world` and the facade boundaries were already
+  raising contexts, and the conformance runner's registrations on its own
+  fresh linker are marked `try!` (failure impossible before its deferred
+  close).
+- 2026-08-02: Partial-graph release no longer needs ownership tracking or
+  the closing-only restriction. The insight: clearing only the aborted
+  frame's own containers (`BuildState::release_aborted`) breaks the frame's
+  `alias outer` cycles — the cycle runs through the frame's arrays — while
+  merely dropping references to imported or outer objects without touching
+  their state. It is therefore safe on an open linker and runs on every
+  abort, including a `register` refusal.
+- 2026-08-02: The frame's resource-table entry in the shared `async_state`
+  map intentionally survives an abort: nested instances that completed and
+  registered before the abort may still resolve it through their ancestor
+  chain. It is released when the async state dies.
 
 ## Close Notes
 
@@ -92,12 +104,21 @@ whole-instantiation lease and converts mid-flight close into `Cancelled`;
 releases the partial graph via `env_instance_from_state` +
 `release_component_instance_graph`).
 
+Second round closed the recorded residuals: `add_import` guards terminal
+close for the whole `add_*` family (now raising), and
+`BuildState::release_aborted` releases the aborted frame's own containers on
+every abort — open or closing linker — replacing the closing-only recursive
+release.
+
 Regression tests: "close during engine registration cancels instantiation"
 (engine callback closes the linker; instantiation surfaces `Cancelled`, the
-registration count stays at one, and the closed linker retains nothing) and
-"closed linker refuses instantiation at entry" (coreless component). Both
-previously reproduced the defect: the first returned success after
-engine-close, the second registered into the closed linker.
+registration count stays at one, and the closed linker retains nothing),
+"closed linker refuses instantiation at entry" (coreless component, plus
+`add_import` refusal after close), and "failed instantiation leaves open
+linker intact" (a nested-component definition creates the `alias outer`
+cycle, a trapping core start aborts the frame, and the imported provider
+instance and the linker both remain fully usable). All previously
+reproduced their defect.
 
-Validation: 1537 native + 983 wasm-gc tests, component spec suites 23/23,
+Validation: 1538 native + 983 wasm-gc tests, component spec suites 23/23,
 24/24, 12/12 files, component security audit, and audit gate tests all pass.

--- a/issues/ISS-374.md
+++ b/issues/ISS-374.md
@@ -1,0 +1,80 @@
+# ISS-374: Linker close destroys externally shared instances
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 1
+- Labels: component-model, lifecycle, ownership, runtime, tests, agent
+- Assignee: claude
+- Created: 2026-08-02
+- Updated: 2026-08-02
+- External ref: none
+
+## Description
+`finish_close` released instance graphs recursively, and its walk covered
+the import table. `add_instance` has no ownership transfer protocol, so a
+linker that merely borrowed an instance destroyed it at close: importing an
+instance created by linker A into linker B and closing B emptied the
+instance's export map, and later calls through A failed with
+`UnknownExport`.
+
+The recursion was equally wrong one level deeper: a registered instance's
+`instances` array and `exports` map also hold borrowed instances (resolved
+imports), so closing a linker whose own component imported a foreign
+instance corrupted that instance too.
+
+## Design
+Release exactly what the linker owns, nothing reachable.
+
+The ownership boundary already exists structurally: every instantiation
+frame registers its instance with the linker (`linker.register` is the
+single exit of `instantiate_component`, including nested frames), and the
+env and inline instances of a frame share that frame's array objects. The
+`alias outer` cycle that motivated recursive release runs through the
+frame's own arrays.
+
+Therefore terminal close shallow-releases each registered instance —
+clearing its own `components`/`instances`/`funcs`/`values`/`exports`
+containers breaks every owned cycle and merely drops references to borrowed
+objects — and the import table is released by clearing the table itself.
+This is the instance-side twin of `BuildState::release_aborted` (ISS-373).
+
+## Acceptance Criteria
+- [x] Closing a linker leaves instances imported via `add_instance` fully
+      usable by their owner.
+- [x] The owning linker's close still releases its registered graphs,
+      including nested-component `alias outer` cycles (ISS-372 regression
+      stays green).
+- [x] Full test suites, component spec suites, and the component security
+      audit pass.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-366, ISS-372, ISS-373
+- Discovered from: review of the ISS-372 release path
+
+## Notes
+- 2026-08-02: WASI host instances stay leak-free without the imports walk:
+  `HostInstanceBuilder::finish` constructs the instance after its export
+  closures exist, so a host instance cannot capture itself and reference
+  counting reclaims it once the import table drops it.
+- 2026-08-02: A host-built instance that references itself through its own
+  export map would now outlive the borrowing linker's close. That is the
+  ownership contract working as intended — the embedder built it, the
+  embedder owns it — and no in-repo construction produces such a cycle.
+
+## Close Notes
+
+`release_component_instance_graph` (recursive, visited-set) is replaced by
+the shallow `release_owned_instance`; `finish_close` walks only
+`self.components` and releases the import table by clearing it. Regression
+test "close releases only owned instances" reproduces the report: linker A's
+instance imported into linker B survives B's close with exports intact and
+callable, and A's own close still releases it. The ISS-372 nested-graph
+regression passes unchanged because every frame registers, so the shallow
+walk covers every graph the recursion used to reach — minus the borrowed
+ones it should never have touched.
+
+Validation: 1539 native + 983 wasm-gc tests, component spec suites 23/23,
+24/24, 12/12 files, and the component security audit all pass.

--- a/modules/regalloc/regalloc_wbtest.mbt
+++ b/modules/regalloc/regalloc_wbtest.mbt
@@ -798,6 +798,7 @@ priv struct VerifierCfgView {
   parameters : Array[Array[VirtualReg]]
   edge_arguments : Array[Array[Array[VirtualReg]]]
   successor_queries : Ref[Int]
+  block_visits : Ref[Int]
 }
 
 ///|
@@ -860,6 +861,7 @@ impl FunctionView for VerifierCfgView with fn block_parameters(self, block) -> A
 impl FunctionView for VerifierCfgView with fn block_instructions(self, block) -> Array[
   Int,
 ] {
+  self.block_visits.val = self.block_visits.val + 1
   self.blocks[block].copy()
 }
 
@@ -933,6 +935,7 @@ test "plan verifier always enters a self-looping entry block" {
         parameters: [[]],
         edge_arguments: [[[]]],
         successor_queries: Ref(0),
+        block_visits: Ref(0),
       },
       None,
       0,
@@ -962,6 +965,7 @@ test "plan verifier checks an unreachable cyclic component" {
         parameters: [[], []],
         edge_arguments: [[], [[]]],
         successor_queries: Ref(0),
+        block_visits: Ref(0),
       },
       Some(0),
       1,
@@ -991,6 +995,7 @@ test "plan verifier queries each block successor list once" {
     parameters: [[], [], [], []],
     edge_arguments: [[[]], [[]], [[]], []],
     successor_queries,
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(1)
   plan.assign_value(value, Reg(register))
@@ -1024,6 +1029,7 @@ test "any-location definitions materialize in their stable home" {
     parameters: [[]],
     edge_arguments: [[]],
     successor_queries: Ref(0),
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(1)
   let slot = plan.create_spill_slot(8, 8)
@@ -1068,6 +1074,7 @@ test "edge arguments do not hide a live-through value transfer" {
     parameters: [[], [parameter]],
     edge_arguments: [[[value]], []],
     successor_queries: Ref(0),
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(2)
   let slot = plan.create_spill_slot(8, 8)
@@ -1162,4 +1169,100 @@ test "production conflict index finds only overlapping occupied segments" {
     conflicting_segments(segments, [0, 1, 2], segments[3], [0]),
     content="[1]",
   )
+}
+
+///|
+/// ISS-370 regression: `index_plan_edits` buckets by position, and bucket
+/// order must preserve the plan's edit order. The three moves below form a
+/// dependency chain at one position — each requires the location produced by
+/// the previous one — so any reordering inside the bucket fails verification
+/// with `IncorrectValue`.
+test "plan verifier applies same-position edits in plan order" {
+  let value : VirtualReg = { id: 0, class: Int }
+  let r0 : PhysicalReg = { id: 0, class: Int }
+  let r1 : PhysicalReg = { id: 1, class: Int }
+  let r2 : PhysicalReg = { id: 2, class: Int }
+  let function : VerifierCfgView = {
+    value_count: 1,
+    blocks: [[0]],
+    operands: [[Operand::use_reg(value)]],
+    successors: [[]],
+    entry_values: [value],
+    parameters: [[]],
+    edge_arguments: [[]],
+    successor_queries: Ref(0),
+    block_visits: Ref(0),
+  }
+  let plan = AllocationPlan::new(1)
+  plan.assign_value(value, Reg(r0))
+  plan.add_edit({ value, from: Reg(r0), to: Reg(r1), position: Before(0) })
+  plan.add_edit({ value, from: Reg(r1), to: Reg(r2), position: Before(0) })
+  plan.add_edit({ value, from: Reg(r2), to: Reg(r0), position: Before(0) })
+  plan.assign_operand(0, 0, Reg(r0))
+  verify_function_allocation(function, MachineEnv::new([r0, r1, r2], []), plan)
+}
+
+///|
+/// ISS-370 regression: reverse postorder is a topological order on an
+/// acyclic CFG, so every join merges all of its incoming states before its
+/// block is processed and the whole function verifies in one pass — each
+/// block exactly once. The chain of diamonds below refines the dataflow
+/// state at every join (each arm publishes the value in a different extra
+/// register, and the meet drops it), which is the shape that made the
+/// previous LIFO worklist reprocess the downstream chain once per join and
+/// grow verification cost with nesting depth.
+test "plan verifier processes a deep diamond join chain once per block" {
+  let diamonds = 8
+  let block_count = 3 * diamonds + 1
+  let value : VirtualReg = { id: 0, class: Int }
+  let r0 : PhysicalReg = { id: 0, class: Int }
+  let registers : Array[PhysicalReg] = Array::makei(diamonds + 1, id => {
+    id,
+    class: Int,
+  })
+  let blocks : Array[Array[Int]] = Array::makei(block_count, _ => [])
+  let successors : Array[Array[Int]] = Array::makei(block_count, _ => [])
+  let parameters : Array[Array[VirtualReg]] = Array::makei(block_count, _ => [])
+  let edge_arguments : Array[Array[Array[VirtualReg]]] = Array::makei(
+    block_count,
+    _ => [],
+  )
+  let plan = AllocationPlan::new(1)
+  plan.assign_value(value, Reg(r0))
+  for i in 0..<diamonds {
+    let top = 3 * i
+    let left = 3 * i + 1
+    let right = 3 * i + 2
+    let join = 3 * i + 3
+    successors[top] = [left, right]
+    edge_arguments[top] = [[], []]
+    successors[left] = [join]
+    edge_arguments[left] = [[]]
+    successors[right] = [join]
+    edge_arguments[right] = [[]]
+    // Only the right arm publishes the value in a per-diamond extra
+    // register, so every join must drop it — and because the extra register
+    // differs per level, a scheduler that enters a join with partial
+    // predecessor state has to re-propagate the shrink one level at a time.
+    plan.add_edit({
+      value,
+      from: Reg(r0),
+      to: Reg(registers[i + 1]),
+      position: Edge(source_block=right, successor_index=0),
+    })
+  }
+  let function : VerifierCfgView = {
+    value_count: 1,
+    blocks,
+    operands: [],
+    successors,
+    entry_values: [value],
+    parameters,
+    edge_arguments,
+    successor_queries: Ref(0),
+    block_visits: Ref(0),
+  }
+  verify_function_allocation(function, MachineEnv::new(registers, []), plan)
+  inspect(function.block_visits.val, content="25")
+  inspect(function.successor_queries.val, content="25")
 }

--- a/modules/wasmoon/component/model/component.mbt
+++ b/modules/wasmoon/component/model/component.mbt
@@ -30,7 +30,31 @@ pub impl Show for Component with fn output(self, logger) {
 
 ///|
 pub fn parse_component(bytes : Bytes) -> Component raise ComponentParseError {
-  let binary = parse_component_binary(bytes)
+  component_from_binary(parse_component_binary(bytes))
+}
+
+///|
+/// Rebuild a component that shares no mutable state with `self`.
+///
+/// Validation and instantiation both read `binary.sections`, so evidence of
+/// successful validation is only meaningful for content the caller cannot
+/// reach afterwards. Sections are immutable; copying the section list and
+/// re-deriving every parsed view yields a component whose observable state
+/// cannot be changed through any reference the caller retains.
+pub fn Component::isolated_copy(
+  self : Component,
+) -> Component raise ComponentParseError {
+  component_from_binary({
+    version: self.binary.version,
+    layer: self.binary.layer,
+    sections: self.binary.sections.copy(),
+  })
+}
+
+///|
+fn component_from_binary(
+  binary : ComponentBinary,
+) -> Component raise ComponentParseError {
   let core_modules : Array[Bytes] = []
   let core_instances : Array[Bytes] = []
   let core_types : Array[Bytes] = []

--- a/modules/wasmoon/component/model/pkg.generated.mbti
+++ b/modules/wasmoon/component/model/pkg.generated.mbti
@@ -146,6 +146,7 @@ pub(all) struct Component {
   start : Start?
   components : Array[Component]
 } derive(Eq, @debug.Debug)
+pub fn Component::isolated_copy(Self) -> Self raise ComponentParseError
 pub impl Show for Component
 
 pub struct ComponentBinary {

--- a/modules/wasmoon/component/runtime_impl/build_strings.mbt
+++ b/modules/wasmoon/component/runtime_impl/build_strings.mbt
@@ -20,6 +20,37 @@ priv struct BuildState {
 }
 
 ///|
+/// Release the build state of an aborted instantiation.
+///
+/// The frame's arrays carry the same deliberate `alias outer` cycles that
+/// `release_component_instance_graph` breaks at terminal close: a nested
+/// closure's outer stack holds an env instance whose child arrays are these
+/// arrays. Nothing registered the partial graph, so no later boundary can
+/// reach it — break the cycles here, on every abort. Clearing only this
+/// frame's own containers drops references to imported and outer objects
+/// without touching their state, so on an open linker the live imports the
+/// frame had resolved are unaffected. The frame's resource table entry in
+/// the shared `async_state` map deliberately stays: nested instances that
+/// completed before the abort are registered with the linker and may still
+/// resolve this table through their ancestor chain.
+fn BuildState::release_aborted(self : BuildState) -> Unit {
+  self.types.clear()
+  self.funcs.clear()
+  self.values.clear()
+  self.components.clear()
+  self.instances.clear()
+  self.core_modules.clear()
+  self.core_instances.clear()
+  self.core_funcs.clear()
+  self.core_types.clear()
+  self.core_tables.clear()
+  self.core_mems.clear()
+  self.core_globals.clear()
+  self.core_tags.clear()
+  self.exports.clear()
+}
+
+///|
 fn BuildState::BuildState(
   stream_table : StreamTable,
   async_state : AsyncState,

--- a/modules/wasmoon/component/runtime_impl/component_api.mbt
+++ b/modules/wasmoon/component/runtime_impl/component_api.mbt
@@ -166,7 +166,13 @@ pub impl Show for CoreInstance with fn output(_self, logger) {
 ///|
 /// A component value is a closure: the component binary plus the captured outer
 /// environment needed to resolve `alias outer ...` when instantiated later.
-pub(all) struct ComponentClosure {
+///
+/// The type is abstract on purpose. Every closure the runtime instantiates
+/// must originate from a validated boundary (`ComponentLinker::instantiate`,
+/// `ComponentLinker::add_component`, or a section of an already-validated
+/// component), so external code must not be able to forge a
+/// `Component(closure)` extern around an unchecked component.
+struct ComponentClosure {
   component : Component
   outer_stack : Array[ComponentInstance]
 }
@@ -576,12 +582,20 @@ pub fn ComponentLinker::add_value(
 }
 
 ///|
+/// Register a component import. Like `ComponentLinker::instantiate`, the
+/// boundary accepts validation evidence rather than a raw component: an
+/// imported component is instantiated by the instance sections of whichever
+/// component imports it, so an unchecked component here would reach
+/// instantiation without ever passing validation.
 pub fn ComponentLinker::add_component(
   self : ComponentLinker,
   name : String,
-  component : Component,
+  component : @component_validator.ValidatedComponent,
 ) -> Unit {
-  self.add_import(name, Component({ component, outer_stack: [] }))
+  self.add_import(
+    name,
+    Component({ component: component.component(), outer_stack: [] }),
+  )
 }
 
 ///|

--- a/modules/wasmoon/component/runtime_impl/component_api.mbt
+++ b/modules/wasmoon/component/runtime_impl/component_api.mbt
@@ -545,7 +545,14 @@ pub fn ComponentLinker::add_import(
   self : ComponentLinker,
   name : String,
   ext : ComponentExtern,
-) -> Unit {
+) -> Unit raise ComponentRuntimeError {
+  // A terminally closed linker accepts no new imports. `finish_close` has
+  // already walked and released the import table, so an extern added after
+  // close would be retained until the linker itself dies — an uncollectable
+  // cycle whenever the extern captures its own linker.
+  if self.closed.val {
+    raise Cancelled
+  }
   self.imports.set(name, ext)
 }
 
@@ -564,7 +571,7 @@ pub fn ComponentLinker::add_func(
   name : String,
   func_type : FuncType,
   func : (Array[ComponentValue]) -> Array[ComponentValue] raise ComponentRuntimeError,
-) -> Unit {
+) -> Unit raise ComponentRuntimeError {
   self.add_import(
     name,
     Func(
@@ -583,7 +590,7 @@ pub fn ComponentLinker::add_value(
   self : ComponentLinker,
   name : String,
   value : ComponentValue,
-) -> Unit {
+) -> Unit raise ComponentRuntimeError {
   self.add_import(name, Value(value))
 }
 
@@ -597,7 +604,7 @@ pub fn ComponentLinker::add_component(
   self : ComponentLinker,
   name : String,
   component : @component_validator.ValidatedComponent,
-) -> Unit {
+) -> Unit raise ComponentRuntimeError {
   self.add_import(
     name,
     Component({ component: component.component(), outer_stack: [] }),
@@ -609,7 +616,7 @@ pub fn ComponentLinker::add_instance(
   self : ComponentLinker,
   name : String,
   instance : ComponentInstance,
-) -> Unit {
+) -> Unit raise ComponentRuntimeError {
   self.add_import(name, Instance(instance))
 }
 
@@ -618,7 +625,7 @@ pub fn ComponentLinker::add_core_module(
   self : ComponentLinker,
   name : String,
   module_ : @types.Module,
-) -> Unit {
+) -> Unit raise ComponentRuntimeError {
   self.add_import(name, CoreModule(module_))
 }
 
@@ -627,7 +634,7 @@ pub fn ComponentLinker::add_core_instance(
   self : ComponentLinker,
   name : String,
   instance : CoreInstance,
-) -> Unit {
+) -> Unit raise ComponentRuntimeError {
   self.add_import(name, CoreInstance(instance))
 }
 

--- a/modules/wasmoon/component/runtime_impl/component_api.mbt
+++ b/modules/wasmoon/component/runtime_impl/component_api.mbt
@@ -414,63 +414,30 @@ pub fn ComponentLinker::close(self : ComponentLinker) -> Unit {
 }
 
 ///|
-/// Release an instance graph at terminal close.
+/// Release one linker-owned instance at terminal close.
 ///
 /// A component that defines a nested component stores a `ComponentClosure`
-/// whose `outer_stack` contains the enclosing instance itself — `alias outer`
-/// resolution requires the enclosing scope when the nested component is
-/// instantiated later. That is a deliberate reference cycle, and reference
-/// counting can never reclaim it: every instance graph with a nested
-/// component definition survives close intact, dragging its imports, host
-/// functions, and their per-function type-space copies along with it.
+/// whose `outer_stack` holds an env instance sharing this instance's child
+/// arrays — `alias outer` resolution requires the enclosing scope when the
+/// nested component is instantiated later. That is a deliberate reference
+/// cycle, and reference counting can never reclaim it. The cycle runs
+/// through this instance's own arrays, so clearing them is what breaks it;
+/// the env and inline instances of the same frame share the very same array
+/// objects and die with it.
 ///
-/// Terminal close is the owning boundary, so break the graph here: clear the
-/// closure and child arrays of every reachable instance. The visited set
-/// terminates on the cycles this exists to break.
-fn release_component_instance_graph(
-  instance : ComponentInstance,
-  visited : Array[ComponentInstance],
-) -> Unit {
-  for seen in visited {
-    if physical_equal(seen, instance) {
-      return
-    }
-  }
-  visited.push(instance)
-  // Instances produced during one instantiation share their backing arrays
-  // and export map — the `alias outer` environment records alias the final
-  // instance's storage. Collect every reachable child first, then clear this
-  // record's storage, and only then recurse: clearing while iterating a
-  // shared map would mutate the collection mid-walk, and a shared array
-  // visited again later is simply seen empty.
-  let children : Array[ComponentInstance] = []
-  for closure in instance.components {
-    for outer in closure.outer_stack {
-      children.push(outer)
-    }
-  }
-  for child in instance.instances {
-    children.push(child)
-  }
-  for entry in instance.exports {
-    let (_, ext) = entry
-    match ext {
-      Instance(child) => children.push(child)
-      Component(closure) =>
-        for outer in closure.outer_stack {
-          children.push(outer)
-        }
-      _ => ()
-    }
-  }
+/// Deliberately shallow. The linker owns exactly the instances its own
+/// instantiations registered — every instantiation frame registers itself,
+/// so `finish_close` walks all of them directly. Recursing into children
+/// would cross the ownership boundary: `instances` and `exports` also hold
+/// instances supplied through `add_instance`/`add_import`, which another
+/// linker or the embedder owns and may still be using. Clearing this
+/// instance's arrays only drops references to those, never their state.
+fn release_owned_instance(instance : ComponentInstance) -> Unit {
   instance.components.clear()
   instance.instances.clear()
   instance.funcs.clear()
   instance.values.clear()
   instance.exports.clear()
-  for child in children {
-    release_component_instance_graph(child, visited)
-  }
 }
 
 ///|
@@ -479,22 +446,13 @@ fn ComponentLinker::finish_close(self : ComponentLinker) -> Unit {
     return
   }
   self.close_complete.val = true
-  let visited : Array[ComponentInstance] = []
   for entry in self.components {
     let (_, instance) = entry
-    release_component_instance_graph(instance, visited)
+    release_owned_instance(instance)
   }
-  for entry in self.imports {
-    let (_, ext) = entry
-    match ext {
-      Instance(instance) => release_component_instance_graph(instance, visited)
-      Component(closure) =>
-        for outer in closure.outer_stack {
-          release_component_instance_graph(outer, visited)
-        }
-      _ => ()
-    }
-  }
+  // Imports are not owned: dropping the table's references is the linker's
+  // entire claim on them. Releasing their graphs here destroyed instances
+  // shared from other linkers or built by the embedder.
   self.components.clear()
   self.imports.clear()
   self.host_runtime.val = None

--- a/modules/wasmoon/component/runtime_impl/component_api.mbt
+++ b/modules/wasmoon/component/runtime_impl/component_api.mbt
@@ -516,7 +516,13 @@ pub fn ComponentLinker::register(
   self : ComponentLinker,
   name : String,
   instance : ComponentInstance,
-) -> Unit {
+) -> Unit raise ComponentRuntimeError {
+  // A terminally closed linker accepts no new instance graph: nothing would
+  // ever release a graph committed after `finish_close` has run or been
+  // scheduled.
+  if self.closed.val {
+    raise Cancelled
+  }
   self.components.push((name, instance))
 }
 
@@ -631,5 +637,35 @@ pub fn ComponentLinker::instantiate(
   name : String,
   component : @component_validator.ValidatedComponent,
 ) -> ComponentInstance raise ComponentRuntimeError {
-  instantiate_component(self, name, component.component(), Map([]), [])
+  // The whole instantiation holds a lifecycle lease. An embedder callback
+  // that closes the linker mid-instantiation (from an engine registration or
+  // a host import) only begins the close: teardown is deferred until this
+  // frame unwinds, so no section ever observes a released engine or cleared
+  // imports, and a close that started mid-flight turns into `Cancelled`
+  // rather than a successful instantiation on a closed linker.
+  self.core_execution_lifecycle.enter()
+  let instance = instantiate_component(
+    self,
+    name,
+    component.component(),
+    Map([]),
+    [],
+  ) catch {
+    error => {
+      let closing = self.core_execution_lifecycle.closing.val
+      self.core_execution_lifecycle.leave()
+      if closing {
+        raise Cancelled
+      }
+      raise error
+    }
+  }
+  let closing = self.core_execution_lifecycle.closing.val
+  self.core_execution_lifecycle.leave()
+  if closing {
+    // The deferred terminal close in `leave` released every registered
+    // graph, including this instance. Do not report success for it.
+    raise Cancelled
+  }
+  instance
 }

--- a/modules/wasmoon/component/runtime_impl/core_engine.mbt
+++ b/modules/wasmoon/component/runtime_impl/core_engine.mbt
@@ -292,7 +292,25 @@ fn CoreExecutionEngine::with_lifecycle(
 ) -> CoreExecutionEngine {
   CoreExecutionEngine(
     fn(store, module_, instance) raise ComponentRuntimeError {
-      self.register_instance(store, module_, instance)
+      // Registration runs embedder code and must hold a lease like invoke:
+      // a callback that closes the linker would otherwise tear the engine
+      // down mid-instantiation, and the registration would still commit.
+      lifecycle.enter()
+      self.register_instance(store, module_, instance) catch {
+        error => {
+          let closing = lifecycle.closing.val
+          lifecycle.leave()
+          if closing {
+            raise Cancelled
+          }
+          raise error
+        }
+      }
+      let closing = lifecycle.closing.val
+      lifecycle.leave()
+      if closing {
+        raise Cancelled
+      }
     },
     fn(store, instance, func_idx, args, request) raise ComponentRuntimeError {
       lifecycle.enter()

--- a/modules/wasmoon/component/runtime_impl/host_instance.mbt
+++ b/modules/wasmoon/component/runtime_impl/host_instance.mbt
@@ -38,7 +38,13 @@ fn HostRuntimeState::with_core_execution_engine(
 /// method before building host instances.
 pub fn ComponentLinker::host_runtime_state(
   self : ComponentLinker,
-) -> HostRuntimeState {
+) -> HostRuntimeState raise ComponentRuntimeError {
+  // A terminally closed linker installs no host runtime. `finish_close` has
+  // already dropped the runtime slot, and repeated closes return early, so
+  // a runtime installed here after close would never be released.
+  if self.closed.val {
+    raise Cancelled
+  }
   match self.host_runtime.val {
     Some(runtime) => runtime
     None => {

--- a/modules/wasmoon/component/runtime_impl/instantiate.mbt
+++ b/modules/wasmoon/component/runtime_impl/instantiate.mbt
@@ -42,21 +42,18 @@ fn instantiate_component(
     linker, name, component, overrides, outer_stack, state, entry_state, store, async_state,
   ) catch {
     error => {
-      // Nothing registered this partial graph, so terminal close cannot
-      // release it. If the linker closed while these sections ran, break
-      // the graph's cycles here before the error unwinds.
-      if linker.closed.val {
-        release_component_instance_graph(
-          env_instance_from_state(name, state, store),
-          [],
-        )
-      }
+      state.release_aborted()
       raise error
     }
   }
   entry_state.enable()
   let instance = env_instance_from_state(name, state, store)
-  linker.register(name, instance)
+  linker.register(name, instance) catch {
+    error => {
+      state.release_aborted()
+      raise error
+    }
+  }
   instance
 }
 

--- a/modules/wasmoon/component/runtime_impl/instantiate.mbt
+++ b/modules/wasmoon/component/runtime_impl/instantiate.mbt
@@ -38,6 +38,40 @@ fn instantiate_component(
   )
   let entry_state = ComponentInstanceEntryState::new()
   let store = linker.get_store()
+  run_component_sections(
+    linker, name, component, overrides, outer_stack, state, entry_state, store, async_state,
+  ) catch {
+    error => {
+      // Nothing registered this partial graph, so terminal close cannot
+      // release it. If the linker closed while these sections ran, break
+      // the graph's cycles here before the error unwinds.
+      if linker.closed.val {
+        release_component_instance_graph(
+          env_instance_from_state(name, state, store),
+          [],
+        )
+      }
+      raise error
+    }
+  }
+  entry_state.enable()
+  let instance = env_instance_from_state(name, state, store)
+  linker.register(name, instance)
+  instance
+}
+
+///|
+fn run_component_sections(
+  linker : ComponentLinker,
+  name : String,
+  component : Component,
+  overrides : Map[String, ComponentExtern],
+  outer_stack : Array[ComponentInstance],
+  state : BuildState,
+  entry_state : ComponentInstanceEntryState,
+  store : @runtime.Store,
+  async_state : AsyncState,
+) -> Unit raise ComponentRuntimeError {
   for section in component.binary.sections {
     match section.id {
       1 => {
@@ -376,28 +410,4 @@ fn instantiate_component(
       _ => ()
     }
   }
-  entry_state.enable()
-  let instance : ComponentInstance = {
-    name,
-    types: state.types,
-    funcs: state.funcs,
-    values: state.values,
-    components: state.components,
-    instances: state.instances,
-    resource_table: state.resource_table,
-    stream_table: state.stream_table,
-    async_state: state.async_state,
-    core_modules: state.core_modules,
-    core_instances: state.core_instances,
-    core_funcs: state.core_funcs,
-    core_types: state.core_types,
-    core_tables: state.core_tables,
-    core_mems: state.core_mems,
-    core_globals: state.core_globals,
-    core_tags: state.core_tags,
-    exports: state.exports,
-    store,
-  }
-  linker.register(name, instance)
-  instance
 }

--- a/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
+++ b/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
@@ -209,7 +209,7 @@ pub fn ComponentLinker::host_instance_builder(Self, String, HostRuntimeState) ->
 pub fn ComponentLinker::host_runtime_state(Self) -> HostRuntimeState
 pub fn ComponentLinker::instantiate(Self, String, @component_model.ValidatedComponent) -> ComponentInstance raise ComponentRuntimeError
 pub fn ComponentLinker::new_host_resource_type(Self) -> @model.TypeDef?
-pub fn ComponentLinker::register(Self, String, ComponentInstance) -> Unit
+pub fn ComponentLinker::register(Self, String, ComponentInstance) -> Unit raise ComponentRuntimeError
 pub fn ComponentLinker::with_core_execution_engine(CoreExecutionEngine) -> Self
 
 pub(all) enum ComponentValue {

--- a/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
+++ b/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
@@ -125,10 +125,7 @@ type CanonResources derive(@debug.Debug)
 
 type CanonSuspend derive(Eq, @debug.Debug)
 
-pub(all) struct ComponentClosure {
-  component : @model.Component
-  outer_stack : Array[ComponentInstance]
-}
+type ComponentClosure
 pub impl Show for ComponentClosure
 
 pub(all) enum ComponentExtern {
@@ -197,7 +194,7 @@ pub(all) enum ComponentInvocationPoll {
 
 type ComponentLinker
 pub fn ComponentLinker::ComponentLinker() -> Self
-pub fn ComponentLinker::add_component(Self, String, @model.Component) -> Unit
+pub fn ComponentLinker::add_component(Self, String, @component_model.ValidatedComponent) -> Unit
 pub fn ComponentLinker::add_core_instance(Self, String, CoreInstance) -> Unit
 pub fn ComponentLinker::add_core_module(Self, String, @types.Module) -> Unit
 pub fn ComponentLinker::add_func(Self, String, @model.FuncType, (Array[ComponentValue]) -> Array[ComponentValue] raise ComponentRuntimeError) -> Unit

--- a/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
+++ b/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
@@ -194,13 +194,13 @@ pub(all) enum ComponentInvocationPoll {
 
 type ComponentLinker
 pub fn ComponentLinker::ComponentLinker() -> Self
-pub fn ComponentLinker::add_component(Self, String, @component_model.ValidatedComponent) -> Unit
-pub fn ComponentLinker::add_core_instance(Self, String, CoreInstance) -> Unit
-pub fn ComponentLinker::add_core_module(Self, String, @types.Module) -> Unit
-pub fn ComponentLinker::add_func(Self, String, @model.FuncType, (Array[ComponentValue]) -> Array[ComponentValue] raise ComponentRuntimeError) -> Unit
-pub fn ComponentLinker::add_import(Self, String, ComponentExtern) -> Unit
-pub fn ComponentLinker::add_instance(Self, String, ComponentInstance) -> Unit
-pub fn ComponentLinker::add_value(Self, String, ComponentValue) -> Unit
+pub fn ComponentLinker::add_component(Self, String, @component_model.ValidatedComponent) -> Unit raise ComponentRuntimeError
+pub fn ComponentLinker::add_core_instance(Self, String, CoreInstance) -> Unit raise ComponentRuntimeError
+pub fn ComponentLinker::add_core_module(Self, String, @types.Module) -> Unit raise ComponentRuntimeError
+pub fn ComponentLinker::add_func(Self, String, @model.FuncType, (Array[ComponentValue]) -> Array[ComponentValue] raise ComponentRuntimeError) -> Unit raise ComponentRuntimeError
+pub fn ComponentLinker::add_import(Self, String, ComponentExtern) -> Unit raise ComponentRuntimeError
+pub fn ComponentLinker::add_instance(Self, String, ComponentInstance) -> Unit raise ComponentRuntimeError
+pub fn ComponentLinker::add_value(Self, String, ComponentValue) -> Unit raise ComponentRuntimeError
 pub fn ComponentLinker::close(Self) -> Unit
 pub fn ComponentLinker::get_component(Self, String) -> ComponentInstance?
 pub fn ComponentLinker::get_import(Self, String) -> ComponentExtern?

--- a/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
+++ b/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
@@ -206,7 +206,7 @@ pub fn ComponentLinker::get_component(Self, String) -> ComponentInstance?
 pub fn ComponentLinker::get_import(Self, String) -> ComponentExtern?
 pub fn ComponentLinker::get_store(Self) -> @runtime.Store
 pub fn ComponentLinker::host_instance_builder(Self, String, HostRuntimeState) -> HostInstanceBuilder
-pub fn ComponentLinker::host_runtime_state(Self) -> HostRuntimeState
+pub fn ComponentLinker::host_runtime_state(Self) -> HostRuntimeState raise ComponentRuntimeError
 pub fn ComponentLinker::instantiate(Self, String, @component_model.ValidatedComponent) -> ComponentInstance raise ComponentRuntimeError
 pub fn ComponentLinker::new_host_resource_type(Self) -> @model.TypeDef?
 pub fn ComponentLinker::register(Self, String, ComponentInstance) -> Unit raise ComponentRuntimeError

--- a/modules/wasmoon/component_conformance/component_script.mbt
+++ b/modules/wasmoon/component_conformance/component_script.mbt
@@ -983,8 +983,8 @@ fn run_component_script_impl(
   let return_three = make_const_u32_func(3)
   let return_four = make_const_u32_func(4)
   let echo_u32 = make_echo_u32_func()
-  linker.add_import("host-return-two", Func(return_two))
-  linker.add_import("host-echo-u32", Func(echo_u32))
+  try! linker.add_import("host-return-two", Func(return_two))
+  try! linker.add_import("host-echo-u32", Func(echo_u32))
   let simple_module_wat = "(module (func (export \"f\") (result i32) i32.const 101) (global (export \"g\") i32 (i32.const 100)))"
   let simple_module = @wat.parse(simple_module_wat) catch {
     e => {
@@ -1248,7 +1248,7 @@ fn run_component_script_impl(
   )
   host_exports.set("[method]resource1.take-own", Func(take_own))
   let host_instance = make_instance("host", store, host_exports)
-  linker.add_instance("host", host_instance)
+  try! linker.add_instance("host", host_instance)
   let components : Map[String, @component.Component] = Map([])
   let instances : Map[String, @runtime_impl.ComponentInstance] = Map([])
   let mut last_component : @component.Component? = None
@@ -1282,7 +1282,7 @@ fn run_component_script_impl(
         match component_import_evidence(component) {
           Ok(validated) => {
             components.set(name, component)
-            linker.add_component(strip_identifier(name), validated)
+            try! linker.add_component(strip_identifier(name), validated)
             result.add_passed()
           }
           Err(e) =>
@@ -1310,7 +1310,7 @@ fn run_component_script_impl(
             // instantiation below reports its validation error through the
             // existing path.
             if component_import_evidence(component) is Ok(validated) {
-              linker.add_component(strip_identifier(n), validated)
+              try! linker.add_component(strip_identifier(n), validated)
             }
           }
           None => ()
@@ -1335,7 +1335,7 @@ fn run_component_script_impl(
               match cmd.name {
                 Some(n) => {
                   instances.set(n, instance)
-                  linker.add_instance(strip_identifier(n), instance)
+                  try! linker.add_instance(strip_identifier(n), instance)
                 }
                 None => ()
               }
@@ -1376,7 +1376,7 @@ fn run_component_script_impl(
             match instantiate_component(linker, inst_name, component) {
               Ok(instance) => {
                 instances.set(name, instance)
-                linker.add_instance(strip_identifier(name), instance)
+                try! linker.add_instance(strip_identifier(name), instance)
                 last_instance = Some(instance)
                 result.add_passed()
               }

--- a/modules/wasmoon/component_conformance/component_script.mbt
+++ b/modules/wasmoon/component_conformance/component_script.mbt
@@ -775,6 +775,23 @@ fn load_component(
 }
 
 ///|
+/// Produce the validation evidence `ComponentLinker::add_component` requires.
+fn component_import_evidence(
+  component : @component.Component,
+) -> Result[@component_model.ValidatedComponent, String] {
+  try
+    @component_model.validate_component_for_instantiation_with_config(
+      component,
+      ComponentValidationConfig(false),
+    )
+  catch {
+    e => Err(e.to_string())
+  } noraise {
+    value => Ok(value)
+  }
+}
+
+///|
 fn instantiate_component(
   linker : @runtime_impl.ComponentLinker,
   name : String,
@@ -1262,9 +1279,15 @@ fn run_component_script_impl(
             continue
           }
         }
-        components.set(name, component)
-        linker.add_component(strip_identifier(name), component)
-        result.add_passed()
+        match component_import_evidence(component) {
+          Ok(validated) => {
+            components.set(name, component)
+            linker.add_component(strip_identifier(name), validated)
+            result.add_passed()
+          }
+          Err(e) =>
+            result.add_failed("component_definition validation failed: \{e}")
+        }
       }
       "component" => {
         let path = match cmd.path {
@@ -1283,7 +1306,12 @@ fn run_component_script_impl(
         match cmd.name {
           Some(n) => {
             components.set(n, component)
-            linker.add_component(strip_identifier(n), component)
+            // An invalid component is never registered as an import; the
+            // instantiation below reports its validation error through the
+            // existing path.
+            if component_import_evidence(component) is Ok(validated) {
+              linker.add_component(strip_identifier(n), validated)
+            }
           }
           None => ()
         }

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -647,6 +647,94 @@ test "component runtime: evidence survives raw component mutation" {
 }
 
 ///|
+/// Lifecycle regression: an engine registration callback that closes its own
+/// linker must not let the instantiation commit. Registration now holds a
+/// lifecycle lease like invoke, so the close defers until the registration
+/// returns, the registration refuses to commit into a closing engine, and
+/// the instantiation surfaces `Cancelled` instead of registering an instance
+/// graph that nothing would ever release.
+test "component runtime: close during engine registration cancels instantiation" {
+  let bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (core module $m (func (export "f") (result i32) (i32.const 7)))
+      #|  (core instance $i (instantiate $m))
+      #|  (func (export "f") (result u32) (canon lift (core func $i "f"))))
+      #|
+    ),
+  )
+  let component = @component.parse_component(bytes)
+  let validated = @component_model.validate_component_for_instantiation_with_config(
+    component,
+    @component_model.ComponentValidationConfig(false),
+  )
+  let linker_slot : Ref[@runtime_impl.ComponentLinker?] = Ref(None)
+  let registrations = Ref(0)
+  let engine = @runtime_impl.CoreExecutionEngine(
+    fn(_store, _module, _instance) {
+      registrations.val = registrations.val + 1
+      if linker_slot.val is Some(linker) {
+        linker.close()
+      }
+    },
+    fn(
+      _store,
+      _instance,
+      _func_idx,
+      _args,
+      _request,
+    ) raise @runtime_impl.ComponentRuntimeError {
+      raise HostCallError("invoke must not run in this test")
+    },
+  )
+  let linker = @runtime_impl.ComponentLinker::with_core_execution_engine(engine)
+  linker_slot.val = Some(linker)
+  let outcome = try linker.instantiate("closing", validated) catch {
+    Cancelled => "cancelled"
+    error => "unexpected error: \{error}"
+  } noraise {
+    _ => "instantiated"
+  }
+  debug_inspect(outcome, content="\"cancelled\"")
+  debug_inspect(registrations.val, content="1")
+  // The aborted instantiation must not resurrect state in the closed linker.
+  debug_inspect(linker.get_component("closing") is None, content="true")
+  // The linker is terminally closed: later instantiations are refused at
+  // entry, before any section runs.
+  let after_close = try linker.instantiate("after-close", validated) catch {
+    Cancelled => "cancelled"
+    error => "unexpected error: \{error}"
+  } noraise {
+    _ => "instantiated"
+  }
+  debug_inspect(after_close, content="\"cancelled\"")
+  debug_inspect(registrations.val, content="1")
+}
+
+///|
+/// Lifecycle regression: a closed linker refuses instantiation at entry even
+/// for a component with no core sections, which previously committed an
+/// instance graph into the closed linker.
+test "component runtime: closed linker refuses instantiation at entry" {
+  let bytes = @component_text.parse_component_wat("(component)")
+  let component = @component.parse_component(bytes)
+  let validated = @component_model.validate_component_for_instantiation_with_config(
+    component,
+    @component_model.ComponentValidationConfig(false),
+  )
+  let linker = @runtime_impl.ComponentLinker::ComponentLinker()
+  linker.close()
+  let outcome = try linker.instantiate("late", validated) catch {
+    Cancelled => "cancelled"
+    error => "unexpected error: \{error}"
+  } noraise {
+    _ => "instantiated"
+  }
+  debug_inspect(outcome, content="\"cancelled\"")
+  debug_inspect(linker.get_component("late") is None, content="true")
+}
+
+///|
 /// Regression test for the ISS-357 boundary gaps: a component import enters
 /// the linker only as validation evidence. The signature change is the
 /// guarantee (a raw component no longer type-checks), and the registered

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -732,6 +732,77 @@ test "component runtime: closed linker refuses instantiation at entry" {
   }
   debug_inspect(outcome, content="\"cancelled\"")
   debug_inspect(linker.get_component("late") is None, content="true")
+  // The import table is equally terminal: `finish_close` released it, so
+  // an extern added afterwards would be retained until the linker dies.
+  let add_outcome = try linker.add_import("late-value", Value(U32(1))) catch {
+    Cancelled => "cancelled"
+    error => "unexpected error: \{error}"
+  } noraise {
+    _ => "added"
+  }
+  debug_inspect(add_outcome, content="\"cancelled\"")
+  debug_inspect(linker.get_import("late-value") is None, content="true")
+}
+
+///|
+/// Lifecycle regression: an instantiation that fails on an open linker must
+/// not corrupt anything it had resolved. The abort path releases only the
+/// frame's own build state — breaking its `alias outer` cycles — while the
+/// imported instance and the linker itself stay fully usable.
+test "component runtime: failed instantiation leaves open linker intact" {
+  let inner_bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (core module $m (func (export "f") (result i32) (i32.const 7)))
+      #|  (core instance $i (instantiate $m))
+      #|  (func (export "f") (result u32) (canon lift (core func $i "f"))))
+      #|
+    ),
+  )
+  let inner = @component.parse_component(inner_bytes)
+  let inner_validated = @component_model.validate_component_for_instantiation_with_config(
+    inner,
+    @component_model.ComponentValidationConfig(false),
+  )
+  let linker = @runtime_impl.ComponentLinker::ComponentLinker()
+  let provider = linker.instantiate("provider", inner_validated)
+  linker.add_instance("a", provider)
+  // The importing component processes a nested component definition (which
+  // creates the `alias outer` cycle the abort path must break) before a core
+  // module whose start function traps at runtime.
+  let failing_bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (import "a" (instance $a (export "f" (func (result u32)))))
+      #|  (component $inner
+      #|    (core module $m (func (export "g") (result i32) (i32.const 1)))
+      #|    (core instance $i (instantiate $m))
+      #|    (func (export "g") (result u32) (canon lift (core func $i "g"))))
+      #|  (instance $one (instantiate $inner))
+      #|  (core module $boom (func $s unreachable) (start $s))
+      #|  (core instance $cb (instantiate $boom)))
+      #|
+    ),
+  )
+  let failing = @component.parse_component(failing_bytes)
+  let failing_validated = @component_model.validate_component_for_instantiation_with_config(
+    failing,
+    @component_model.ComponentValidationConfig(false),
+  )
+  let outcome = try linker.instantiate("failing", failing_validated) catch {
+    Cancelled => "cancelled"
+    _ => "failed"
+  } noraise {
+    _ => "instantiated"
+  }
+  debug_inspect(outcome, content="\"failed\"")
+  debug_inspect(linker.get_component("failing") is None, content="true")
+  // The imported instance the failed frame had resolved is untouched.
+  debug_inspect(provider.call_exported_func("f", []), content="[U32(7)]")
+  // The linker remains fully usable for later instantiations.
+  let again = linker.instantiate("again", inner_validated)
+  debug_inspect(again.call_exported_func("f", []), content="[U32(7)]")
+  linker.close()
 }
 
 ///|

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -606,3 +606,72 @@ test "linker close releases nested-component instance graphs" {
     content="(0, 0, 0, 0)",
   )
 }
+
+///|
+/// Regression test for the ISS-357 boundary gaps: validation evidence holds
+/// an isolated snapshot rebuilt from the component's sections, so mutating
+/// the raw component after validation cannot change what the runtime
+/// instantiates.
+test "component runtime: evidence survives raw component mutation" {
+  let bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (core module $m (func (export "f") (result i32) (i32.const 7)))
+      #|  (core instance $i (instantiate $m))
+      #|  (func (export "f") (result u32) (canon lift (core func $i "f"))))
+      #|
+    ),
+  )
+  let component = @component.parse_component(bytes)
+  let validated = @component_model.validate_component_for_instantiation_with_config(
+    component,
+    @component_model.ComponentValidationConfig(false),
+  )
+  // Erase every mutable view reachable through the caller's raw reference.
+  component.binary.sections.clear()
+  component.core_modules.clear()
+  component.core_instances.clear()
+  component.core_types.clear()
+  component.types.clear()
+  component.imports.clear()
+  component.exports.clear()
+  component.instances.clear()
+  component.aliases.clear()
+  component.canons.clear()
+  component.components.clear()
+  let linker = @runtime_impl.ComponentLinker::ComponentLinker()
+  let instance = linker.instantiate("mutated", validated)
+  let results = instance.call_exported_func("f", [])
+  debug_inspect(results, content="[U32(7)]")
+  linker.close()
+}
+
+///|
+/// Regression test for the ISS-357 boundary gaps: a component import enters
+/// the linker only as validation evidence. The signature change is the
+/// guarantee (a raw component no longer type-checks), and the registered
+/// import holds the evidence snapshot, which "evidence survives raw component
+/// mutation" above proves is unreachable from the caller's raw reference.
+test "component runtime: component import registration requires evidence" {
+  let inner_bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (core module $m (func (export "f") (result i32) (i32.const 7)))
+      #|  (core instance $i (instantiate $m))
+      #|  (func (export "f") (result u32) (canon lift (core func $i "f"))))
+      #|
+    ),
+  )
+  let inner = @component.parse_component(inner_bytes)
+  let inner_validated = @component_model.validate_component_for_instantiation_with_config(
+    inner,
+    @component_model.ComponentValidationConfig(false),
+  )
+  let linker = @runtime_impl.ComponentLinker::ComponentLinker()
+  linker.add_component("inner", inner_validated)
+  debug_inspect(
+    linker.get_import("inner") is Some(Component(_)),
+    content="true",
+  )
+  linker.close()
+}

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -742,6 +742,15 @@ test "component runtime: closed linker refuses instantiation at entry" {
   }
   debug_inspect(add_outcome, content="\"cancelled\"")
   debug_inspect(linker.get_import("late-value") is None, content="true")
+  // The host runtime slot is terminal too: `finish_close` dropped it, and a
+  // runtime installed afterwards would never be released.
+  let runtime_outcome = try linker.host_runtime_state() catch {
+    Cancelled => "cancelled"
+    error => "unexpected error: \{error}"
+  } noraise {
+    _ => "installed"
+  }
+  debug_inspect(runtime_outcome, content="\"cancelled\"")
 }
 
 ///|

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -745,6 +745,41 @@ test "component runtime: closed linker refuses instantiation at entry" {
 }
 
 ///|
+/// Ownership regression: closing a linker must not destroy instances it
+/// merely borrowed. `finish_close` used to release the graphs of imported
+/// instances recursively, so importing linker A's instance into linker B
+/// and closing B emptied the instance's exports — later calls through A
+/// failed with `UnknownExport`. Close now releases only the instances this
+/// linker's own instantiations registered; imports are dropped by clearing
+/// the import table, never by touching their state.
+test "component runtime: close releases only owned instances" {
+  let bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (core module $m (func (export "f") (result i32) (i32.const 7)))
+      #|  (core instance $i (instantiate $m))
+      #|  (func (export "f") (result u32) (canon lift (core func $i "f"))))
+      #|
+    ),
+  )
+  let component = @component.parse_component(bytes)
+  let validated = @component_model.validate_component_for_instantiation_with_config(
+    component,
+    @component_model.ComponentValidationConfig(false),
+  )
+  let linker_a = @runtime_impl.ComponentLinker::ComponentLinker()
+  let provider = linker_a.instantiate("provider", validated)
+  let linker_b = @runtime_impl.ComponentLinker::ComponentLinker()
+  linker_b.add_instance("a", provider)
+  linker_b.close()
+  // Linker A still owns the instance; its exports must be intact.
+  debug_inspect(provider.call_exported_func("f", []), content="[U32(7)]")
+  linker_a.close()
+  // A's own close is the owning boundary and does release the graph.
+  debug_inspect(provider.exports.length(), content="0")
+}
+
+///|
 /// Lifecycle regression: an instantiation that fails on an open linker must
 /// not corrupt anything it had resolved. The abort path releases only the
 /// frame's own build state — breaking its `alias outer` cycles — while the

--- a/modules/wasmoon/validator/component_model/validate.mbt
+++ b/modules/wasmoon/validator/component_model/validate.mbt
@@ -926,10 +926,19 @@ pub fn validate_component_for_instantiation(
 ///|
 /// Validate a component with the requested name policy and return evidence
 /// accepted by runtime instantiation.
+///
+/// The evidence holds an isolated snapshot rebuilt from the component's
+/// binary sections: the snapshot is what gets validated, and it is the only
+/// component the runtime will instantiate. Mutating the argument after this
+/// call — its parsed views or its section list — cannot invalidate the
+/// evidence.
 pub fn validate_component_for_instantiation_with_config(
   component : @component.Component,
   cfg : ComponentValidationConfig,
 ) -> ValidatedComponent raise ComponentValidationError {
-  validate_component_with_config(component, cfg)
-  { component, }
+  let snapshot = component.isolated_copy() catch {
+    e => raise SectionParseError(0, "component snapshot: \{e}")
+  }
+  validate_component_with_config(snapshot, cfg)
+  { component: snapshot }
 }

--- a/scripts/audit_component_security.py
+++ b/scripts/audit_component_security.py
@@ -104,10 +104,24 @@ def has_validated_instantiation_boundary(
         r" -> ComponentInstance raise ComponentRuntimeError",
         runtime,
     )
+    # A component import is instantiated by whichever component imports it,
+    # so the registration boundary needs the same evidence as instantiation.
+    component_import_requires_evidence = re.search(
+        r"pub fn ComponentLinker::add_component"
+        r"\(Self, String, @component_model\.ValidatedComponent\) -> Unit",
+        runtime,
+    )
+    # A constructible closure would let external code forge a
+    # `Component(closure)` extern around an unchecked component.
+    closure_not_constructible = re.search(
+        r"\btype ComponentClosure\b", runtime
+    ) and not re.search(r"pub(\(all\))? struct ComponentClosure\b", runtime)
     return bool(
         has_abstract_evidence
         and has_evidence_producer
         and linker_requires_evidence
+        and component_import_requires_evidence
+        and closure_not_constructible
     )
 
 
@@ -259,8 +273,9 @@ def audit_repo(root: Path) -> list[AuditCheck]:
                 validator_interface,
                 runtime_interface,
             ),
-            "ComponentLinker::instantiate must require abstract evidence "
-            "returned by successful component validation",
+            "ComponentLinker::instantiate and ComponentLinker::add_component "
+            "must require abstract evidence returned by successful component "
+            "validation, and ComponentClosure must not be constructible",
         )
     )
     checks.append(

--- a/scripts/tests/test_component_security_audit.py
+++ b/scripts/tests/test_component_security_audit.py
@@ -69,6 +69,9 @@ class ComponentSecurityAuditTests(unittest.TestCase):
             encoding="utf-8",
         )
         (root / "runtime.mbti").write_text(
+            "type ComponentClosure\n"
+            "pub fn ComponentLinker::add_component"
+            "(Self, String, @component_model.ValidatedComponent) -> Unit\n"
             "pub fn ComponentLinker::instantiate"
             "(Self, String, @component_model.ValidatedComponent)"
             " -> ComponentInstance raise ComponentRuntimeError\n",
@@ -266,6 +269,39 @@ class ComponentSecurityAuditTests(unittest.TestCase):
             (root / "runtime.mbti").write_text(
                 "pub fn ComponentLinker::instantiate"
                 "(Self, String, @model.Component)"
+                " -> ComponentInstance raise ComponentRuntimeError\n",
+                encoding="utf-8",
+            )
+            self.assert_failed(root, "validate-before-instantiate")
+
+    def test_raw_component_import_boundary_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_fixture(root)
+            (root / "runtime.mbti").write_text(
+                "type ComponentClosure\n"
+                "pub fn ComponentLinker::add_component"
+                "(Self, String, @model.Component) -> Unit\n"
+                "pub fn ComponentLinker::instantiate"
+                "(Self, String, @component_model.ValidatedComponent)"
+                " -> ComponentInstance raise ComponentRuntimeError\n",
+                encoding="utf-8",
+            )
+            self.assert_failed(root, "validate-before-instantiate")
+
+    def test_constructible_component_closure_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_fixture(root)
+            (root / "runtime.mbti").write_text(
+                "pub(all) struct ComponentClosure {\n"
+                "  component : @model.Component\n"
+                "  outer_stack : Array[ComponentInstance]\n"
+                "}\n"
+                "pub fn ComponentLinker::add_component"
+                "(Self, String, @component_model.ValidatedComponent) -> Unit\n"
+                "pub fn ComponentLinker::instantiate"
+                "(Self, String, @component_model.ValidatedComponent)"
                 " -> ComponentInstance raise ComponentRuntimeError\n",
                 encoding="utf-8",
             )


### PR DESCRIPTION
## Summary

Review found two paths that defeated the ISS-357 type-state boundary: `ComponentLinker::add_component` still accepted a raw `Component` (an imported component is instantiated by the instance sections of whichever component imports it, so it reached full instantiation unvalidated), and `ValidatedComponent` wrapped the same reference the caller retained, so mutating the raw component after validation invalidated the evidence. `ComponentClosure` was also `pub(all)`, so a `Component(closure)` extern could be forged around an unchecked component.

## Fix

- `Component::isolated_copy` rebuilds a component from a copy of its immutable binary sections — the source both validation and instantiation actually read.
- `validate_component_for_instantiation_with_config` validates the snapshot and the evidence holds only the snapshot; no reference the caller retains can reach validated content.
- `ComponentLinker::add_component` now requires `ValidatedComponent`; `ComponentClosure` is abstract.
- The audit's validate-before-instantiate check additionally pins the `add_component` signature and non-constructibility of `ComponentClosure`, with negative gate tests.
- Conformance runner registers component definitions through the evidence-producing path.

Defense in depth: the validator independently rejects root-level component imports and requires nested component imports to be satisfied by explicit instantiate arguments, so the linker component-import fallback is unreachable from validated components today; the hardened boundary matters if either rule is ever relaxed.

Also corrects the stale ISS-367 note (upstream report has been made).

## Testing

- 1535 native + 983 wasm-gc tests pass, including two new regressions: evidence survives full mutation of the raw component; component import registration requires evidence.
- Component spec suites: stable-0.2 23/23, async-0.3 24/24, future-gated 12/12 files.
- Component security audit passes; 21 audit gate tests pass (2 new negative cases).

Closes ISS-357 (reopened close notes updated in `issues/ISS-357.md`).