### PR TITLE
fix: release only linker-owned instances at terminal close (ISS-374)

### DIFF
--- a/issues/ISS-370.md
+++ b/issues/ISS-370.md
@@ -106,6 +106,15 @@ is out of this issue's scope and is tracked by ISS-371.
 - 2026-07-31: Reproduced via `wasmoon explore` (same pipeline, no
   instantiation needed since the module's imports are absent). Sample
   attribution: 6564/6600 in `regalloc.apply_position_edits`.
+- 2026-08-02: Review noted the fix lacked targeted regressions, so two
+  whitebox tests now lock its invariants. "plan verifier applies
+  same-position edits in plan order" chains three dependent moves at one
+  `EditPosition` — any bucket reordering fails with `IncorrectValue`
+  (mutation-verified by reversing bucket iteration). "plan verifier
+  processes a deep diamond join chain once per block" counts
+  `block_instructions` calls over a join-dense CFG whose right arms publish
+  per-level extra registers, asserting exactly one visit per block
+  (mutation-verified: restoring a naive LIFO worklist fails the count).
 
 ## Close Notes
 - 2026-08-01: Bucketed plan edits by position once per verification and

--- a/issues/ISS-373.md
+++ b/issues/ISS-373.md
@@ -88,6 +88,13 @@ contract at its own boundary:
   merely dropping references to imported or outer objects without touching
   their state. It is therefore safe on an open linker and runs on every
   abort, including a `register` refusal.
+- 2026-08-02: Review found one more retaining mutator outside the guarded
+  set: `ComponentLinker::host_runtime_state` lazily installed a
+  `HostRuntimeState` into the runtime slot after close (repeated closes
+  return early, so it would never be released). It now raises `Cancelled`
+  on a closed linker, completing terminal coverage of every public mutator
+  that retains state. `new_host_resource_type` stays non-raising by design:
+  it only bumps an id counter and retains nothing.
 - 2026-08-02: The frame's resource-table entry in the shared `async_state`
   map intentionally survives an abort: nested instances that completed and
   registered before the abort may still resolve it through their ancestor

--- a/issues/ISS-374.md
+++ b/issues/ISS-374.md
@@ -1,0 +1,80 @@
+# ISS-374: Linker close destroys externally shared instances
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 1
+- Labels: component-model, lifecycle, ownership, runtime, tests, agent
+- Assignee: claude
+- Created: 2026-08-02
+- Updated: 2026-08-02
+- External ref: none
+
+## Description
+`finish_close` released instance graphs recursively, and its walk covered
+the import table. `add_instance` has no ownership transfer protocol, so a
+linker that merely borrowed an instance destroyed it at close: importing an
+instance created by linker A into linker B and closing B emptied the
+instance's export map, and later calls through A failed with
+`UnknownExport`.
+
+The recursion was equally wrong one level deeper: a registered instance's
+`instances` array and `exports` map also hold borrowed instances (resolved
+imports), so closing a linker whose own component imported a foreign
+instance corrupted that instance too.
+
+## Design
+Release exactly what the linker owns, nothing reachable.
+
+The ownership boundary already exists structurally: every instantiation
+frame registers its instance with the linker (`linker.register` is the
+single exit of `instantiate_component`, including nested frames), and the
+env and inline instances of a frame share that frame's array objects. The
+`alias outer` cycle that motivated recursive release runs through the
+frame's own arrays.
+
+Therefore terminal close shallow-releases each registered instance —
+clearing its own `components`/`instances`/`funcs`/`values`/`exports`
+containers breaks every owned cycle and merely drops references to borrowed
+objects — and the import table is released by clearing the table itself.
+This is the instance-side twin of `BuildState::release_aborted` (ISS-373).
+
+## Acceptance Criteria
+- [x] Closing a linker leaves instances imported via `add_instance` fully
+      usable by their owner.
+- [x] The owning linker's close still releases its registered graphs,
+      including nested-component `alias outer` cycles (ISS-372 regression
+      stays green).
+- [x] Full test suites, component spec suites, and the component security
+      audit pass.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-366, ISS-372, ISS-373
+- Discovered from: review of the ISS-372 release path
+
+## Notes
+- 2026-08-02: WASI host instances stay leak-free without the imports walk:
+  `HostInstanceBuilder::finish` constructs the instance after its export
+  closures exist, so a host instance cannot capture itself and reference
+  counting reclaims it once the import table drops it.
+- 2026-08-02: A host-built instance that references itself through its own
+  export map would now outlive the borrowing linker's close. That is the
+  ownership contract working as intended — the embedder built it, the
+  embedder owns it — and no in-repo construction produces such a cycle.
+
+## Close Notes
+
+`release_component_instance_graph` (recursive, visited-set) is replaced by
+the shallow `release_owned_instance`; `finish_close` walks only
+`self.components` and releases the import table by clearing it. Regression
+test "close releases only owned instances" reproduces the report: linker A's
+instance imported into linker B survives B's close with exports intact and
+callable, and A's own close still releases it. The ISS-372 nested-graph
+regression passes unchanged because every frame registers, so the shallow
+walk covers every graph the recursion used to reach — minus the borrowed
+ones it should never have touched.
+
+Validation: 1539 native + 983 wasm-gc tests, component spec suites 23/23,
+24/24, 12/12 files, and the component security audit all pass.

--- a/modules/regalloc/regalloc_wbtest.mbt
+++ b/modules/regalloc/regalloc_wbtest.mbt
@@ -798,6 +798,7 @@ priv struct VerifierCfgView {
   parameters : Array[Array[VirtualReg]]
   edge_arguments : Array[Array[Array[VirtualReg]]]
   successor_queries : Ref[Int]
+  block_visits : Ref[Int]
 }
 
 ///|
@@ -860,6 +861,7 @@ impl FunctionView for VerifierCfgView with fn block_parameters(self, block) -> A
 impl FunctionView for VerifierCfgView with fn block_instructions(self, block) -> Array[
   Int,
 ] {
+  self.block_visits.val = self.block_visits.val + 1
   self.blocks[block].copy()
 }
 
@@ -933,6 +935,7 @@ test "plan verifier always enters a self-looping entry block" {
         parameters: [[]],
         edge_arguments: [[[]]],
         successor_queries: Ref(0),
+        block_visits: Ref(0),
       },
       None,
       0,
@@ -962,6 +965,7 @@ test "plan verifier checks an unreachable cyclic component" {
         parameters: [[], []],
         edge_arguments: [[], [[]]],
         successor_queries: Ref(0),
+        block_visits: Ref(0),
       },
       Some(0),
       1,
@@ -991,6 +995,7 @@ test "plan verifier queries each block successor list once" {
     parameters: [[], [], [], []],
     edge_arguments: [[[]], [[]], [[]], []],
     successor_queries,
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(1)
   plan.assign_value(value, Reg(register))
@@ -1024,6 +1029,7 @@ test "any-location definitions materialize in their stable home" {
     parameters: [[]],
     edge_arguments: [[]],
     successor_queries: Ref(0),
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(1)
   let slot = plan.create_spill_slot(8, 8)
@@ -1068,6 +1074,7 @@ test "edge arguments do not hide a live-through value transfer" {
     parameters: [[], [parameter]],
     edge_arguments: [[[value]], []],
     successor_queries: Ref(0),
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(2)
   let slot = plan.create_spill_slot(8, 8)
@@ -1162,4 +1169,100 @@ test "production conflict index finds only overlapping occupied segments" {
     conflicting_segments(segments, [0, 1, 2], segments[3], [0]),
     content="[1]",
   )
+}
+
+///|
+/// ISS-370 regression: `index_plan_edits` buckets by position, and bucket
+/// order must preserve the plan's edit order. The three moves below form a
+/// dependency chain at one position — each requires the location produced by
+/// the previous one — so any reordering inside the bucket fails verification
+/// with `IncorrectValue`.
+test "plan verifier applies same-position edits in plan order" {
+  let value : VirtualReg = { id: 0, class: Int }
+  let r0 : PhysicalReg = { id: 0, class: Int }
+  let r1 : PhysicalReg = { id: 1, class: Int }
+  let r2 : PhysicalReg = { id: 2, class: Int }
+  let function : VerifierCfgView = {
+    value_count: 1,
+    blocks: [[0]],
+    operands: [[Operand::use_reg(value)]],
+    successors: [[]],
+    entry_values: [value],
+    parameters: [[]],
+    edge_arguments: [[]],
+    successor_queries: Ref(0),
+    block_visits: Ref(0),
+  }
+  let plan = AllocationPlan::new(1)
+  plan.assign_value(value, Reg(r0))
+  plan.add_edit({ value, from: Reg(r0), to: Reg(r1), position: Before(0) })
+  plan.add_edit({ value, from: Reg(r1), to: Reg(r2), position: Before(0) })
+  plan.add_edit({ value, from: Reg(r2), to: Reg(r0), position: Before(0) })
+  plan.assign_operand(0, 0, Reg(r0))
+  verify_function_allocation(function, MachineEnv::new([r0, r1, r2], []), plan)
+}
+
+///|
+/// ISS-370 regression: reverse postorder is a topological order on an
+/// acyclic CFG, so every join merges all of its incoming states before its
+/// block is processed and the whole function verifies in one pass — each
+/// block exactly once. The chain of diamonds below refines the dataflow
+/// state at every join (each arm publishes the value in a different extra
+/// register, and the meet drops it), which is the shape that made the
+/// previous LIFO worklist reprocess the downstream chain once per join and
+/// grow verification cost with nesting depth.
+test "plan verifier processes a deep diamond join chain once per block" {
+  let diamonds = 8
+  let block_count = 3 * diamonds + 1
+  let value : VirtualReg = { id: 0, class: Int }
+  let r0 : PhysicalReg = { id: 0, class: Int }
+  let registers : Array[PhysicalReg] = Array::makei(diamonds + 1, id => {
+    id,
+    class: Int,
+  })
+  let blocks : Array[Array[Int]] = Array::makei(block_count, _ => [])
+  let successors : Array[Array[Int]] = Array::makei(block_count, _ => [])
+  let parameters : Array[Array[VirtualReg]] = Array::makei(block_count, _ => [])
+  let edge_arguments : Array[Array[Array[VirtualReg]]] = Array::makei(
+    block_count,
+    _ => [],
+  )
+  let plan = AllocationPlan::new(1)
+  plan.assign_value(value, Reg(r0))
+  for i in 0..<diamonds {
+    let top = 3 * i
+    let left = 3 * i + 1
+    let right = 3 * i + 2
+    let join = 3 * i + 3
+    successors[top] = [left, right]
+    edge_arguments[top] = [[], []]
+    successors[left] = [join]
+    edge_arguments[left] = [[]]
+    successors[right] = [join]
+    edge_arguments[right] = [[]]
+    // Only the right arm publishes the value in a per-diamond extra
+    // register, so every join must drop it — and because the extra register
+    // differs per level, a scheduler that enters a join with partial
+    // predecessor state has to re-propagate the shrink one level at a time.
+    plan.add_edit({
+      value,
+      from: Reg(r0),
+      to: Reg(registers[i + 1]),
+      position: Edge(source_block=right, successor_index=0),
+    })
+  }
+  let function : VerifierCfgView = {
+    value_count: 1,
+    blocks,
+    operands: [],
+    successors,
+    entry_values: [value],
+    parameters,
+    edge_arguments,
+    successor_queries: Ref(0),
+    block_visits: Ref(0),
+  }
+  verify_function_allocation(function, MachineEnv::new(registers, []), plan)
+  inspect(function.block_visits.val, content="25")
+  inspect(function.successor_queries.val, content="25")
 }

--- a/modules/wasmoon/component/runtime_impl/component_api.mbt
+++ b/modules/wasmoon/component/runtime_impl/component_api.mbt
@@ -414,63 +414,30 @@ pub fn ComponentLinker::close(self : ComponentLinker) -> Unit {
 }
 
 ///|
-/// Release an instance graph at terminal close.
+/// Release one linker-owned instance at terminal close.
 ///
 /// A component that defines a nested component stores a `ComponentClosure`
-/// whose `outer_stack` contains the enclosing instance itself — `alias outer`
-/// resolution requires the enclosing scope when the nested component is
-/// instantiated later. That is a deliberate reference cycle, and reference
-/// counting can never reclaim it: every instance graph with a nested
-/// component definition survives close intact, dragging its imports, host
-/// functions, and their per-function type-space copies along with it.
+/// whose `outer_stack` holds an env instance sharing this instance's child
+/// arrays — `alias outer` resolution requires the enclosing scope when the
+/// nested component is instantiated later. That is a deliberate reference
+/// cycle, and reference counting can never reclaim it. The cycle runs
+/// through this instance's own arrays, so clearing them is what breaks it;
+/// the env and inline instances of the same frame share the very same array
+/// objects and die with it.
 ///
-/// Terminal close is the owning boundary, so break the graph here: clear the
-/// closure and child arrays of every reachable instance. The visited set
-/// terminates on the cycles this exists to break.
-fn release_component_instance_graph(
-  instance : ComponentInstance,
-  visited : Array[ComponentInstance],
-) -> Unit {
-  for seen in visited {
-    if physical_equal(seen, instance) {
-      return
-    }
-  }
-  visited.push(instance)
-  // Instances produced during one instantiation share their backing arrays
-  // and export map — the `alias outer` environment records alias the final
-  // instance's storage. Collect every reachable child first, then clear this
-  // record's storage, and only then recurse: clearing while iterating a
-  // shared map would mutate the collection mid-walk, and a shared array
-  // visited again later is simply seen empty.
-  let children : Array[ComponentInstance] = []
-  for closure in instance.components {
-    for outer in closure.outer_stack {
-      children.push(outer)
-    }
-  }
-  for child in instance.instances {
-    children.push(child)
-  }
-  for entry in instance.exports {
-    let (_, ext) = entry
-    match ext {
-      Instance(child) => children.push(child)
-      Component(closure) =>
-        for outer in closure.outer_stack {
-          children.push(outer)
-        }
-      _ => ()
-    }
-  }
+/// Deliberately shallow. The linker owns exactly the instances its own
+/// instantiations registered — every instantiation frame registers itself,
+/// so `finish_close` walks all of them directly. Recursing into children
+/// would cross the ownership boundary: `instances` and `exports` also hold
+/// instances supplied through `add_instance`/`add_import`, which another
+/// linker or the embedder owns and may still be using. Clearing this
+/// instance's arrays only drops references to those, never their state.
+fn release_owned_instance(instance : ComponentInstance) -> Unit {
   instance.components.clear()
   instance.instances.clear()
   instance.funcs.clear()
   instance.values.clear()
   instance.exports.clear()
-  for child in children {
-    release_component_instance_graph(child, visited)
-  }
 }
 
 ///|
@@ -479,22 +446,13 @@ fn ComponentLinker::finish_close(self : ComponentLinker) -> Unit {
     return
   }
   self.close_complete.val = true
-  let visited : Array[ComponentInstance] = []
   for entry in self.components {
     let (_, instance) = entry
-    release_component_instance_graph(instance, visited)
+    release_owned_instance(instance)
   }
-  for entry in self.imports {
-    let (_, ext) = entry
-    match ext {
-      Instance(instance) => release_component_instance_graph(instance, visited)
-      Component(closure) =>
-        for outer in closure.outer_stack {
-          release_component_instance_graph(outer, visited)
-        }
-      _ => ()
-    }
-  }
+  // Imports are not owned: dropping the table's references is the linker's
+  // entire claim on them. Releasing their graphs here destroyed instances
+  // shared from other linkers or built by the embedder.
   self.components.clear()
   self.imports.clear()
   self.host_runtime.val = None

--- a/modules/wasmoon/component/runtime_impl/host_instance.mbt
+++ b/modules/wasmoon/component/runtime_impl/host_instance.mbt
@@ -38,7 +38,13 @@ fn HostRuntimeState::with_core_execution_engine(
 /// method before building host instances.
 pub fn ComponentLinker::host_runtime_state(
   self : ComponentLinker,
-) -> HostRuntimeState {
+) -> HostRuntimeState raise ComponentRuntimeError {
+  // A terminally closed linker installs no host runtime. `finish_close` has
+  // already dropped the runtime slot, and repeated closes return early, so
+  // a runtime installed here after close would never be released.
+  if self.closed.val {
+    raise Cancelled
+  }
   match self.host_runtime.val {
     Some(runtime) => runtime
     None => {

--- a/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
+++ b/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
@@ -206,7 +206,7 @@ pub fn ComponentLinker::get_component(Self, String) -> ComponentInstance?
 pub fn ComponentLinker::get_import(Self, String) -> ComponentExtern?
 pub fn ComponentLinker::get_store(Self) -> @runtime.Store
 pub fn ComponentLinker::host_instance_builder(Self, String, HostRuntimeState) -> HostInstanceBuilder
-pub fn ComponentLinker::host_runtime_state(Self) -> HostRuntimeState
+pub fn ComponentLinker::host_runtime_state(Self) -> HostRuntimeState raise ComponentRuntimeError
 pub fn ComponentLinker::instantiate(Self, String, @component_model.ValidatedComponent) -> ComponentInstance raise ComponentRuntimeError
 pub fn ComponentLinker::new_host_resource_type(Self) -> @model.TypeDef?
 pub fn ComponentLinker::register(Self, String, ComponentInstance) -> Unit raise ComponentRuntimeError

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -742,6 +742,15 @@ test "component runtime: closed linker refuses instantiation at entry" {
   }
   debug_inspect(add_outcome, content="\"cancelled\"")
   debug_inspect(linker.get_import("late-value") is None, content="true")
+  // The host runtime slot is terminal too: `finish_close` dropped it, and a
+  // runtime installed afterwards would never be released.
+  let runtime_outcome = try linker.host_runtime_state() catch {
+    Cancelled => "cancelled"
+    error => "unexpected error: \{error}"
+  } noraise {
+    _ => "installed"
+  }
+  debug_inspect(runtime_outcome, content="\"cancelled\"")
 }
 
 ///|

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -745,6 +745,41 @@ test "component runtime: closed linker refuses instantiation at entry" {
 }
 
 ///|
+/// Ownership regression: closing a linker must not destroy instances it
+/// merely borrowed. `finish_close` used to release the graphs of imported
+/// instances recursively, so importing linker A's instance into linker B
+/// and closing B emptied the instance's exports — later calls through A
+/// failed with `UnknownExport`. Close now releases only the instances this
+/// linker's own instantiations registered; imports are dropped by clearing
+/// the import table, never by touching their state.
+test "component runtime: close releases only owned instances" {
+  let bytes = @component_text.parse_component_wat(
+    (
+      #|(component
+      #|  (core module $m (func (export "f") (result i32) (i32.const 7)))
+      #|  (core instance $i (instantiate $m))
+      #|  (func (export "f") (result u32) (canon lift (core func $i "f"))))
+      #|
+    ),
+  )
+  let component = @component.parse_component(bytes)
+  let validated = @component_model.validate_component_for_instantiation_with_config(
+    component,
+    @component_model.ComponentValidationConfig(false),
+  )
+  let linker_a = @runtime_impl.ComponentLinker::ComponentLinker()
+  let provider = linker_a.instantiate("provider", validated)
+  let linker_b = @runtime_impl.ComponentLinker::ComponentLinker()
+  linker_b.add_instance("a", provider)
+  linker_b.close()
+  // Linker A still owns the instance; its exports must be intact.
+  debug_inspect(provider.call_exported_func("f", []), content="[U32(7)]")
+  linker_a.close()
+  // A's own close is the owning boundary and does release the graph.
+  debug_inspect(provider.exports.length(), content="0")
+}
+
+///|
 /// Lifecycle regression: an instantiation that fails on an open linker must
 /// not corrupt anything it had resolved. The abort path releases only the
 /// frame's own build state — breaking its `alias outer` cycles — while the


### PR DESCRIPTION
## Summary

`finish_close` released instance graphs recursively and its walk covered the import table, but `add_instance` has no ownership transfer protocol — so a linker destroyed instances it merely borrowed. Repro: import linker A's instance into linker B, close B, and the instance's export map is emptied; later calls through A fail with `UnknownExport`. The recursion was equally wrong one level deeper: a registered instance's `instances`/`exports` also hold borrowed instances resolved from imports.

## Fix

Release exactly what the linker owns. The ownership boundary is already structural: **every** instantiation frame registers its instance (`linker.register` is the single exit of `instantiate_component`, nested frames included), and a frame's `alias outer` cycle runs through the frame's own arrays — env and inline instances share those same array objects. So:

- `release_component_instance_graph` (recursive, visited-set) → shallow `release_owned_instance`: clearing the registered instance's own containers breaks every owned cycle and merely drops references to borrowed objects.
- `finish_close` walks only `self.components`; the import table is released by clearing the table itself — dropping references is the linker's entire claim on imports.

This is the instance-side twin of ISS-373's `BuildState::release_aborted`. WASI host instances stay leak-free: `HostInstanceBuilder::finish` builds the instance after its export closures exist, so no self-capture, and RC reclaims them once the import table drops them.

## Testing

- New regression "close releases only owned instances": A's instance imported into B survives B's close with exports intact and callable; A's own close still releases it. Reproduced `UnknownExport` before the fix.
- ISS-372 nested-graph regression passes unchanged (every frame registers, so the shallow walk covers everything the recursion legitimately reached).
- 1539 native + 983 wasm-gc tests; spec suites 23/23, 24/24, 12/12; component security audit green.

Stacked on #459. Closes ISS-374.