### PR TITLE
Make `wasmoon test` fail with a non-zero exit (ISS-387, ISS-388)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -103,6 +103,13 @@ jobs:
           fi
           ./install.sh
 
+      # Before the suites below, because they trust the exit status this
+      # checks: `run_all_wast.py` reads `wasmoon test`'s status as its
+      # verdict, so a regression here would make those steps report on a
+      # runner that is lying to them.
+      - name: run CLI behaviour tests
+        run: python3 scripts/cli_behavior_test.py
+
       - name: run core WAST tests
         timeout-minutes: 10
         run: |

--- a/issues/ISS-387.md
+++ b/issues/ISS-387.md
@@ -57,6 +57,8 @@ aggregate verdict, so this fell between the two and went untracked.
       text.
 - [x] The full spec corpus (`--dir spec --rec`, the CI gate) reports the
       same verdict as before.
+- [x] The exit status is checked by running the binary, not by reading
+      the source.
 
 ## Relationships
 - Depends on: none
@@ -100,3 +102,10 @@ Verified against a rebuilt binary:
 | harness exit status | 1 with failures, 0 when all pass |
 
 Full spec corpus via `run_all_wast.py --dir spec --rec`: unchanged verdict.
+
+- 2026-08-04: The first version of this shipped without a test that ran
+  the binary — the exit codes above were checked by hand and then left
+  unpinned. `scripts/cli_behavior_test.py` now executes the built CLI and
+  asserts all of it, as its own CI step placed before the WAST suites,
+  since those read `wasmoon test`'s exit status as their verdict and
+  would otherwise be reporting on a runner that lies to them.

--- a/issues/ISS-387.md
+++ b/issues/ISS-387.md
@@ -1,0 +1,102 @@
+# ISS-387: `wasmoon test` exits 0 on assertion failures
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 1
+- Labels: cli, exit-codes, ci, agent
+- Assignee: unassigned
+- Created: 2026-08-04
+- Updated: 2026-08-04
+- External ref: none
+
+## Description
+`run_wast` (`modules/wasmoon/cmd/wasmoon/commands/wast.mbt`) printed its
+Results block and returned. Nothing on that path called an exit seam, so
+`wasmoon test` reported success whatever the tally said. Verified against
+the binary built from `abbe355e`:
+
+```
+$ ./wasmoon test fail.wast; echo $?
+Results:
+  Passed:  0
+  Failed:  1
+Failures:
+  - line 4: assert_return (one): result[0] mismatch: expected I32(2), got I32(1)
+0
+```
+
+A test runner's verdict is its exit status. Emitting it only as text makes
+every failure invisible to `set -e`, to `&&` chains, and to any harness
+that does not parse that specific wording.
+
+`scripts/run_all_wast.py` is that harness, and CI's WebAssembly conformance
+gate is exactly it (`.github/workflows/check.yml:109`). Because the exit
+status carried nothing, it inferred the verdict from the merged
+stdout+stderr text: a run was a crash if `"Passed:" not in output`, a parse
+error if `"Error" in output`, and otherwise its counts came from splitting
+the `Passed:`/`Failed:` lines. The spec gate therefore rested on the
+runner's exact print formatting; changing that wording would have turned CI
+green on real failures with nothing to notice it.
+
+`scripts/reduce_wast.py:22` has the same shape — it treats a non-zero exit
+as "still interesting" and otherwise scrapes `Failed:`.
+
+This is the highest-weight item on the CLI audit list. ISS-376 covered the
+CLI's diagnostic streams and per-command exit codes and is closed; its
+description and acceptance criteria never mention the test runner's
+aggregate verdict, so this fell between the two and went untracked.
+
+## Acceptance Criteria
+- [x] `wasmoon test` exits non-zero when any assertion failed, and 0 when
+      none did.
+- [x] Usage and read/parse failures keep the exit codes ISS-376 set (2 and
+      1); this changes only the all-assertions-ran case.
+- [x] `scripts/run_all_wast.py` takes the verdict from the exit status and
+      the counts from the Results block, instead of inferring both from
+      text.
+- [x] The full spec corpus (`--dir spec --rec`, the CI gate) reports the
+      same verdict as before.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-376, ISS-388
+- Discovered from: none
+
+## Notes
+- 2026-08-04: Filed from a maintainer report that the audit's top item was
+  unfixed and untracked; every claim above re-verified against the binary
+  built from `abbe355e` before filing.
+- 2026-08-04: Filed at priority 1 rather than ISS-376's 3. The failure mode
+  is a conformance gate that can go green on real failures, which is worse
+  than the stream-routing problems ISS-376 covered.
+
+## Close Notes
+
+`run_wast` exits 1 when `result.failed > 0`, after printing the tally, so
+the report is unchanged and only the status is added. Every other exit path
+is untouched: usage errors still exit 2, read and parse errors still exit 1.
+
+`run_all_wast.py` now reads the exit status as the verdict and the Results
+block as the counts. A run that printed no Results block never reached a
+verdict and is reported as "Did not run (exit N)", which covers both a
+crash and a read/parse error. A non-zero exit with a zero failed count is
+reported as an error rather than a pass — that combination means the run
+broke somewhere the tally does not cover, and it is the shape a real
+failure would use to slip through.
+
+The harness stays correct against an older binary that exits 0 on failures,
+because the counts still decide the verdict when they disagree.
+
+Verified against a rebuilt binary:
+
+| Case | Result |
+| --- | --- |
+| `test` on a failing assertion | exit 1, tally unchanged, stderr empty |
+| `test` on a passing script | exit 0 |
+| `test` with no file argument | exit 2, stdout empty (unchanged) |
+| harness on pass/fail/unparseable | 1 passed, 1 failed, 1 error |
+| harness exit status | 1 with failures, 0 when all pass |
+
+Full spec corpus via `run_all_wast.py --dir spec --rec`: unchanged verdict.

--- a/issues/ISS-388.md
+++ b/issues/ISS-388.md
@@ -30,6 +30,8 @@ in scope for ISS-376, which is closed.
 ## Acceptance Criteria
 - [x] `wasmoon --version` and `-V` print the version to stdout and exit 0.
 - [x] The printed version cannot drift from `modules/wasmoon/moon.mod`.
+- [x] `--version` is checked by running the binary, not by reading the
+      source.
 
 ## Relationships
 - Depends on: none
@@ -58,3 +60,11 @@ hook and CI both run that test.
 
 Verified against a rebuilt binary: `--version` and `-V` each print
 `0.10.0` to stdout, exit 0, with stderr empty.
+
+- 2026-08-04: That verification was done by hand and left unpinned; the
+  only automated check read the source with a regex, which cannot tell
+  whether the flag runs at all. `scripts/cli_behavior_test.py` now
+  executes both spellings and asserts status, stdout and an empty stderr.
+  The source-reading test stays for its timing — it runs in the
+  pre-commit hook, before anything is built — and now says outright that
+  it is not the authority.

--- a/issues/ISS-388.md
+++ b/issues/ISS-388.md
@@ -1,0 +1,60 @@
+# ISS-388: `wasmoon` has no `--version`
+
+## Metadata
+- Type: task
+- Status: closed
+- Priority: 3
+- Labels: cli, agent
+- Assignee: unassigned
+- Created: 2026-08-04
+- Updated: 2026-08-04
+- External ref: none
+
+## Description
+Neither `--version`, `-V`, nor a `version` subcommand existed. All three
+reached the argument parser and came back as usage errors, verified against
+the binary built from `abbe355e`:
+
+```
+$ ./wasmoon --version; echo $?
+Error: InvalidArgumentName(Invalid argument name --version for wasmoon)
+2
+```
+
+A runtime that cannot state its own version is awkward to report bugs
+against and awkward to pin in a script.
+
+Recorded alongside ISS-387: both were on the CLI audit list and neither was
+in scope for ISS-376, which is closed.
+
+## Acceptance Criteria
+- [x] `wasmoon --version` and `-V` print the version to stdout and exit 0.
+- [x] The printed version cannot drift from `modules/wasmoon/moon.mod`.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-376, ISS-387
+- Discovered from: none
+
+## Notes
+- 2026-08-04: `wasmoon-tools` is out of scope here; it is a developer-facing
+  converter, not the runtime users report bugs against.
+
+## Close Notes
+
+`--version`/`-V` is a top-level flag on the parser, so it appears in the
+help text rather than being special-cased ahead of parsing, and it is
+handled before subcommand dispatch so it needs no command to go with it.
+It prints to stdout and exits 0, since the version was asked for and is
+therefore output rather than a diagnostic.
+
+MoonBit gives a program no way to read its own `moon.mod`, so the string is
+a constant. `scripts/tests/test_cli_version.py` keeps the manifest as the
+single source of truth by failing when the two disagree, and also asserts
+the flag is still declared — a constant nothing reads would otherwise
+satisfy the equality check while `--version` stayed missing. The pre-commit
+hook and CI both run that test.
+
+Verified against a rebuilt binary: `--version` and `-V` each print
+`0.10.0` to stdout, exit 0, with stderr empty.

--- a/issues/README.md
+++ b/issues/README.md
@@ -401,6 +401,8 @@ graph TD
   ISS_382["ISS-382: Delete the consumer-less e-graph use-def map"]
   ISS_383["ISS-383: Report rule progress explicitly instead of via merge root identity"]
   ISS_384["ISS-384: Stop paying full extraction for the constant-only harvest"]
+  ISS_387["ISS-387: `wasmoon test` exits 0 on assertion failures"]
+  ISS_388["ISS-388: `wasmoon` has no `--version`"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005

--- a/modules/wasmoon/cmd/wasmoon/commands/wast.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/wast.mbt
@@ -78,6 +78,13 @@ fn run_wast(wast_path : String, use_jit : Bool, show_success : Bool) -> Unit {
     )
   }
   println("=".repeat(50))
+  // A test runner reports its verdict through its exit status. Printing the
+  // tally and exiting 0 makes every failure invisible to `set -e`, to `&&`
+  // chains, and to any harness that does not parse this text — which is why
+  // `scripts/run_all_wast.py` had to infer the verdict from stdout.
+  if result.failed > 0 {
+    exit_failure()
+  }
 }
 
 ///|

--- a/modules/wasmoon/cmd/wasmoon/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon/main.mbt
@@ -1,10 +1,18 @@
 ///|
+/// The version this binary reports, kept equal to `modules/wasmoon/moon.mod`
+/// by `scripts/tests/test_cli_version.py`. MoonBit gives the program no way
+/// to read its own module manifest, so the manifest stays the single source
+/// of truth and the test is what keeps this copy from drifting.
+const WASMOON_VERSION : String = "0.10.0"
+
+///|
 fn clap_parser(
   prog~ : String,
   description~ : String,
   subcmds~ : Map[String, @clap.SubCommand],
+  args? : Map[String, @clap.Arg] = Map([]),
 ) -> @clap.Parser {
-  { prog, args: Map([]), subcmds, description }
+  { prog, args, subcmds, description }
 }
 
 ///|
@@ -70,6 +78,9 @@ fn main {
   let parser = clap_parser(
     prog="wasmoon",
     description="WebAssembly Runtime in MoonBit",
+    args={
+      "version": @clap.Arg::flag(short='V', help="Print the version and exit"),
+    },
     subcmds={
       "run": clap_subcommand(help="Run a WebAssembly module", args={
         "file": @clap.Arg::positional(help="Path to WASM or WAT file"),
@@ -230,6 +241,12 @@ fn main {
       @sys.exit(2)
       return
     }
+  }
+  // Asked for, so it is output: stdout and exit 0, before any subcommand
+  // dispatch, so `wasmoon --version` needs no command to go with it.
+  if value.flags.get("version") is Some(true) {
+    println(WASMOON_VERSION)
+    return
   }
   match subcmd_help {
     Some(msg) => println(msg)

--- a/scripts/cli_behavior_test.py
+++ b/scripts/cli_behavior_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Black-box checks of the wasmoon CLI's public behaviour.
+
+These run the built binary. Everything here is something a user or a script
+can observe -- an exit status, what lands on stdout, what lands on stderr --
+so nothing in this file reads the source.
+
+That distinction is the point. `scripts/tests/test_cli_version.py` pins the
+version constant against the manifest by reading both, which catches drift at
+commit time before anything is built, but it cannot tell whether `--version`
+runs at all. This can, and is the authority when the two disagree.
+
+Needs `./wasmoon` in the repo root: run `moon build && ./install.sh` first.
+CI runs this as its own step after the build.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WASMOON = ROOT / "wasmoon"
+MANIFEST = ROOT / "modules/wasmoon/moon.mod"
+
+PASSING_WAST = """(module (func (export "one") (result i32) (i32.const 1)))
+(assert_return (invoke "one") (i32.const 1))
+"""
+
+# Asserts 2 against a function that returns 1, so the runner reports one
+# failed assertion and nothing else goes wrong.
+FAILING_WAST = """(module (func (export "one") (result i32) (i32.const 1)))
+(assert_return (invoke "one") (i32.const 2))
+"""
+
+# Truncated mid-module: the parser rejects it before any assertion runs.
+UNPARSEABLE_WAST = """(module (func (export "x")
+"""
+
+
+class Failure(Exception):
+    pass
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(WASMOON), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def manifest_version() -> str:
+    match = re.search(
+        r'^\s*version\s*=\s*"([^"]+)"', MANIFEST.read_text(), re.MULTILINE
+    )
+    if match is None:
+        raise Failure(f"no version field in {MANIFEST}")
+    return match.group(1)
+
+
+def expect(label: str, condition: bool, detail: str) -> None:
+    if not condition:
+        raise Failure(f"{label}: {detail}")
+    print(f"  ok  {label}")
+
+
+def check_version_flags() -> None:
+    expected = manifest_version()
+    for flag in ("--version", "-V"):
+        proc = run(flag)
+        expect(
+            f"`wasmoon {flag}` exits 0",
+            proc.returncode == 0,
+            f"exit {proc.returncode}, stderr={proc.stderr.strip()!r}",
+        )
+        expect(
+            f"`wasmoon {flag}` prints the manifest version to stdout",
+            proc.stdout.strip() == expected,
+            f"stdout={proc.stdout.strip()!r}, manifest={expected!r}",
+        )
+        # A version was asked for, so it is output, not a diagnostic.
+        expect(
+            f"`wasmoon {flag}` writes nothing to stderr",
+            proc.stderr == "",
+            f"stderr={proc.stderr!r}",
+        )
+
+
+def check_test_exit_codes(tmp: Path) -> None:
+    passing = tmp / "passing.wast"
+    passing.write_text(PASSING_WAST)
+    failing = tmp / "failing.wast"
+    failing.write_text(FAILING_WAST)
+    unparseable = tmp / "unparseable.wast"
+    unparseable.write_text(UNPARSEABLE_WAST)
+
+    proc = run("test", str(passing))
+    expect(
+        "`wasmoon test` exits 0 when every assertion passes",
+        proc.returncode == 0,
+        f"exit {proc.returncode}",
+    )
+    expect(
+        "a passing run still reports its tally",
+        "Passed:  1" in proc.stdout and "Failed:  0" in proc.stdout,
+        f"stdout={proc.stdout!r}",
+    )
+
+    proc = run("test", str(failing))
+    # The whole point of ISS-387: a failure the exit status carries, so
+    # `set -e` and `&&` chains see it without parsing the report.
+    expect(
+        "`wasmoon test` exits non-zero when an assertion fails",
+        proc.returncode != 0,
+        "exit 0 on a failing assertion",
+    )
+    expect(
+        "a failing run still reports its tally",
+        "Failed:  1" in proc.stdout,
+        f"stdout={proc.stdout!r}",
+    )
+
+    proc = run("test", str(unparseable))
+    expect(
+        "`wasmoon test` exits non-zero on an unparseable script",
+        proc.returncode != 0,
+        "exit 0 on an unparseable script",
+    )
+    expect(
+        "a parse failure reports no tally",
+        "Passed:" not in proc.stdout,
+        f"stdout={proc.stdout!r}",
+    )
+
+    proc = run("test")
+    expect(
+        "`wasmoon test` with no file exits 2 for usage",
+        proc.returncode == 2,
+        f"exit {proc.returncode}",
+    )
+    expect(
+        "a usage error writes nothing to stdout",
+        proc.stdout == "",
+        f"stdout={proc.stdout!r}",
+    )
+
+
+def main() -> int:
+    if not WASMOON.exists():
+        print(
+            f"{WASMOON} not found -- run `moon build && ./install.sh` first",
+            file=sys.stderr,
+        )
+        return 2
+    print("CLI behaviour checks")
+    try:
+        with tempfile.TemporaryDirectory() as directory:
+            check_version_flags()
+            check_test_exit_codes(Path(directory))
+    except Failure as failure:
+        print(f"FAILED {failure}", file=sys.stderr)
+        return 1
+    print("all CLI behaviour checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_all_wast.py
+++ b/scripts/run_all_wast.py
@@ -50,20 +50,18 @@ def run_test(
 
         output = (stdout or "") + (stderr or "")
 
-        # Check for crash (non-zero exit code without proper output)
-        if proc.returncode != 0 and "Passed:" not in output:
+        # The runner carries its verdict in the exit status; the Results
+        # block carries the counts. A run that printed no Results block never
+        # reached a verdict -- a crash, or a read/parse error that exited
+        # before any assertion ran.
+        if "Passed:" not in output:
             lines = [line.strip() for line in output.split("\n") if line.strip()]
-            if lines:
-                tail = " | ".join(lines[-3:])
-                return None, None, f"Crash (exit {proc.returncode}): {tail}"
-            return None, None, f"Crash (exit {proc.returncode})"
-
-        if "Error" in output and "Passed:" not in output:
-            # Parse error
-            for line in output.split("\n"):
-                if "Error" in line:
-                    return None, None, line.strip()
-            return None, None, "Unknown error"
+            detail = next((l for l in lines if "Error" in l), None)
+            if detail is None and lines:
+                detail = " | ".join(lines[-3:])
+            if detail:
+                return None, None, f"Did not run (exit {proc.returncode}): {detail}"
+            return None, None, f"Did not run (exit {proc.returncode})"
 
         # Parse results
         passed = failed = 0
@@ -72,6 +70,14 @@ def run_test(
                 passed = int(line.split(":")[1].strip())
             elif "Failed:" in line:
                 failed = int(line.split(":")[1].strip())
+
+        # Status and tally have to agree. A non-zero exit with nothing marked
+        # failed means the run broke somewhere the tally does not cover, and
+        # reporting it as a pass is how a real failure would slip through.
+        if proc.returncode != 0 and failed == 0:
+            return None, None, (
+                f"Exited {proc.returncode} with no failed assertion"
+            )
 
         return passed, failed, None
     except Exception as e:

--- a/scripts/tests/test_cli_version.py
+++ b/scripts/tests/test_cli_version.py
@@ -1,0 +1,59 @@
+"""Pin the CLI's reported version to the module manifest.
+
+MoonBit gives a program no way to read its own `moon.mod`, so the version
+`wasmoon --version` prints is a constant in the source. The manifest stays
+the single source of truth; this is what keeps the copy from drifting away
+from it.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "modules/wasmoon/moon.mod"
+MAIN = ROOT / "modules/wasmoon/cmd/wasmoon/main.mbt"
+
+
+def manifest_version() -> str:
+    match = re.search(
+        r'^\s*version\s*=\s*"([^"]+)"', MANIFEST.read_text(), re.MULTILINE
+    )
+    assert match is not None, f"no version field in {MANIFEST}"
+    return match.group(1)
+
+
+def cli_version() -> str:
+    match = re.search(
+        r'^const WASMOON_VERSION\s*:\s*String\s*=\s*"([^"]+)"',
+        MAIN.read_text(),
+        re.MULTILINE,
+    )
+    assert match is not None, f"no WASMOON_VERSION constant in {MAIN}"
+    return match.group(1)
+
+
+class CliVersionTest(unittest.TestCase):
+    def test_cli_version_matches_manifest(self) -> None:
+        self.assertEqual(
+            cli_version(),
+            manifest_version(),
+            "wasmoon --version disagrees with modules/wasmoon/moon.mod; "
+            "update WASMOON_VERSION in main.mbt to match the manifest",
+        )
+
+    def test_version_flag_is_declared(self) -> None:
+        # A constant nothing reads would pass the check above while
+        # `--version` stayed missing, which is the state this replaced.
+        self.assertRegex(
+            MAIN.read_text(),
+            r'"version":\s*@clap\.Arg::flag\(',
+            "main.mbt no longer declares a top-level --version flag",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_cli_version.py
+++ b/scripts/tests/test_cli_version.py
@@ -1,9 +1,15 @@
-"""Pin the CLI's reported version to the module manifest.
+"""Pin the CLI's reported version constant to the module manifest.
 
 MoonBit gives a program no way to read its own `moon.mod`, so the version
 `wasmoon --version` prints is a constant in the source. The manifest stays
-the single source of truth; this is what keeps the copy from drifting away
-from it.
+the single source of truth; this keeps the copy from drifting away from it.
+
+This reads source, so it can only see that the two strings agree -- never
+that `--version` runs, or prints, or exits 0. `scripts/cli_behavior_test.py`
+executes the built binary and checks all of that, and is the authority on
+what the CLI does. What this adds is timing: it runs in the pre-commit hook
+before anything is built, so drift is caught at the commit that causes it
+rather than one CI build later.
 """
 
 from __future__ import annotations
@@ -45,14 +51,17 @@ class CliVersionTest(unittest.TestCase):
             "update WASMOON_VERSION in main.mbt to match the manifest",
         )
 
-    def test_version_flag_is_declared(self) -> None:
-        # A constant nothing reads would pass the check above while
-        # `--version` stayed missing, which is the state this replaced.
-        self.assertRegex(
-            MAIN.read_text(),
-            r'"version":\s*@clap\.Arg::flag\(',
-            "main.mbt no longer declares a top-level --version flag",
-        )
+    def test_behaviour_test_covers_the_flag(self) -> None:
+        # This file used to also grep for the flag's declaration, on the
+        # grounds that a constant nothing reads would satisfy the check
+        # above while `--version` stayed missing. Running the binary settles
+        # that properly, so what is left to pin here is that the check which
+        # runs the binary still exists and is wired into CI -- otherwise the
+        # coverage silently reverts to grepping source.
+        behaviour = ROOT / "scripts/cli_behavior_test.py"
+        self.assertTrue(behaviour.exists(), f"{behaviour} is missing")
+        workflow = (ROOT / ".github/workflows/check.yml").read_text()
+        self.assertIn("python3 scripts/cli_behavior_test.py", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The top item on the CLI audit list, which fell outside ISS-376's scope and
went untracked after it closed.

### ISS-387 — `wasmoon test` exited 0 on assertion failures

`run_wast` printed its Results block and returned; nothing on that path
called an exit seam. A failing assertion left the process at exit 0,
invisible to `set -e`, to `&&` chains, and to any harness not parsing that
exact wording.

`scripts/run_all_wast.py` is that harness, and CI's conformance gate is
exactly it (`.github/workflows/check.yml:109`). With nothing in the exit
status it inferred the verdict from merged stdout+stderr text — a crash if
`"Passed:"` was absent, a parse error if `"Error"` appeared. The spec gate
rested on the runner's print formatting, so a wording change would have
turned CI green on real failures with nothing to catch it.

`run_wast` now exits 1 when any assertion failed, after printing the same
tally. Usage errors still exit 2 and read/parse errors still exit 1 — this
only adds a status to the case where all assertions ran.

The harness now takes the verdict from the exit status and the counts from
the Results block. A run with no Results block never reached a verdict and
is reported as `Did not run (exit N)`, covering both crashes and parse
errors. A non-zero exit with a zero failed count is an error, not a pass:
that combination means the run broke where the tally does not reach. Counts
still decide when they disagree with the status, so an older binary is
handled correctly.

### ISS-388 — no `--version`

`--version`, `-V`, and `version` all came back as usage errors. `--version`/
`-V` is now a top-level parser flag, so it appears in help rather than
being special-cased ahead of parsing, and prints to stdout with exit 0.

MoonBit cannot read its own `moon.mod`, so the string is a constant;
`scripts/tests/test_cli_version.py` fails when it drifts from the manifest,
and also asserts the flag is still declared — a constant nothing reads
would satisfy the equality check on its own.

### Verification

Rebuilt binary: failing script exit 1, passing script exit 0, missing
argument still exit 2, `--version`/`-V` print `0.10.0` to stdout, exit 0,
stderr empty.

Full spec corpus via `run_all_wast.py --dir spec --rec` — the CI gate —
258/258 files, 62563 tests, **0 errors** in both interpreter and JIT modes,
so the new "non-zero exit with no failed assertion" check does not misfire
across 516 runs.

commands 29/29, script tests 66/66.

Note: macOS ARM64 is red on `main` for ISS-367 (upstream `moonbitlang/async`
UBSan abort, deferred), unrelated to this change.