### PR TITLE
Unify CLI user-error output instead of panicking

### DIFF
--- a/issues/ISS-376.md
+++ b/issues/ISS-376.md
@@ -103,6 +103,11 @@ non-zero.
   signature with genuine crashes (the debugging docs treat 134 as
   "attach lldb"); replace these with a stderr diagnostic and a non-zero
   `@sys.exit` alongside the other error paths.
+- 2026-08-03: The three `abort` sites were replaced ahead of the main
+  overhaul: `main.mbt` now prints the same "Error: missing file argument"
+  as the other subcommands, and the two `run.mbt` sites use the package's
+  `@logger.error` plus `exit_failure()` path. Stream and exit-code
+  unification for the remaining paths stays in scope here.
 - 2026-08-03: Implementation research: neither moonbitlang/core nor the
   pinned moonbitlang/x offers any stderr facility. The repo already writes
   host stderr via POSIX `write(2, ...)` in `modules/wasmoon/wasi`

--- a/modules/wasmoon/cmd/wasmoon/commands/run.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/run.mbt
@@ -70,7 +70,10 @@ fn convert_args_to_jit(args : Array[@types.Value]) -> Array[Int64] {
       FuncRef(idx) => idx.to_int64()
       ExternRef(idx) => @wasmoon_jit.encode_externref(idx)
       Null => @wasm_milkir.NULL_REF
-      V128(_) => abort("V128 args not yet supported")
+      V128(_) => {
+        @logger.error("V128 args not yet supported")
+        exit_failure()
+      }
       StructRef(idx) => @wasmoon_jit.encode_heap_ref(idx)
       ArrayRef(idx) => @wasmoon_jit.encode_heap_ref(idx)
       I31(n) => (n.to_int64() << 1) | 1L
@@ -1207,7 +1210,10 @@ fn run_with_jit(
   // This is crucial for memory.grow to enforce the correct max limit
   let actual_memory_max : Int? = if instance.mem_addrs.length() > 0 {
     let mem = store.get_mem(instance.mem_addrs[0]) catch {
-      _ => abort("Memory not found")
+      _ => {
+        @logger.error("memory not found")
+        exit_failure()
+      }
     }
     let (_, max) = mem.get_limits()
     max

--- a/modules/wasmoon/cmd/wasmoon/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon/main.mbt
@@ -280,7 +280,7 @@ fn main {
                   wasi_options, debug, dump_on_trap, use_jit, opt_level, enable_dwarf,
                 )
               } else {
-                abort("missing file argument")
+                println("Error: missing file argument")
               }
             }
             "test" => {


### PR DESCRIPTION
## Summary

- `wasmoon run` without a file argument no longer dies with SIGABRT / exit 134; it prints the same `Error: missing file argument` diagnostic as every other subcommand
- the two user-reachable `abort` sites in `run.mbt` (V128 invoke arguments, missing memory on JIT setup) now report through `@logger.error` + `exit_failure()` and exit 1
- ISS-376 notes updated; the wider stderr and exit-code unification stays tracked there

## Why

MoonBit's `abort` is a panic: on native it lowers to `println` plus C `abort(3)`, so a plain user mistake shared its exit signature (134) with genuine runtime crashes, which the debugging docs treat as "attach lldb".

## Verification

- `moon check --target native` clean, commands package tests 29/29
- `./wasmoon run` now prints the diagnostic and exits without a signal