### PR TITLE
Record corpus compile-time attribution in ISS-371

### DIFF
--- a/issues/ISS-371.md
+++ b/issues/ISS-371.md
@@ -63,6 +63,33 @@ ISS-369's coalescing work touches the same code.
 
 ## Notes
 
+- 2026-08-04: Corpus-level attribution, from a 70-workload paired run against
+  Wasmtime (5 iterations plus warmup, isolated JIT cache, macOS ARM64, tree at
+  `0f7d5906`). No failures; 13 workloads exceed a threshold.
+
+  Six of those thirteen show this issue's signature directly — Wasmoon's guest
+  value ratio is **below 1.0**, meaning the generated code runs faster than
+  Wasmtime's, while wall time is several times worse. The difference is
+  compile time:
+
+  | Workload | Value median | Wall median |
+  | --- | ---: | ---: |
+  | `keygen.wasm` | 0.7035 | **7.4302** |
+  | `siphashx24.wasm` | 0.8567 | **6.5429** |
+  | `kdf.wasm` | 0.6208 | **4.8935** |
+  | `secretstream_xchacha20poly1305.wasm` | 0.8956 | 3.3211 |
+  | `stream3.wasm` | 1.0263 | 3.1340 |
+  | `aead_chacha20poly1305.wasm` | 0.8403 | 2.1727 |
+
+  These are better attribution targets than the reporter module this issue was
+  filed from: they are in-tree, run in the standard harness, and separate the
+  two costs by construction, so a compile-time change shows up in the wall
+  column while the value column guards against trading code quality for it.
+
+  The remaining seven gaps are ordinary runtime gaps (value and wall both near
+  each other), including the AEGIS pair at 1.13 and 1.08 that ISS-364 left as
+  its measured limitation.
+
 - 2026-08-01: A separate, smaller finding from the same investigation: the
   `explore` command's diagnostic text rendering (`vcode.Function::summary`)
   builds output by repeated string concatenation and dominates explore's


### PR DESCRIPTION
Docs only. A 70-workload paired run against Wasmtime (5 iterations plus warmup, isolated JIT cache, tree at `0f7d5906`) gives ISS-371 better attribution targets than the out-of-tree reporter module it was filed from.

Six of the thirteen flagged workloads show the compile-time signature directly — **the generated code is faster than Wasmtime's** (value ratio below 1.0) while wall time is several times worse:

| Workload | Value median | Wall median |
| --- | ---: | ---: |
| `keygen.wasm` | 0.7035 | **7.4302** |
| `siphashx24.wasm` | 0.8567 | **6.5429** |
| `kdf.wasm` | 0.6208 | **4.8935** |
| `secretstream_xchacha20poly1305.wasm` | 0.8956 | 3.3211 |
| `stream3.wasm` | 1.0263 | 3.1340 |
| `aead_chacha20poly1305.wasm` | 0.8403 | 2.1727 |

The value column is what makes these useful: it guards against exactly the trade ISS-371 warns about ("Do not trade allocation quality for compile time without measuring both"). A compile-time win shows up in the wall column; if it costs code quality, the value column moves too.

The other seven gaps are ordinary runtime gaps with value and wall close together, including the AEGIS pair at 1.13 and 1.08 that ISS-364 recorded as its remaining limitation — consistent with that issue's close notes, which is also independent confirmation for the ISS-369 closure.