### PR TITLE
fix: guard host_runtime_state after close; lock verifier invariants with tests

### DIFF
--- a/issues/ISS-370.md
+++ b/issues/ISS-370.md
@@ -106,6 +106,15 @@ is out of this issue's scope and is tracked by ISS-371.
 - 2026-07-31: Reproduced via `wasmoon explore` (same pipeline, no
   instantiation needed since the module's imports are absent). Sample
   attribution: 6564/6600 in `regalloc.apply_position_edits`.
+- 2026-08-02: Review noted the fix lacked targeted regressions, so two
+  whitebox tests now lock its invariants. "plan verifier applies
+  same-position edits in plan order" chains three dependent moves at one
+  `EditPosition` — any bucket reordering fails with `IncorrectValue`
+  (mutation-verified by reversing bucket iteration). "plan verifier
+  processes a deep diamond join chain once per block" counts
+  `block_instructions` calls over a join-dense CFG whose right arms publish
+  per-level extra registers, asserting exactly one visit per block
+  (mutation-verified: restoring a naive LIFO worklist fails the count).
 
 ## Close Notes
 - 2026-08-01: Bucketed plan edits by position once per verification and

--- a/issues/ISS-373.md
+++ b/issues/ISS-373.md
@@ -88,6 +88,13 @@ contract at its own boundary:
   merely dropping references to imported or outer objects without touching
   their state. It is therefore safe on an open linker and runs on every
   abort, including a `register` refusal.
+- 2026-08-02: Review found one more retaining mutator outside the guarded
+  set: `ComponentLinker::host_runtime_state` lazily installed a
+  `HostRuntimeState` into the runtime slot after close (repeated closes
+  return early, so it would never be released). It now raises `Cancelled`
+  on a closed linker, completing terminal coverage of every public mutator
+  that retains state. `new_host_resource_type` stays non-raising by design:
+  it only bumps an id counter and retains nothing.
 - 2026-08-02: The frame's resource-table entry in the shared `async_state`
   map intentionally survives an abort: nested instances that completed and
   registered before the abort may still resolve it through their ancestor

--- a/modules/regalloc/regalloc_wbtest.mbt
+++ b/modules/regalloc/regalloc_wbtest.mbt
@@ -798,6 +798,7 @@ priv struct VerifierCfgView {
   parameters : Array[Array[VirtualReg]]
   edge_arguments : Array[Array[Array[VirtualReg]]]
   successor_queries : Ref[Int]
+  block_visits : Ref[Int]
 }
 
 ///|
@@ -860,6 +861,7 @@ impl FunctionView for VerifierCfgView with fn block_parameters(self, block) -> A
 impl FunctionView for VerifierCfgView with fn block_instructions(self, block) -> Array[
   Int,
 ] {
+  self.block_visits.val = self.block_visits.val + 1
   self.blocks[block].copy()
 }
 
@@ -933,6 +935,7 @@ test "plan verifier always enters a self-looping entry block" {
         parameters: [[]],
         edge_arguments: [[[]]],
         successor_queries: Ref(0),
+        block_visits: Ref(0),
       },
       None,
       0,
@@ -962,6 +965,7 @@ test "plan verifier checks an unreachable cyclic component" {
         parameters: [[], []],
         edge_arguments: [[], [[]]],
         successor_queries: Ref(0),
+        block_visits: Ref(0),
       },
       Some(0),
       1,
@@ -991,6 +995,7 @@ test "plan verifier queries each block successor list once" {
     parameters: [[], [], [], []],
     edge_arguments: [[[]], [[]], [[]], []],
     successor_queries,
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(1)
   plan.assign_value(value, Reg(register))
@@ -1024,6 +1029,7 @@ test "any-location definitions materialize in their stable home" {
     parameters: [[]],
     edge_arguments: [[]],
     successor_queries: Ref(0),
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(1)
   let slot = plan.create_spill_slot(8, 8)
@@ -1068,6 +1074,7 @@ test "edge arguments do not hide a live-through value transfer" {
     parameters: [[], [parameter]],
     edge_arguments: [[[value]], []],
     successor_queries: Ref(0),
+    block_visits: Ref(0),
   }
   let plan = AllocationPlan::new(2)
   let slot = plan.create_spill_slot(8, 8)
@@ -1162,4 +1169,100 @@ test "production conflict index finds only overlapping occupied segments" {
     conflicting_segments(segments, [0, 1, 2], segments[3], [0]),
     content="[1]",
   )
+}
+
+///|
+/// ISS-370 regression: `index_plan_edits` buckets by position, and bucket
+/// order must preserve the plan's edit order. The three moves below form a
+/// dependency chain at one position — each requires the location produced by
+/// the previous one — so any reordering inside the bucket fails verification
+/// with `IncorrectValue`.
+test "plan verifier applies same-position edits in plan order" {
+  let value : VirtualReg = { id: 0, class: Int }
+  let r0 : PhysicalReg = { id: 0, class: Int }
+  let r1 : PhysicalReg = { id: 1, class: Int }
+  let r2 : PhysicalReg = { id: 2, class: Int }
+  let function : VerifierCfgView = {
+    value_count: 1,
+    blocks: [[0]],
+    operands: [[Operand::use_reg(value)]],
+    successors: [[]],
+    entry_values: [value],
+    parameters: [[]],
+    edge_arguments: [[]],
+    successor_queries: Ref(0),
+    block_visits: Ref(0),
+  }
+  let plan = AllocationPlan::new(1)
+  plan.assign_value(value, Reg(r0))
+  plan.add_edit({ value, from: Reg(r0), to: Reg(r1), position: Before(0) })
+  plan.add_edit({ value, from: Reg(r1), to: Reg(r2), position: Before(0) })
+  plan.add_edit({ value, from: Reg(r2), to: Reg(r0), position: Before(0) })
+  plan.assign_operand(0, 0, Reg(r0))
+  verify_function_allocation(function, MachineEnv::new([r0, r1, r2], []), plan)
+}
+
+///|
+/// ISS-370 regression: reverse postorder is a topological order on an
+/// acyclic CFG, so every join merges all of its incoming states before its
+/// block is processed and the whole function verifies in one pass — each
+/// block exactly once. The chain of diamonds below refines the dataflow
+/// state at every join (each arm publishes the value in a different extra
+/// register, and the meet drops it), which is the shape that made the
+/// previous LIFO worklist reprocess the downstream chain once per join and
+/// grow verification cost with nesting depth.
+test "plan verifier processes a deep diamond join chain once per block" {
+  let diamonds = 8
+  let block_count = 3 * diamonds + 1
+  let value : VirtualReg = { id: 0, class: Int }
+  let r0 : PhysicalReg = { id: 0, class: Int }
+  let registers : Array[PhysicalReg] = Array::makei(diamonds + 1, id => {
+    id,
+    class: Int,
+  })
+  let blocks : Array[Array[Int]] = Array::makei(block_count, _ => [])
+  let successors : Array[Array[Int]] = Array::makei(block_count, _ => [])
+  let parameters : Array[Array[VirtualReg]] = Array::makei(block_count, _ => [])
+  let edge_arguments : Array[Array[Array[VirtualReg]]] = Array::makei(
+    block_count,
+    _ => [],
+  )
+  let plan = AllocationPlan::new(1)
+  plan.assign_value(value, Reg(r0))
+  for i in 0..<diamonds {
+    let top = 3 * i
+    let left = 3 * i + 1
+    let right = 3 * i + 2
+    let join = 3 * i + 3
+    successors[top] = [left, right]
+    edge_arguments[top] = [[], []]
+    successors[left] = [join]
+    edge_arguments[left] = [[]]
+    successors[right] = [join]
+    edge_arguments[right] = [[]]
+    // Only the right arm publishes the value in a per-diamond extra
+    // register, so every join must drop it — and because the extra register
+    // differs per level, a scheduler that enters a join with partial
+    // predecessor state has to re-propagate the shrink one level at a time.
+    plan.add_edit({
+      value,
+      from: Reg(r0),
+      to: Reg(registers[i + 1]),
+      position: Edge(source_block=right, successor_index=0),
+    })
+  }
+  let function : VerifierCfgView = {
+    value_count: 1,
+    blocks,
+    operands: [],
+    successors,
+    entry_values: [value],
+    parameters,
+    edge_arguments,
+    successor_queries: Ref(0),
+    block_visits: Ref(0),
+  }
+  verify_function_allocation(function, MachineEnv::new(registers, []), plan)
+  inspect(function.block_visits.val, content="25")
+  inspect(function.successor_queries.val, content="25")
 }

--- a/modules/wasmoon/component/runtime_impl/host_instance.mbt
+++ b/modules/wasmoon/component/runtime_impl/host_instance.mbt
@@ -38,7 +38,13 @@ fn HostRuntimeState::with_core_execution_engine(
 /// method before building host instances.
 pub fn ComponentLinker::host_runtime_state(
   self : ComponentLinker,
-) -> HostRuntimeState {
+) -> HostRuntimeState raise ComponentRuntimeError {
+  // A terminally closed linker installs no host runtime. `finish_close` has
+  // already dropped the runtime slot, and repeated closes return early, so
+  // a runtime installed here after close would never be released.
+  if self.closed.val {
+    raise Cancelled
+  }
   match self.host_runtime.val {
     Some(runtime) => runtime
     None => {

--- a/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
+++ b/modules/wasmoon/component/runtime_impl/pkg.generated.mbti
@@ -206,7 +206,7 @@ pub fn ComponentLinker::get_component(Self, String) -> ComponentInstance?
 pub fn ComponentLinker::get_import(Self, String) -> ComponentExtern?
 pub fn ComponentLinker::get_store(Self) -> @runtime.Store
 pub fn ComponentLinker::host_instance_builder(Self, String, HostRuntimeState) -> HostInstanceBuilder
-pub fn ComponentLinker::host_runtime_state(Self) -> HostRuntimeState
+pub fn ComponentLinker::host_runtime_state(Self) -> HostRuntimeState raise ComponentRuntimeError
 pub fn ComponentLinker::instantiate(Self, String, @component_model.ValidatedComponent) -> ComponentInstance raise ComponentRuntimeError
 pub fn ComponentLinker::new_host_resource_type(Self) -> @model.TypeDef?
 pub fn ComponentLinker::register(Self, String, ComponentInstance) -> Unit raise ComponentRuntimeError

--- a/modules/wasmoon/testsuite/component_runtime_test.mbt
+++ b/modules/wasmoon/testsuite/component_runtime_test.mbt
@@ -742,6 +742,15 @@ test "component runtime: closed linker refuses instantiation at entry" {
   }
   debug_inspect(add_outcome, content="\"cancelled\"")
   debug_inspect(linker.get_import("late-value") is None, content="true")
+  // The host runtime slot is terminal too: `finish_close` dropped it, and a
+  // runtime installed afterwards would never be released.
+  let runtime_outcome = try linker.host_runtime_state() catch {
+    Cancelled => "cancelled"
+    error => "unexpected error: \{error}"
+  } noraise {
+    _ => "installed"
+  }
+  debug_inspect(runtime_outcome, content="\"cancelled\"")
 }
 
 ///|


### PR DESCRIPTION
## Summary

Two review findings:

**Terminal state didn't cover every mutator.** `register`/`add_import` were already guarded (ISS-373/#459), but the sweep found one more retaining mutator: `ComponentLinker::host_runtime_state` lazily installed a `HostRuntimeState` into the slot `finish_close` had already dropped — and repeated closes return early, so it would never be released. It now raises `Cancelled` on a closed linker (zero caller cascade: wasi's `install_command_world` and the facade were already raising). `new_host_resource_type` stays non-raising by design — it bumps an id counter and retains nothing. Regression extended: the closed-linker test asserts `host_runtime_state` refusal.

**ISS-370 verifier rewrite lacked targeted regressions.** Two whitebox tests now lock its invariants, both mutation-verified:

- *same-position edit order*: a three-move dependency chain at one `EditPosition` — each move requires the location the previous one produced, so any reordering inside the bucket fails with `IncorrectValue`. Reversing bucket iteration turns the test red.
- *deep-join visit count*: an 8-diamond join-dense CFG counted through `FunctionView::block_instructions`, asserting exactly one visit per block (25). Right arms publish per-level extra registers so every join's meet must shrink and a partial-state scheduler has to re-propagate level by level — restoring a naive LIFO worklist turns the test red, while RPO (a topological order on DAGs) merges every join fully before processing.

## Testing

1539 native + 985 wasm-gc tests (regalloc 72/72 incl. the 2 new locks); spec suites 23/23, 24/24, 12/12; security audit green. ISS-370 and ISS-373 notes updated.

Stacked on #460.