### PR TITLE
Make elaboration's build loop total (ISS-391)

### DIFF
--- a/issues/ISS-386.md
+++ b/issues/ISS-386.md
@@ -53,6 +53,14 @@ on that argument rather than on the code's structure.
   call site — was not taken. It leaves the seam intact for the next caller;
   the function that makes the promise should be the one that keeps it.
 
+- 2026-08-04: Reopened in review and finished under ISS-391. Two gaps:
+  the staging did not cover `func`'s ID counters, since `new_value` and
+  `new_inst` ran inside the commit loop with failure points still after
+  them, so an abandoned rewrite leaked IDs; and the test added here never
+  reaches the commit loop, so it passes with or without this change. The
+  commit message disclosed the second, which is not the same as fixing
+  it. ISS-391 removes the failure points instead of staging around them.
+
 ## Close Notes
 
 The commit loop now builds into a local `staged` array and a local list of

--- a/issues/ISS-391.md
+++ b/issues/ISS-391.md
@@ -1,0 +1,97 @@
+# ISS-391: Elaboration's commit loop still had failure points after allocation
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 3
+- Labels: milkir, egraph, elaboration, agent
+- Assignee: unassigned
+- Created: 2026-08-04
+- Updated: 2026-08-04
+- External ref: none
+
+## Description
+ISS-386 moved `elaborate_inst`'s built instructions into a staging array so
+an abandoned rewrite would append nothing. It did not finish the job, on two
+counts raised in review.
+
+**The staging did not cover `func`'s ID counters.** The commit loop called
+`func.new_value` and `func.new_inst` inside the loop body, and four guards
+could still return false after the first of them: the next iteration's
+opcode, child-type and operand-resolution guards, and the root operand
+resolution afterwards. `new_value` advances `next_value_id` and `new_inst`
+advances `next_inst_id`, so an abandoned rewrite would leak IDs even though
+the staged instructions and bindings were correctly discarded. The commit
+claimed the rewrite leaves "the function untouched"; that was true of the
+caller's array and of `value_map`, not of the function.
+
+**The test did not exercise the hardened path.** `an abandoned elaboration
+appends nothing` builds a seven-class shape against a budget of four, so it
+is abandoned by the budget check during planning and never reaches the
+commit loop. It passes with or without ISS-386. That much the ISS-386 commit
+message stated, but stating it does not make the change tested.
+
+The two are the same defect seen from either side: the commit loop still
+contained failure points after it had begun creating things, and those
+points were unreachable, so no test could reach them either.
+
+## Design
+Neither symptom is fixable by adding more staging or another test. The
+failure points themselves have to go.
+
+Every guard in the commit loop re-derived something planning had already
+proved — an opcode that encodes, a child type that is known, an operand that
+resolves — and then threw the derivation away. Planning now records what it
+proves: each `ElaborationStep` carries its own `Opcode` and, for each
+operand, an `ElaborationOperand` that is either `Existing(Value)` for a
+value already in scope or `FromStep(Int)` for one an earlier step builds.
+Post-order scheduling makes a `FromStep` index always smaller than the index
+of the step naming it, so the build loop resolves operands by array
+indexing.
+
+The build loop then has nothing to check and no way to return early, which
+makes "an abandoned rewrite creates nothing" a property of the code's shape
+rather than an argument about which guards can fire. `resolve_operand` and
+the staging arrays both disappear, since neither has anything left to do.
+
+## Acceptance Criteria
+- [x] No failure point exists between the first `new_value` and the end of
+      the rewrite.
+- [x] An abandoned rewrite leaves `next_value_id` and `next_inst_id`
+      unchanged, asserted by test.
+- [x] A successful rewrite advances each counter by exactly the number of
+      instructions it emits, asserted by test.
+- [x] The limits of those tests are stated where they are written, rather
+      than left for a reader to discover.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-377, ISS-385, ISS-386
+- Discovered from: ISS-386
+
+## Notes
+- 2026-08-04: Raised by the maintainer in review of the merged ISS-386
+  change, both points confirmed against the code before any fix was written.
+
+## Close Notes
+
+The build loop is now total: planning resolves the opcode and every operand
+source, and committing indexes an array. `ElaborationOperand` is the type
+that carries the resolution, and it is what removes the lookups that used to
+be able to fail.
+
+On testability, stated plainly because ISS-386's mistake was to imply more
+coverage than existed: **no test can distinguish this implementation from
+the previous one.** The leak needed a post-allocation failure point, every
+such point was unreachable, and unreachable code cannot be driven from a
+test. The defect is removed by construction, not by a regression test, and
+the test comments now say so where a reader will find them.
+
+What the tests do pin is the observable contract on both sides: an abandoned
+rewrite leaves both counters where they were, and a successful one spends
+exactly one value and one instruction per instruction emitted — four each
+for the four-instruction case, which would catch a future build loop that
+creates something and drops it.
+
+milkir 2568/2568.

--- a/issues/README.md
+++ b/issues/README.md
@@ -403,6 +403,7 @@ graph TD
   ISS_384["ISS-384: Stop paying full extraction for the constant-only harvest"]
   ISS_385["ISS-385: Elaboration planning keys by e-class, not by (e-class, type)"]
   ISS_386["ISS-386: Elaboration's commit loop can leave half a plan behind"]
+  ISS_391["ISS-391: Elaboration's commit loop still had failure points after allocation"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005

--- a/modules/milkir/egraph_elaborate.mbt
+++ b/modules/milkir/egraph_elaborate.mbt
@@ -132,32 +132,53 @@ fn child_type_of(
 }
 
 ///|
-/// One instruction elaboration intends to create.
-priv struct ElaborationStep {
-  class_id : Int
-  node : @egraph.ENode
-  ty : Type
+/// Where an operand's value comes from at commit time.
+///
+/// Planning decides this, so committing never has to look anything up and
+/// so can never fail. `FromStep` indexes `steps`, and post-order guarantees
+/// the referenced step is earlier than the one naming it.
+priv enum ElaborationOperand {
+  Existing(Value)
+  FromStep(Int)
 }
 
 ///|
-/// Collect the classes that must be built to have a value for `class_id`,
-/// children before parents. Returns false when the shape cannot be built:
-/// no IR encoding, an out-of-scope `Var`, an unknown operand type, a cycle,
-/// or more work than the budget allows.
+/// One instruction elaboration intends to create, resolved down to what
+/// building it needs: no e-node, no lookups, nothing left to re-derive.
+priv struct ElaborationStep {
+  class_id : Int
+  ty : Type
+  opcode : Opcode
+  operands : Array[ElaborationOperand]
+}
+
+///|
+/// Plan how to obtain a value for `class_id` at type `ty`, appending the
+/// classes that must be built to `steps`, children before parents.
+///
+/// Returns how the caller should reference the result, or `None` when the
+/// shape cannot be built: no IR encoding (which covers `Var`, whose class
+/// has no dominating binding here), an unknown operand type, a cycle, or
+/// more work than the budget allows.
+///
+/// Everything this proves is recorded in the step rather than discarded.
+/// Committing used to re-derive the opcode, the operand types and the
+/// operand values, which put failure points after the first `new_value`
+/// call; recording them is what removes those.
 fn EGraphBuilder::collect_elaboration_steps(
   self : EGraphBuilder,
   best_nodes : Map[Int, @egraph.ENode],
   class_id : @egraph.EClassId,
   ty : Type,
   steps : Array[ElaborationStep],
-  planned : @hashset.HashSet[RepKey],
+  planned : Map[RepKey, Int],
   in_progress : @hashset.HashSet[Int],
-) -> Bool {
+) -> ElaborationOperand? {
   let canonical = self.egraph.find(class_id).0
   // Already available as an IR value that dominates this point: free.
   let key : RepKey = { class_id: canonical, ty }
-  if self.class_to_value.get(key) is Some(_) {
-    return true
+  if self.class_to_value.get(key) is Some(value) {
+    return Some(Existing(value))
   }
   // Keyed by `RepKey`, not by class alone: one class can be needed at two
   // widths in a single plan, because constants are interned by value and so
@@ -165,78 +186,64 @@ fn EGraphBuilder::collect_elaboration_steps(
   // carries the shift amount across a width change unchanged. Keying on the
   // class would report the I64 build as satisfying the I32 operand, and the
   // commit below would then use an I64 value where an I32 one belongs.
-  if planned.contains(key) {
-    return true
+  if planned.get(key) is Some(index) {
+    return Some(FromStep(index))
   }
   // A class reached again while still being planned is a cyclic expression.
   // Class-keyed on purpose: a node of class C taking C as an operand is a
   // cycle whatever widths the two mentions carry.
   if in_progress.contains(canonical) {
-    return false
+    return None
   }
   if steps.length() >= ELABORATION_BUDGET {
-    return false
+    return None
   }
-  guard best_nodes.get(canonical) is Some(node) else { return false }
-  guard eopcode_to_opcode(node.op) is Some(_) else { return false }
-  // `Var` names an existing IR value; without a dominating binding (checked
-  // above) it cannot be referenced from here.
-  if node.op is Var(_) {
-    return false
-  }
+  guard best_nodes.get(canonical) is Some(node) else { return None }
+  guard eopcode_to_opcode(node.op) is Some(opcode) else { return None }
   in_progress.add(canonical)
+  let operands : Array[ElaborationOperand] = []
   for index in 0..<node.children.length() {
     guard child_type_of(self.egraph, node, index, ty) is Some(child_ty) else {
       in_progress.remove(canonical)
-      return false
+      return None
     }
-    if !self.collect_elaboration_steps(
+    guard self.collect_elaboration_steps(
         best_nodes,
         node.children[index],
         child_ty,
         steps,
         planned,
         in_progress,
-      ) {
+      )
+      is Some(operand) else {
       in_progress.remove(canonical)
-      return false
+      return None
     }
+    operands.push(operand)
   }
   in_progress.remove(canonical)
-  planned.add(key)
-  // Post-order: every operand of this node is already scheduled.
-  steps.push({ class_id: canonical, node, ty })
-  true
-}
-
-///|
-/// Resolve a class to an IR value, given the values elaboration just built.
-fn EGraphBuilder::resolve_operand(
-  self : EGraphBuilder,
-  class_id : @egraph.EClassId,
-  ty : Type,
-  built : Map[RepKey, Value],
-) -> Value? {
-  let canonical = self.egraph.find(class_id).0
-  let key : RepKey = { class_id: canonical, ty }
-  match self.class_to_value.get(key) {
-    Some(value) => Some(value)
-    // Same key as the plan used, so an operand only ever resolves to a value
-    // of its own type: a class built at another width does not answer here.
-    None => built.get(key)
-  }
+  // Post-order: every operand of this node is already scheduled, so this
+  // step's index is greater than every index it names.
+  let index = steps.length()
+  planned.set(key, index)
+  steps.push({ class_id: canonical, ty, opcode, operands })
+  Some(FromStep(index))
 }
 
 ///|
 /// Rewrite `inst` into the form extraction chose for its e-class, appending
 /// any instructions needed to build that form's operands to `emitted`.
 ///
-/// Returns whether the instruction changed. The rewrite is abandoned — with
-/// nothing appended and `inst` untouched — whenever the chosen form is not
-/// materializable, so a failure is silent and harmless. Everything the
-/// rewrite creates is staged until the last point of failure has passed, so
-/// that holds however the abandonment arises rather than by the caller
-/// cleaning up after a partial run.
+/// Returns whether the instruction changed. An abandoned rewrite leaves no
+/// trace at all: nothing appended, `inst` untouched, `value_map` unchanged,
+/// and `func`'s value and instruction counters where they were.
+///
+/// That last part is why planning resolves the whole shape before building
+/// starts. `new_value` and `new_inst` advance counters on `func`, so any
+/// failure point reached after the first of them leaks IDs no matter what
+/// the rewrite stages and discards. Planning records the opcode, the operand
+/// types and the operand sources into each step, which leaves the build loop
+/// below with nothing to check and therefore no way to fail partway.
 fn EGraphBuilder::elaborate_inst(
   self : EGraphBuilder,
   func : Function,
@@ -248,99 +255,70 @@ fn EGraphBuilder::elaborate_inst(
   guard self.lookup_value(result) is Some(class_id) else { return false }
   let canonical = class_id.0
   guard best_nodes.get(canonical) is Some(node) else { return false }
+  // `Var` has no IR encoding, so the guard above already rejected it: the
+  // class is best represented by an existing value, which operand rewriting
+  // handles.
   guard eopcode_to_opcode(node.op) is Some(opcode) else { return false }
-  // `Var` means "this class is best represented by an existing value";
-  // operand rewriting already handles that case.
-  if node.op is Var(_) {
-    return false
-  }
   // Nothing to do when the instruction already has the chosen shape.
   if opcode == inst.opcode && self.operands_match(node, inst) {
     return false
   }
-  // Plan the operands first: a plan that cannot be completed must leave the
-  // function untouched.
+  // Plan the whole shape first. Every way this rewrite can fail lives in
+  // here, before anything is created.
   let steps : Array[ElaborationStep] = []
-  let planned : @hashset.HashSet[RepKey] = HashSet([])
+  let planned : Map[RepKey, Int] = Map([])
   let in_progress : @hashset.HashSet[Int] = HashSet([])
   in_progress.add(canonical)
-  let operand_types : Array[Type] = []
+  let root_operands : Array[ElaborationOperand] = []
   for index in 0..<node.children.length() {
     guard child_type_of(self.egraph, node, index, result.ty) is Some(child_ty) else {
       return false
     }
-    operand_types.push(child_ty)
-    if !self.collect_elaboration_steps(
+    guard self.collect_elaboration_steps(
         best_nodes,
         node.children[index],
         child_ty,
         steps,
         planned,
         in_progress,
-      ) {
+      )
+      is Some(operand) else {
       return false
     }
+    root_operands.push(operand)
   }
   if steps.length() > ELABORATION_BUDGET {
     return false
   }
-  // Build the operand instructions children-first, into a staging area
-  // rather than straight into `emitted`.
-  //
-  // Every `return false` below abandons the rewrite, and this function
-  // promises to leave nothing behind when it does. Appending to the
-  // caller's array as we go would break that promise from the first step
-  // onward, and the caller cannot tell a half-built plan from a whole one:
-  // it binds whatever appeared as a class representative either way. The
-  // guards here re-derive facts planning already established — an opcode
-  // that encodes, a child type that is known, an operand that resolves —
-  // so none of them fires today. Staging is what keeps that a statement
-  // about the guards rather than about the caller's cleanup.
-  let staged : Array[Inst] = []
-  let bindings : Array[(Int, Int)] = []
-  let built : Map[RepKey, Value] = Map([])
+  // Past every point of failure. From here the work is total: each step
+  // carries its own opcode and the source of each of its operands, and
+  // post-order means a `FromStep` index is always one this loop has already
+  // filled in. Nothing below can return, so nothing below can leave the
+  // function half-changed.
+  let built : Array[Value] = []
   for step in steps {
-    guard eopcode_to_opcode(step.node.op) is Some(step_opcode) else {
-      return false
-    }
     let step_operands : Array[Value] = []
-    for index in 0..<step.node.children.length() {
-      guard child_type_of(self.egraph, step.node, index, step.ty)
-        is Some(child_ty) else {
-        return false
-      }
-      guard self.resolve_operand(step.node.children[index], child_ty, built)
-        is Some(value) else {
-        return false
-      }
-      step_operands.push(value)
+    for operand in step.operands {
+      step_operands.push(
+        match operand {
+          Existing(value) => value
+          FromStep(index) => built[index]
+        },
+      )
     }
     let value = func.new_value(step.ty)
-    staged.push(func.new_inst(step_opcode, step_operands, [value]))
-    built.set({ class_id: step.class_id, ty: step.ty }, value)
-    bindings.push((value.id, step.class_id))
+    emitted.push(func.new_inst(step.opcode, step_operands, [value]))
+    built.push(value)
+    self.ensure_value_slot(value.id)
+    self.value_map[value.id] = Some(@egraph.EClassId(step.class_id))
   }
   let new_operands : Array[Value] = []
-  for index in 0..<node.children.length() {
-    guard self.resolve_operand(
-        node.children[index],
-        operand_types[index],
-        built,
-      )
-      is Some(value) else {
-      return false
+  for operand in root_operands {
+    let value = match operand {
+      Existing(value) => value
+      FromStep(index) => built[index]
     }
     new_operands.push(value)
-  }
-  // Past the last point of failure: publish the staged instructions, then
-  // the value-to-class bindings that let later lookups share them.
-  for staged_inst in staged {
-    emitted.push(staged_inst)
-  }
-  for binding in bindings {
-    let (value_id, step_class) = binding
-    self.ensure_value_slot(value_id)
-    self.value_map[value_id] = Some(@egraph.EClassId(step_class))
   }
   inst.opcode = opcode
   inst.operands.clear()

--- a/modules/milkir/egraph_elaborate_wbtest.mbt
+++ b/modules/milkir/egraph_elaborate_wbtest.mbt
@@ -79,10 +79,19 @@ fn splice_before(func : Function, target : Inst, built : Array[Inst]) -> Unit {
 /// binds whatever was appended as a class representative without consulting
 /// the return value, so a half-built plan would be spliced into the block.
 ///
-/// This pins the contract at the boundary. It does not reach the guards in
-/// the commit loop — those re-derive facts planning already proved, so no
-/// input gets to them — which is the reason the commit loop stages its work
-/// instead of relying on that unreachability holding forever.
+/// "Nothing" includes `func`'s ID counters. `new_value` and `new_inst`
+/// advance them, so a rewrite that built anything before deciding to abandon
+/// would leak IDs while still appending nothing — invisible in the printed
+/// function, which is why the counters are checked directly.
+///
+/// What this test does not do is separate this implementation from the one
+/// before it. Both abandon this input during planning, before anything is
+/// built. The previous one could only leak from failure points sitting after
+/// the first `new_value` in its commit loop, and those were unreachable:
+/// each re-derived what planning had already proved. An unreachable defect
+/// cannot be pinned by a test, so it was removed by construction instead —
+/// the build loop has no failure points now — and what stays testable is the
+/// boundary contract below.
 test "an abandoned elaboration appends nothing" {
   let fb = FunctionBuilder::FunctionBuilder("over_budget")
   let wide = fb.add_param(I64)
@@ -122,11 +131,15 @@ test "an abandoned elaboration appends nothing" {
     }
   }
   let emitted : Array[Inst] = []
+  let values_before = func.next_value_id
+  let insts_before = func.next_inst_id
   inspect(
     builder.elaborate_inst(func, best_nodes, sum_inst.unwrap(), emitted),
     content="false",
   )
   inspect(emitted.length(), content="0")
+  inspect(func.next_value_id == values_before, content="true")
+  inspect(func.next_inst_id == insts_before, content="true")
   // `inst` still holds its original shape too.
   inspect(func.verify(), content="()")
   inspect(
@@ -146,10 +159,18 @@ test "an abandoned elaboration appends nothing" {
 test "elaboration builds a shared constant once per width it is needed at" {
   let (func, sum_inst, builder, best_nodes) = dual_width_const_function()
   let emitted : Array[Inst] = []
+  let values_before = func.next_value_id
+  let insts_before = func.next_inst_id
   inspect(
     builder.elaborate_inst(func, best_nodes, sum_inst, emitted),
     content="true",
   )
+  // A successful rewrite spends exactly one value and one instruction per
+  // instruction it emits. Anything more would mean the build loop created
+  // something it then dropped.
+  inspect(func.next_value_id - values_before, content="4")
+  inspect(func.next_inst_id - insts_before, content="4")
+  inspect(emitted.length(), content="4")
   splice_before(func, sum_inst, emitted)
   // The whole point: `ishl` needs an i32 shift amount and `iadd` an i64 one.
   // Reusing one built value for both puts an i64 operand on the i32 shift,


### PR DESCRIPTION
Follow-up to ISS-386, from maintainer review of the merged change. Both
points confirmed against the code before anything was written.

### What was still wrong

**The staging did not cover `func`'s ID counters.** `new_value` and
`new_inst` ran inside the commit loop with four guards still able to return
false after them — the next iteration's opcode, child-type and operand
guards, then the root operand resolution. Those calls advance
`next_value_id` and `next_inst_id`, so an abandoned rewrite leaked IDs even
while correctly discarding its staged instructions and bindings. ISS-386
claimed the rewrite left "the function untouched"; that held for the
caller's array and for `value_map`, not for the function.

**The test never reached the hardened path.** `an abandoned elaboration
appends nothing` builds seven classes against a budget of four, so it is
abandoned during planning and never enters the commit loop — it passes with
or without ISS-386. That commit's message disclosed this, which is not the
same as fixing it.

Both are one defect seen from either side: the loop still had failure points
after it had begun creating things, and those points were unreachable, so no
test could reach them either.

### The fix

Every guard in that loop re-derived something planning had already proved,
then threw the derivation away. Planning now keeps it:

```moonbit
priv enum ElaborationOperand {
  Existing(Value)   // already in scope
  FromStep(Int)     // built by an earlier step
}
```

A step carries its own `Opcode` and the source of each operand. Post-order
makes a `FromStep` index always lower than the step naming it, so the build
loop resolves operands by array indexing — no lookup, no `Option`, no guard.
It has nothing left to check and no way to return early, which makes "an
abandoned rewrite creates nothing" a property of the loop's shape rather than
an argument about which guards can fire. `resolve_operand` and both staging
arrays go with it; the file is ~80 lines shorter.

### On testability — stated up front, because that was ISS-386's mistake

**No test can separate this implementation from the previous one.** The leak
needed a post-allocation failure point, every such point was unreachable, and
unreachable code cannot be driven from a test. The defect is removed by
construction, not covered by a regression test, and the test comments now say
so where a reader will find them instead of leaving it to be discovered.

What the tests do pin is the contract that stays observable on both sides: an
abandoned rewrite leaves both counters where they were, and a successful one
spends exactly one value and one instruction per instruction emitted — four
each in the four-instruction case, which would catch a future build loop that
creates something and drops it.

### Verification

milkir 2568/2568, wasmoon 2568/2568, spec corpus 258/258 files and 62563
tests in both interpreter and JIT modes.