### PR TITLE
Gate the allocation invariant verifier (ISS-371) and fix elaboration plan keying (ISS-385)

### DIFF
--- a/issues/ISS-371.md
+++ b/issues/ISS-371.md
@@ -63,6 +63,40 @@ ISS-369's coalescing work touches the same code.
 
 ## Notes
 
+- 2026-08-04: `plan_translation` turned out to be a third ungated verifier, not
+  translation work. `allocate_selected_vcode` ended with an unconditional
+  `@vcode.verify_allocation_invariants`, whose interference check is
+  superlinear in edits: on `kdf`, `func_46` (2845 instructions, 1335 edits)
+  cost 122ms of the phase's 150ms, while `func_28` (1607 instructions, 215
+  edits) cost 2.4ms. Gating it behind the same `MACHV_REGALLOC_VALIDATION`
+  switch drops the phase to 3.4-4.7ms — the actual translation cost — and
+  module compile time by 8 to 12 percent (kdf 1068 to 936ms, keygen 1038 to
+  932ms, siphashx24 953 to 875ms).
+
+  So the production JIT was running three allocation verifiers. The
+  measured split: `verify_allocation_invariants` 145ms, the allocator's own
+  plan verifier 24ms, and the target's `verify_target_allocation` about zero.
+  Only the first two are now gated; a gate was written for the third and
+  reverted when it measured as noise, because it would have reduced checking
+  for no gain.
+
+- 2026-08-04: **The corpus wall column cannot validate a compile-time change
+  at this workload size**, which matters for this issue's second acceptance
+  criterion. Most `examples/algorithms` workloads run for 5 to 150
+  milliseconds, and the harness measures whole-process wall time, so whether
+  one paired sample happens to hit a fresh compile moves the median several
+  fold: `shorthash` ranged 0.006 to 0.084s within a single run. The
+  before/after comparison accordingly showed `stream3` at -87 percent and
+  `shorthash` at +711 percent, which are the same noise in opposite
+  directions, and the 13 flagged workloads changed identity without changing
+  count. Neither side is evidence.
+
+  What the corpus does establish is the guard this issue asks for: across the
+  31 workloads that run longer than 0.3s, the **value** ratio moved by a
+  median of -0.10 percent, and there were no failures. Compile-time wins
+  should be read from the in-process metrics (`WASMOON_PERF_METRICS=1`)
+  instead.
+
 - 2026-08-04: Per-phase attribution now exists in-tree and is on by default
   under `WASMOON_PERF_METRICS=1`. `regalloc` stays clock-free: it announces
   each phase through an optional observer on `RegallocConfig`, the targets

--- a/issues/ISS-385.md
+++ b/issues/ISS-385.md
@@ -1,0 +1,76 @@
+# ISS-385: Elaboration planning keys by e-class, not by (e-class, type)
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 2
+- Labels: milkir, egraph, correctness, agent
+- Assignee: unassigned
+- Created: 2026-08-04
+- Updated: 2026-08-04
+- External ref: none
+
+## Description
+`collect_elaboration_steps` (`modules/milkir/egraph_elaborate.mbt`) tracked
+what a plan had already scheduled in `planned : HashSet[Int]`, keyed by
+e-class id alone, and `elaborate_inst` recorded what it had built in
+`built : Map[Int, Value]`, likewise keyed by class alone. `resolve_operand`
+consulted `class_to_value` under the full `RepKey` and then fell back to
+`built.get(canonical)`, dropping the type.
+
+An e-class does not determine an IR type. The e-graph interns constants by
+value, so `Const(3)` is one class whether it is an i32 or an i64 operand —
+that is exactly why `RepKey` (`modules/milkir/egraph_builder.mbt:28`) pairs
+the class with a `Type`, and its own comment says so. A plan can reach one
+class at two widths: `child_type_of` propagates the result type through
+same-type opcodes but resets it at `Ireduce`/`Uextend`/`Sextend`, and
+`rule_ireduce_ishl` (`ireduce(shl(x, k)) = shl(ireduce(x), k)`) carries the
+shift amount across a width change unchanged.
+
+When that happened, the second width found `planned.contains(class)` true
+and scheduled no build; at commit time `built.get(class)` handed back the
+value built for the *first* width. The result was ill-typed MilkIR — an
+i64 value as the shift amount of an i32 `ishl`, which `Function::verify`
+rejects with `TypeMismatch`.
+
+The trigger is narrow: it needs one class needed at two widths inside a
+single plan of at most `ELABORATION_BUDGET` (4) steps, with neither width
+already available as a dominating IR value. The corpus never hit it, but
+the shape is reachable from the shipped ruleset.
+
+## Acceptance Criteria
+- [x] `planned` and `built` are keyed by `RepKey`, so a class needed at two
+      widths is built once per width.
+- [x] A regression test pins the behavior and fails without the fix.
+- [x] milkir suite stays green with unchanged snapshots.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-377, ISS-379
+- Discovered from: none
+
+## Notes
+- 2026-08-04: Found by review of the elaboration planner added under
+  ISS-377. `class_to_value` already carried the `(class, type)` key and the
+  reason for it; the planner introduced alongside it did not.
+
+## Close Notes
+
+`planned` is now `HashSet[RepKey]` and `built` is `Map[RepKey, Value]`, the
+same key `class_to_value` uses, so an operand only ever resolves to a value
+of its own type. `in_progress` stays class-keyed on purpose: a node of
+class C taking C as an operand is a cycle whatever widths the two mentions
+carry, and rejecting it is the conservative answer.
+
+Where the old code silently produced a wrong-width operand, the new code
+schedules a second build; if that pushes the plan past
+`ELABORATION_BUDGET`, the rewrite is abandoned and the function is left
+untouched — the existing failure mode for an unaffordable plan.
+
+Pinned by `modules/milkir/egraph_elaborate_wbtest.mbt`, which hands the
+elaborator `uextend(narrow << 3) + 3` — one `Const(3)` class, an i32 use
+and an i64 use — and checks the rewritten function verifies and carries two
+constants. With the fix reverted that test fails with
+`TypeMismatch(message="integer binary operands have mismatched types")`,
+the exact predicted symptom. milkir: 2567/2567 green.

--- a/issues/ISS-386.md
+++ b/issues/ISS-386.md
@@ -1,0 +1,75 @@
+# ISS-386: Elaboration's commit loop can leave half a plan behind
+
+## Metadata
+- Type: task
+- Status: closed
+- Priority: 3
+- Labels: milkir, egraph, robustness, agent
+- Assignee: unassigned
+- Created: 2026-08-04
+- Updated: 2026-08-04
+- External ref: none
+
+## Description
+`elaborate_inst` (`modules/milkir/egraph_elaborate.mbt`) documented that a
+rewrite it cannot complete is abandoned "with nothing appended", but its
+commit loop appended each built instruction straight into the caller's
+`emitted` array and only then continued to the next step. Three guards
+inside that loop — and one in the loop that resolves the rewritten
+instruction's own operands — could still `return false` after instructions
+had been appended.
+
+The caller (`modules/milkir/egraph_builder.mbt:585`) captures
+`before = rewritten.length()` but never rolls back to it, and runs its
+`bind_rep` loop over `before..<rewritten.length()` without consulting the
+return value. A partial plan would therefore be spliced into the block and
+its values bound as class representatives.
+
+The same applies to the builder's own state: `ensure_value_slot` and
+`value_map` were written per step, so an abandoned rewrite left bindings
+for values that never entered any block.
+
+No input reaches those guards today. Each re-derives something planning
+already established for the same step — that the opcode encodes, that the
+child type is known, that the operand resolves — and nothing mutates the
+e-graph between planning and commit. The defect is that the contract rested
+on that argument rather than on the code's structure.
+
+## Acceptance Criteria
+- [x] A failed rewrite appends nothing to `emitted` and leaves `value_map`
+      unchanged, by construction rather than by caller cleanup.
+- [x] The boundary contract is pinned by a test.
+- [x] milkir and JIT/interp suites stay green with unchanged snapshots.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-377, ISS-385
+- Discovered from: ISS-385
+
+## Notes
+- 2026-08-04: Found in the same review pass as ISS-385.
+- 2026-08-04: The one-line alternative — `rewritten.truncate(before)` at the
+  call site — was not taken. It leaves the seam intact for the next caller;
+  the function that makes the promise should be the one that keeps it.
+
+## Close Notes
+
+The commit loop now builds into a local `staged` array and a local list of
+value-to-class bindings, publishing both only after the last point of
+failure has passed. Every `return false` path is therefore inert, whatever
+future drift makes one of them reachable, and the call site's existing
+`before`/`bind_rep` logic becomes correct without changing it.
+
+Pinned by "an abandoned elaboration appends nothing" in
+`modules/milkir/egraph_elaborate_wbtest.mbt`: a plan of seven classes
+against a budget of four is abandoned, and the test asserts nothing is
+appended and the instruction keeps its shape.
+
+That test does not, and cannot, exercise the hardened path — it fails
+during planning, before the commit loop, so it passes with or without this
+change. The guards inside the commit loop are unreachable from outside the
+package, so no input drives them; the test pins the seam a future drift
+would violate, not the drift itself.
+
+Verified: milkir 2568/2568, wasmoon testsuite 562/562, snapshots unchanged.

--- a/issues/README.md
+++ b/issues/README.md
@@ -401,6 +401,7 @@ graph TD
   ISS_382["ISS-382: Delete the consumer-less e-graph use-def map"]
   ISS_383["ISS-383: Report rule progress explicitly instead of via merge root identity"]
   ISS_384["ISS-384: Stop paying full extraction for the constant-only harvest"]
+  ISS_385["ISS-385: Elaboration planning keys by e-class, not by (e-class, type)"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005

--- a/issues/README.md
+++ b/issues/README.md
@@ -402,6 +402,7 @@ graph TD
   ISS_383["ISS-383: Report rule progress explicitly instead of via merge root identity"]
   ISS_384["ISS-384: Stop paying full extraction for the constant-only harvest"]
   ISS_385["ISS-385: Elaboration planning keys by e-class, not by (e-class, type)"]
+  ISS_386["ISS-386: Elaboration's commit loop can leave half a plan behind"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005

--- a/modules/machv_regalloc/vcode_adapter.mbt
+++ b/modules/machv_regalloc/vcode_adapter.mbt
@@ -264,8 +264,10 @@ pub fn[Inst] allocate_selected_vcode(
       }
     }
   }
-  @vcode.verify_allocation_invariants(function, allocation) catch {
-    error => raise InvalidAllocation(cause=error)
+  if verify {
+    @vcode.verify_allocation_invariants(function, allocation) catch {
+      error => raise InvalidAllocation(cause=error)
+    }
   }
   allocation
 }

--- a/modules/milkir/egraph_elaborate.mbt
+++ b/modules/milkir/egraph_elaborate.mbt
@@ -232,8 +232,11 @@ fn EGraphBuilder::resolve_operand(
 /// any instructions needed to build that form's operands to `emitted`.
 ///
 /// Returns whether the instruction changed. The rewrite is abandoned — with
-/// nothing appended — whenever the chosen form is not materializable, so a
-/// failure is silent and harmless.
+/// nothing appended and `inst` untouched — whenever the chosen form is not
+/// materializable, so a failure is silent and harmless. Everything the
+/// rewrite creates is staged until the last point of failure has passed, so
+/// that holds however the abandonment arises rather than by the caller
+/// cleaning up after a partial run.
 fn EGraphBuilder::elaborate_inst(
   self : EGraphBuilder,
   func : Function,
@@ -281,7 +284,20 @@ fn EGraphBuilder::elaborate_inst(
   if steps.length() > ELABORATION_BUDGET {
     return false
   }
-  // Commit: build the operand instructions children-first.
+  // Build the operand instructions children-first, into a staging area
+  // rather than straight into `emitted`.
+  //
+  // Every `return false` below abandons the rewrite, and this function
+  // promises to leave nothing behind when it does. Appending to the
+  // caller's array as we go would break that promise from the first step
+  // onward, and the caller cannot tell a half-built plan from a whole one:
+  // it binds whatever appeared as a class representative either way. The
+  // guards here re-derive facts planning already established — an opcode
+  // that encodes, a child type that is known, an operand that resolves —
+  // so none of them fires today. Staging is what keeps that a statement
+  // about the guards rather than about the caller's cleanup.
+  let staged : Array[Inst] = []
+  let bindings : Array[(Int, Int)] = []
   let built : Map[RepKey, Value] = Map([])
   for step in steps {
     guard eopcode_to_opcode(step.node.op) is Some(step_opcode) else {
@@ -300,11 +316,9 @@ fn EGraphBuilder::elaborate_inst(
       step_operands.push(value)
     }
     let value = func.new_value(step.ty)
-    emitted.push(func.new_inst(step_opcode, step_operands, [value]))
+    staged.push(func.new_inst(step_opcode, step_operands, [value]))
     built.set({ class_id: step.class_id, ty: step.ty }, value)
-    // Record the new value so later lookups and rewrites can share it.
-    self.ensure_value_slot(value.id)
-    self.value_map[value.id] = Some(@egraph.EClassId(step.class_id))
+    bindings.push((value.id, step.class_id))
   }
   let new_operands : Array[Value] = []
   for index in 0..<node.children.length() {
@@ -317,6 +331,16 @@ fn EGraphBuilder::elaborate_inst(
       return false
     }
     new_operands.push(value)
+  }
+  // Past the last point of failure: publish the staged instructions, then
+  // the value-to-class bindings that let later lookups share them.
+  for staged_inst in staged {
+    emitted.push(staged_inst)
+  }
+  for binding in bindings {
+    let (value_id, step_class) = binding
+    self.ensure_value_slot(value_id)
+    self.value_map[value_id] = Some(@egraph.EClassId(step_class))
   }
   inst.opcode = opcode
   inst.operands.clear()

--- a/modules/milkir/egraph_elaborate.mbt
+++ b/modules/milkir/egraph_elaborate.mbt
@@ -150,7 +150,7 @@ fn EGraphBuilder::collect_elaboration_steps(
   class_id : @egraph.EClassId,
   ty : Type,
   steps : Array[ElaborationStep],
-  planned : @hashset.HashSet[Int],
+  planned : @hashset.HashSet[RepKey],
   in_progress : @hashset.HashSet[Int],
 ) -> Bool {
   let canonical = self.egraph.find(class_id).0
@@ -159,10 +159,18 @@ fn EGraphBuilder::collect_elaboration_steps(
   if self.class_to_value.get(key) is Some(_) {
     return true
   }
-  if planned.contains(canonical) {
+  // Keyed by `RepKey`, not by class alone: one class can be needed at two
+  // widths in a single plan, because constants are interned by value and so
+  // are shared across widths, and `ireduce(shl(x, k)) = shl(ireduce(x), k)`
+  // carries the shift amount across a width change unchanged. Keying on the
+  // class would report the I64 build as satisfying the I32 operand, and the
+  // commit below would then use an I64 value where an I32 one belongs.
+  if planned.contains(key) {
     return true
   }
   // A class reached again while still being planned is a cyclic expression.
+  // Class-keyed on purpose: a node of class C taking C as an operand is a
+  // cycle whatever widths the two mentions carry.
   if in_progress.contains(canonical) {
     return false
   }
@@ -195,7 +203,7 @@ fn EGraphBuilder::collect_elaboration_steps(
     }
   }
   in_progress.remove(canonical)
-  planned.add(canonical)
+  planned.add(key)
   // Post-order: every operand of this node is already scheduled.
   steps.push({ class_id: canonical, node, ty })
   true
@@ -207,13 +215,15 @@ fn EGraphBuilder::resolve_operand(
   self : EGraphBuilder,
   class_id : @egraph.EClassId,
   ty : Type,
-  built : Map[Int, Value],
+  built : Map[RepKey, Value],
 ) -> Value? {
   let canonical = self.egraph.find(class_id).0
   let key : RepKey = { class_id: canonical, ty }
   match self.class_to_value.get(key) {
     Some(value) => Some(value)
-    None => built.get(canonical)
+    // Same key as the plan used, so an operand only ever resolves to a value
+    // of its own type: a class built at another width does not answer here.
+    None => built.get(key)
   }
 }
 
@@ -248,7 +258,7 @@ fn EGraphBuilder::elaborate_inst(
   // Plan the operands first: a plan that cannot be completed must leave the
   // function untouched.
   let steps : Array[ElaborationStep] = []
-  let planned : @hashset.HashSet[Int] = HashSet([])
+  let planned : @hashset.HashSet[RepKey] = HashSet([])
   let in_progress : @hashset.HashSet[Int] = HashSet([])
   in_progress.add(canonical)
   let operand_types : Array[Type] = []
@@ -272,7 +282,7 @@ fn EGraphBuilder::elaborate_inst(
     return false
   }
   // Commit: build the operand instructions children-first.
-  let built : Map[Int, Value] = Map([])
+  let built : Map[RepKey, Value] = Map([])
   for step in steps {
     guard eopcode_to_opcode(step.node.op) is Some(step_opcode) else {
       return false
@@ -291,7 +301,7 @@ fn EGraphBuilder::elaborate_inst(
     }
     let value = func.new_value(step.ty)
     emitted.push(func.new_inst(step_opcode, step_operands, [value]))
-    built.set(step.class_id, value)
+    built.set({ class_id: step.class_id, ty: step.ty }, value)
     // Record the new value so later lookups and rewrites can share it.
     self.ensure_value_slot(value.id)
     self.value_map[value.id] = Some(@egraph.EClassId(step.class_id))

--- a/modules/milkir/egraph_elaborate_wbtest.mbt
+++ b/modules/milkir/egraph_elaborate_wbtest.mbt
@@ -1,0 +1,105 @@
+///|
+/// Build the e-graph shape `uextend(narrow << 3) + 3` for `sum`.
+///
+/// The two `3`s are one e-class: the e-graph interns constants by value, so
+/// nothing distinguishes an i32 `3` from an i64 `3`. Elaborating this shape
+/// therefore needs the same class materialized at both widths, which is the
+/// case a class-keyed plan collapses into one.
+fn dual_width_const_function() -> (
+  Function,
+  Inst,
+  EGraphBuilder,
+  Map[Int, @egraph.ENode],
+) {
+  let fb = FunctionBuilder::FunctionBuilder("dual_width_const")
+  let wide = fb.add_param(I64)
+  let narrow = fb.add_param(I32)
+  fb.add_result(I64)
+  let sum = fb.iadd(wide, wide)
+  fb.return_([sum])
+  let func = fb.get_function()
+  let builder = EGraphBuilder::new_with_limits_and_ruleset(
+    @egraph.SaturationLimits::cranelift_default(),
+    @egraph.get_global_ruleset(),
+  )
+  let eg = builder.egraph
+  let three = eg.add_const(3)
+  let narrow_var = eg.add_var(narrow.id)
+  let shifted = eg.add({ op: Shl, children: [narrow_var, three] })
+  let widened = eg.add({ op: Uextend(32, 64), children: [shifted] })
+  let root = eg.add({ op: Add, children: [widened, three] })
+  // `narrow` is the one value elaboration may reuse; everything else in the
+  // shape has to be built.
+  builder.ensure_value_slot(narrow.id)
+  builder.class_to_value.set(
+    { class_id: eg.find(narrow_var).0, ty: I32 },
+    narrow,
+  )
+  builder.ensure_value_slot(sum.id)
+  builder.value_map[sum.id] = Some(root)
+  // Each class here holds exactly one node, but read it back rather than
+  // reusing the literal: `add` canonicalizes commutative operands.
+  let best_nodes : Map[Int, @egraph.ENode] = Map([])
+  for class_id in [three, narrow_var, shifted, widened, root] {
+    let canonical = eg.find(class_id).0
+    best_nodes.set(canonical, eg.get_nodes(class_id)[0])
+  }
+  let mut sum_inst : Inst? = None
+  for inst in func.blocks[0].instructions {
+    if inst.first_result() is Some(value) && value.id == sum.id {
+      sum_inst = Some(inst)
+    }
+  }
+  (func, sum_inst.unwrap(), builder, best_nodes)
+}
+
+///|
+/// Splice the instructions elaboration built in ahead of the one it rewrote,
+/// the way the dominator walk does, so the result can be verified.
+fn splice_before(func : Function, target : Inst, built : Array[Inst]) -> Unit {
+  let block = func.blocks[0]
+  let rebuilt : Array[Inst] = []
+  for inst in block.instructions {
+    if inst.id == target.id {
+      for inst in built {
+        rebuilt.push(inst)
+      }
+    }
+    rebuilt.push(inst)
+  }
+  block.instructions.clear()
+  for inst in rebuilt {
+    block.instructions.push(inst)
+  }
+}
+
+///|
+test "elaboration builds a shared constant once per width it is needed at" {
+  let (func, sum_inst, builder, best_nodes) = dual_width_const_function()
+  let emitted : Array[Inst] = []
+  inspect(
+    builder.elaborate_inst(func, best_nodes, sum_inst, emitted),
+    content="true",
+  )
+  splice_before(func, sum_inst, emitted)
+  // The whole point: `ishl` needs an i32 shift amount and `iadd` an i64 one.
+  // Reusing one built value for both puts an i64 operand on the i32 shift,
+  // which is what the verifier rejects.
+  inspect(func.verify(), content="()")
+  // Two constants, one per width, rather than one shared across both.
+  inspect(
+    func.print(),
+    content=(
+      #|function dual_width_const(v0:i64, v1:i32) -> i64 {
+      #|block0:
+      #|    v3:i32 = iconst 3
+      #|    v4:i32 = ishl v1, v3
+      #|    v5:i64 = uextend v4
+      #|    v6:i64 = iconst 3
+      #|    v2:i64 = iadd v5, v6
+      #|    return v2
+      #|}
+      #|
+    ),
+  )
+}

--- a/modules/milkir/egraph_elaborate_wbtest.mbt
+++ b/modules/milkir/egraph_elaborate_wbtest.mbt
@@ -74,6 +74,75 @@ fn splice_before(func : Function, target : Inst, built : Array[Inst]) -> Unit {
 }
 
 ///|
+/// A plan that runs past `ELABORATION_BUDGET` is abandoned partway through.
+/// Nothing it worked out along the way may reach the caller: the caller
+/// binds whatever was appended as a class representative without consulting
+/// the return value, so a half-built plan would be spliced into the block.
+///
+/// This pins the contract at the boundary. It does not reach the guards in
+/// the commit loop — those re-derive facts planning already proved, so no
+/// input gets to them — which is the reason the commit loop stages its work
+/// instead of relying on that unreachability holding forever.
+test "an abandoned elaboration appends nothing" {
+  let fb = FunctionBuilder::FunctionBuilder("over_budget")
+  let wide = fb.add_param(I64)
+  fb.add_result(I64)
+  let sum = fb.iadd(wide, wide)
+  fb.return_([sum])
+  let func = fb.get_function()
+  let builder = EGraphBuilder::new_with_limits_and_ruleset(
+    @egraph.SaturationLimits::cranelift_default(),
+    @egraph.get_global_ruleset(),
+  )
+  let eg = builder.egraph
+  // `(1 + 2) + (3 + 4)`: seven classes to build against a budget of four,
+  // and the budget runs out with four instructions already planned.
+  let left = eg.add({ op: Add, children: [eg.add_const(1), eg.add_const(2)] })
+  let right = eg.add({ op: Add, children: [eg.add_const(3), eg.add_const(4)] })
+  let root = eg.add({ op: Add, children: [left, right] })
+  builder.ensure_value_slot(sum.id)
+  builder.value_map[sum.id] = Some(root)
+  let best_nodes : Map[Int, @egraph.ENode] = Map([])
+  for
+    class_id in [
+      eg.add_const(1),
+      eg.add_const(2),
+      eg.add_const(3),
+      eg.add_const(4),
+      left,
+      right,
+      root,
+    ] {
+    best_nodes.set(eg.find(class_id).0, eg.get_nodes(class_id)[0])
+  }
+  let mut sum_inst : Inst? = None
+  for inst in func.blocks[0].instructions {
+    if inst.first_result() is Some(value) && value.id == sum.id {
+      sum_inst = Some(inst)
+    }
+  }
+  let emitted : Array[Inst] = []
+  inspect(
+    builder.elaborate_inst(func, best_nodes, sum_inst.unwrap(), emitted),
+    content="false",
+  )
+  inspect(emitted.length(), content="0")
+  // `inst` still holds its original shape too.
+  inspect(func.verify(), content="()")
+  inspect(
+    func.print(),
+    content=(
+      #|function over_budget(v0:i64) -> i64 {
+      #|block0:
+      #|    v1:i64 = iadd v0, v0
+      #|    return v1
+      #|}
+      #|
+    ),
+  )
+}
+
+///|
 test "elaboration builds a shared constant once per width it is needed at" {
   let (func, sum_inst, builder, best_nodes) = dual_width_const_function()
   let emitted : Array[Inst] = []


### PR DESCRIPTION
Two commits that missed PR #475: auto-merge fired at 05:15Z with only the
first two commits on the branch.

### `f1d0cadf` — Gate the allocation invariant verifier (ISS-371)

`allocate_selected_vcode` ran `@vcode.verify_allocation_invariants`
unconditionally. Its interference check is superlinear in edit count: on
kdf, `func_46` (1335 edits) accounted for 122ms of the phase's 150ms,
while `func_28` (215 edits) cost 2.4ms. It is now behind the same
`MACHV_REGALLOC_VALIDATION` gate as the allocator's own plan verifier;
CI's `moon test` step sets the variable, so the test matrix keeps full
verification.

Measured: the `plan_translation` phase drops from 150ms to 3.4–4.7ms, and
module compile time falls 8–12% (kdf 1068→936ms, keygen 1038→932ms,
siphashx24 953→875ms).

A third verifier, `verify_target_allocation`, was also gated and then
reverted — it measured as noise (149.3→147.6ms), and cutting coverage for
no gain is a bad trade.

### `4ac358e6` — Key elaboration plans by (e-class, type) (ISS-385)

An e-class does not determine an IR type: the e-graph interns constants by
value, so `Const(3)` is one class whether it is an i32 or an i64 operand.
The elaboration planner's `planned` set and the commit step's `built` map
were keyed by class alone, so a class needed at two widths in one plan was
reported as already scheduled and then resolved to the value built for the
other width — emitting ill-typed MilkIR.

Both now use `RepKey`, the key `class_to_value` already used for exactly
this reason. New whitebox test fails with `TypeMismatch` when the fix is
reverted.

### Verification

milkir 2567/2567, egraph 199/199, wasmoon testsuite 562/562 (JIT/interp
comparisons), all snapshots unchanged.

Note: macOS ARM64 is red on `main` and will be red here — the sanitizer
job aborts in `moonbitlang_async_make_sigwait_job` under UBSan, which is
ISS-367 (deferred, reported upstream), not anything in these commits.