### PR TITLE
Restore the 75-minute sanitizer budget (ISS-368)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -164,6 +164,12 @@ jobs:
       # dependency closures, not the size of the covered packages, which is
       # why the step below is cached rather than trimmed further.
       #
+      # The budget is back at 75 minutes. It was lowered to 60 on the strength
+      # of that single 52m27s observation, and the next uncached run on main
+      # was killed at the 60-minute mark without finding anything — one sample
+      # is not a bound on a shared runner. Lower it again only after several
+      # cached runs show a stable margin.
+      #
       # The cache key pins everything that silently changes what the wrapper
       # produces: the resolved toolchain (MOONBIT_TOOLCHAIN_VERSION is the
       # literal "nightly", which would let yesterday's objects survive a new
@@ -192,7 +198,7 @@ jobs:
             sanitizer-${{ matrix.os }}-${{ steps.sanitizer_cache_key.outputs.digest }}-
 
       - name: run native sanitizer checks
-        timeout-minutes: 60
+        timeout-minutes: 75
         env:
           MOONBIT_NEW_NATIVE: 0
           ASAN_OPTIONS: ${{ matrix.asan_options }}

--- a/issues/ISS-368.md
+++ b/issues/ISS-368.md
@@ -114,9 +114,29 @@ component teardown, which is where use-after-free and leak regressions land.
   binaries for sanitizer symbols and libraries after the run, so a restored
   cache cannot make an uninstrumented build report green.
 
-  Still open until a Linux run measures the effect: the budget stays at 60
-  minutes, and the first run after this lands will populate the cache rather
-  than benefit from it.
+  Still open until a Linux run measures the effect: the first run after this
+  lands populates the cache rather than benefiting from it.
+
+- 2026-08-04: **The 60-minute budget was wrong and is reverted to 75.** The
+  first main run after the cache landed was killed by that budget —
+  `The action 'run native sanitizer checks' has timed out after 60 minutes`,
+  no sanitizer finding involved. Lowering 75 to 60 rested on a single 52m27s
+  observation, which is not a bound on a shared runner; 12 percent of margin
+  was not conservative. Lower it again only after several cached runs show a
+  stable margin.
+
+  Two things also became clear about the cache that the previous note did not
+  state:
+
+  - GitHub scopes a cache to the branch that wrote it, except that caches
+    written on the default branch are readable everywhere. The cache written
+    by PR #472's run was scoped to `refs/pull/472/merge` (239MB compressed)
+    and was therefore invisible to main. The killed run was a cache **miss**,
+    so it paid the full build plus the cache step's overhead and gained
+    nothing — the worst case for this change, and the one that hit the budget.
+  - The first useful measurement is the second main run, once main's own cache
+    exists. That is still pending, so the value of the cache remains unproven
+    on Linux.
 
 - 2026-08-03: **Reopened.** The first Linux AMD64 run to complete this step
   after the change took **52m27s** against the new 60-minute budget

--- a/scripts/tests/test_cutover_gate.py
+++ b/scripts/tests/test_cutover_gate.py
@@ -553,11 +553,11 @@ class GateManifestTests(unittest.TestCase):
             1,
         )
         self.assertEqual(workflow.count('export MOON_AR="$(command -v ar)"'), 1)
-        # The sanitizer gate's budget is measured headroom. ISS-368 removed
-        # the 17k-line wasmoon/testsuite package from the gate by moving its
-        # two covered blackbox tests into wasmoon/sanitizer_testsuite, and
-        # lowered the budget from 75 to 60 minutes.
-        self.assertEqual(workflow.count("timeout-minutes: 60"), 1)
+        # The sanitizer gate's budget. A 60-minute budget, set from a single
+        # 52m27s observation, killed the next uncached run on main without it
+        # finding anything, so the budget is back at 75 until several cached
+        # runs show a stable margin.
+        self.assertEqual(workflow.count("timeout-minutes: 75"), 1)
         self.assertEqual(
             workflow.count(
                 "python3 scripts/find_gc_bugs.py --dir spec/gc --timeout 30"


### PR DESCRIPTION
The first main run after the cache change landed was **killed by the 60-minute budget** — `The action 'run native sanitizer checks' has timed out after 60 minutes`, with no sanitizer finding involved.

Lowering 75 to 60 was my error: it rested on a single 52m27s observation, and 12% of margin is not conservative on a shared runner.

It was also the worst case for the cache, for a reason I had not accounted for: **GitHub scopes a cache to the branch that wrote it**, with only default-branch caches readable everywhere. PR #472's cache was scoped to `refs/pull/472/merge` (239MB compressed) and was invisible to main, so the run was a cache *miss* that paid the full build plus the cache step's overhead.

This puts the budget back at 75 and records in the workflow comment and the issue that it should only come down again after several cached runs show a stable margin. The first genuinely useful measurement is the second main run, once main's own cache exists — still pending, so the cache's value stays unproven on Linux.