### PR TITLE
End the observer's phase sequence when allocation fails (ISS-392)

### DIFF
--- a/issues/ISS-392.md
+++ b/issues/ISS-392.md
@@ -1,0 +1,82 @@
+# ISS-392: A failed allocation never ends the observer's phase sequence
+
+## Metadata
+- Type: bug
+- Status: closed
+- Priority: 3
+- Labels: regalloc, observability, agent
+- Assignee: unassigned
+- Created: 2026-08-04
+- Updated: 2026-08-04
+- External ref: none
+
+## Description
+`RegallocConfig`'s observer is documented in `modules/regalloc/api.mbt:54` as
+"Called as each phase begins, and once with None when the last one ends."
+
+`allocate_function` only honoured that when allocation succeeded. The
+terminating `config.enter_phase(None)` was the last statement of the body, so
+any raise from inside skipped it:
+
+```moonbit
+if config.verify() {
+  config.enter_phase(Some(Verification))
+  verify_function_allocation(function, environment, plan)  // raises
+}
+config.enter_phase(None)                                   // never runs
+```
+
+`verify_function_allocation` raises `VerifyError`, and so does
+`allocate_bundle_plan`, which opens seven phases of its own. Either way the
+observer is left holding a phase that never closed — and it is always the
+phase that failed, which is the one worth seeing. The consumer in
+`modules/aarch64_target/compile.mbt:32` maps `None` to
+`RegallocPhasesFinished`, so a failed allocation simply never reports that
+its phases finished.
+
+Reachable, not theoretical: a `FixedReg` constraint naming a register outside
+the allocatable set runs the whole pipeline and is then rejected by the plan
+verifier.
+
+## Design
+MoonBit has no `finally`, and a `raise` runs straight past a trailing call,
+so the terminator cannot be attached to a single function body. Split the
+phases into `run_allocation_phases` and let `allocate_function` wrap the
+call, emitting `None` on both the returning and the raising path.
+
+`verify_operand_preferences` stays outside that wrapper deliberately. It
+raises before the first phase opens, so no sequence is in progress; emitting
+a lone `None` there would report the end of something that never began.
+
+## Acceptance Criteria
+- [x] A failed allocation delivers exactly one terminating `None`.
+- [x] A rejection that happens before the first phase delivers no events.
+- [x] Both are asserted by tests that fail against the previous code.
+
+## Relationships
+- Depends on: none
+- Parent: none
+- Related: ISS-371
+- Discovered from: none
+
+## Notes
+- 2026-08-04: Reported by the maintainer, pointing at
+  `function_allocate.mbt:319` against the contract in `api.mbt:54`.
+
+## Close Notes
+
+Unlike ISS-391, this one is properly testable, and the tests were checked
+against the previous code rather than assumed to cover it. With the fix
+reverted, `a failed allocation still ends the observer's phase sequence`
+fails with the sequence ending at `verification` and no `END`:
+
+```
+- ...,edge_transfers,edit_resolution,verification,END
++ ...,edge_transfers,edit_resolution,verification
+```
+
+The second test pins the deliberate exception — a pre-phase rejection emits
+nothing — so a future "just always send None" simplification cannot pass
+unnoticed.
+
+regalloc 2570/2570.

--- a/issues/README.md
+++ b/issues/README.md
@@ -403,6 +403,7 @@ graph TD
   ISS_384["ISS-384: Stop paying full extraction for the constant-only harvest"]
   ISS_385["ISS-385: Elaboration planning keys by e-class, not by (e-class, type)"]
   ISS_386["ISS-386: Elaboration's commit loop can leave half a plan behind"]
+  ISS_392["ISS-392: A failed allocation never ends the observer's phase sequence"]
   ISS_002 --> ISS_003
   ISS_002 --> ISS_004
   ISS_003 --> ISS_005

--- a/modules/regalloc/allocation_plan_test.mbt
+++ b/modules/regalloc/allocation_plan_test.mbt
@@ -1081,3 +1081,90 @@ test "backtracking keeps edit-only scratch registers out of instruction operands
     ),
   )
 }
+
+///|
+/// The observer contract says every phase that opens is followed, eventually,
+/// by exactly one `None`. A failing allocation is still an allocation that
+/// ended, so it owes that event too — without it, whoever is measuring is
+/// left holding a phase that never closed, and it is always the phase that
+/// failed, which is the one worth seeing.
+///
+/// A `FixedReg` preference for a register outside the allocatable set gets
+/// all the way through the pipeline before the plan verifier rejects it, so
+/// this drives the real path rather than a contrived one.
+test "a failed allocation still ends the observer's phase sequence" {
+  let events : Array[String] = []
+  let config = RegallocConfig::RegallocConfig(
+    observer=Some(phase => {
+      events.push(
+        match phase {
+          Some(named) => "\{named}"
+          None => "END"
+        },
+      )
+    }),
+  )
+  let function : TestFunction = {
+    value_count: 1,
+    instructions: [
+      [Operand::use_reg(value(0)).with_constraint(FixedReg(int_reg(9)))],
+    ],
+    block_parameters: [value(0)],
+  }
+  let mut raised = false
+  try
+    allocate_function(function, MachineEnv::new([int_reg(0)], []), config~)
+    |> ignore
+  catch {
+    _ => raised = true
+  }
+  inspect(raised, content="true")
+  inspect(
+    events.join(","),
+    content="live_ranges,segment_construction,bundle_formation,bundle_allocation,home_assignment,operand_assignment,edge_transfers,edit_resolution,verification,END",
+  )
+  // The terminator arrives once, at the end, not for every phase.
+  inspect(events.filter(event => event == "END").length(), content="1")
+}
+
+///|
+/// A rejection that happens before the first phase opens is different: the
+/// observer has heard nothing, so it is owed nothing. Sending a lone `None`
+/// there would report the end of a sequence that never began.
+test "a pre-phase rejection notifies the observer at all" {
+  let events : Array[String] = []
+  let config = RegallocConfig::RegallocConfig(
+    observer=Some(phase => {
+      events.push(
+        match phase {
+          Some(named) => "\{named}"
+          None => "END"
+        },
+      )
+    }),
+  )
+  let function : TestFunction = {
+    value_count: 1,
+    instructions: [
+      [
+        Operand::use_reg(value(0))
+        .with_constraint(AnyLocation)
+        .with_preference(int_reg(9)),
+      ],
+    ],
+    block_parameters: [value(0)],
+  }
+  let mut raised = false
+  try
+    allocate_function(
+      function,
+      MachineEnv::new([int_reg(0)], [int_reg(1)]),
+      config~,
+    )
+    |> ignore
+  catch {
+    _ => raised = true
+  }
+  inspect(raised, content="true")
+  inspect(events.length(), content="0")
+}

--- a/modules/regalloc/function_allocate.mbt
+++ b/modules/regalloc/function_allocate.mbt
@@ -310,19 +310,48 @@ fn[F : FunctionView] verify_operand_preferences(
 }
 
 ///|
-/// Allocate directly from a read-only machine-function view.
-pub fn[F : FunctionView] allocate_function(
+/// The phases proper: everything from the first `enter_phase` onwards.
+///
+/// Split out so the terminating event can be attached to every way this
+/// returns. A single body cannot express that — MoonBit has no `finally`,
+/// and a `raise` runs straight past a trailing call.
+fn[F : FunctionView] run_allocation_phases(
   function : F,
   environment : MachineEnv,
-  config? : RegallocConfig = RegallocConfig(),
+  config : RegallocConfig,
 ) -> AllocationPlan raise VerifyError {
-  verify_operand_preferences(function, environment)
   let plan = allocate_bundle_plan(function, environment, config)
   config.enter_phase(Some(EditResolution))
   resolve_instruction_edits(plan, environment)
   if config.verify() {
     config.enter_phase(Some(Verification))
     verify_function_allocation(function, environment, plan)
+  }
+  plan
+}
+
+///|
+/// Allocate directly from a read-only machine-function view.
+///
+/// The observer sees `Some(phase)` as each phase begins and exactly one
+/// `None` once the last one ends, *including when allocation fails*. A raise
+/// used to skip that `None`, leaving whoever was measuring with a phase that
+/// never ended — `Verification` most often, since verifying the finished
+/// plan is both the likeliest raise and the last phase to open.
+pub fn[F : FunctionView] allocate_function(
+  function : F,
+  environment : MachineEnv,
+  config? : RegallocConfig = RegallocConfig(),
+) -> AllocationPlan raise VerifyError {
+  // Ahead of the first phase on purpose: this raises before any phase has
+  // opened, so there is no sequence to terminate, and an observer that has
+  // heard nothing is owed nothing.
+  verify_operand_preferences(function, environment)
+  let plan = run_allocation_phases(function, environment, config) catch {
+    error => {
+      config.enter_phase(None)
+      raise error
+    }
   }
   config.enter_phase(None)
   plan


### PR DESCRIPTION
`modules/regalloc/api.mbt:54` promises the observer hears each phase begin and
then one `None` when the last ends. `allocate_function` kept that promise only
when allocation succeeded — the terminating `enter_phase(None)` was the body's
last statement, so any raise skipped it.

Both raising callees sit past the first phase. `verify_function_allocation`
raises with `Verification` open; `allocate_bundle_plan` raises with any of the
seven phases it opens still current. Either way the observer is left holding a
phase that never closed, and it is always the phase that *failed* — the one
worth seeing. `modules/aarch64_target/compile.mbt:32` maps `None` to
`RegallocPhasesFinished`, so a failed allocation never reported that its phases
had finished.

### The fix

MoonBit has no `finally` and a `raise` runs straight past a trailing call, so
the terminator cannot be attached to one function body. The phases move into
`run_allocation_phases`; `allocate_function` wraps the call and emits `None` on
both the returning and the raising path.

`verify_operand_preferences` stays outside that wrapper deliberately. It raises
before the first phase opens, so no sequence is in progress and a lone `None`
would report the end of something that never began. A second test pins that
exception, so a later "just always send `None`" simplification cannot pass
unnoticed.

### These tests were checked against the old code

Unlike ISS-391, this failure is reachable, so the tests are verified rather
than assumed. A `FixedReg` constraint naming a register outside the allocatable
set runs the entire pipeline and is then rejected by the plan verifier. With
the fix reverted, the new test fails exactly as predicted:

```
- ...,edge_transfers,edit_resolution,verification,END
+ ...,edge_transfers,edit_resolution,verification
```

regalloc 2570/2570.