### PR TITLE
Release all modules with minor version bumps

### DIFF
--- a/modules/aarch64_target/moon.mod
+++ b/modules/aarch64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/aarch64_target"
 
-version = "0.4.0"
+version = "0.5.0"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "aarch64", "compiler", "codegen", "jit" ]
 description = "AArch64 target pipeline from semantic MachV to native code"
 
 import {
-  "Milky2018/milkir@0.4.0",
-  "Milky2018/machv@0.6.0",
-  "Milky2018/machv_regalloc@0.4.0",
-  "Milky2018/milkir_machv@0.5.0",
+  "Milky2018/milkir@0.5.0",
+  "Milky2018/machv@0.7.0",
+  "Milky2018/machv_regalloc@0.5.0",
+  "Milky2018/milkir_machv@0.6.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/machv/moon.mod
+++ b/modules/machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv"
 
-version = "0.6.0"
+version = "0.7.0"
 
 readme = "README.mbt.md"
 

--- a/modules/machv_regalloc/moon.mod
+++ b/modules/machv_regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv_regalloc"
 
-version = "0.4.0"
+version = "0.5.0"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "Target VCode adapter for the reusable register allocator"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/machv@0.6.0",
-  "Milky2018/regalloc@0.5.0",
+  "Milky2018/machv@0.7.0",
+  "Milky2018/regalloc@0.6.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/milkir/moon.mod
+++ b/modules/milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir"
 
-version = "0.4.0"
+version = "0.5.0"
 
 readme = "README.mbt.md"
 

--- a/modules/milkir_machv/moon.mod
+++ b/modules/milkir_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir_machv"
 
-version = "0.5.0"
+version = "0.6.0"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "MilkIR-to-MachV lowering"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/milkir@0.4.0",
-  "Milky2018/machv@0.6.0",
+  "Milky2018/milkir@0.5.0",
+  "Milky2018/machv@0.7.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/regalloc/moon.mod
+++ b/modules/regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/regalloc"
 
-version = "0.5.0"
+version = "0.6.0"
 
 readme = "README.mbt.md"
 

--- a/modules/wasm_core/moon.mod
+++ b/modules/wasm_core/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_core"
 
-version = "0.3.0"
+version = "0.4.0"
 
 readme = "README.mbt.md"
 

--- a/modules/wasm_machv/moon.mod
+++ b/modules/wasm_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_machv"
 
-version = "0.3.0"
+version = "0.4.0"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "wasm", "webassembly", "milkir", "machv", "lowering" ]
 description = "WebAssembly MilkIR dialect adapter for target-neutral MachV"
 
 import {
-  "Milky2018/wasm_milkir@0.4.0",
-  "Milky2018/milkir@0.4.0",
-  "Milky2018/machv@0.6.0",
-  "Milky2018/milkir_machv@0.5.0",
+  "Milky2018/wasm_milkir@0.5.0",
+  "Milky2018/milkir@0.5.0",
+  "Milky2018/machv@0.7.0",
+  "Milky2018/milkir_machv@0.6.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasm_milkir/moon.mod
+++ b/modules/wasm_milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_milkir"
 
-version = "0.4.0"
+version = "0.5.0"
 
 readme = "README.mbt.md"
 
@@ -13,7 +13,7 @@ keywords = [ "wasm", "webassembly", "milkir", "compiler", "dialect" ]
 description = "WebAssembly dialect adapter for MilkIR extension operations"
 
 import {
-  "Milky2018/milkir@0.4.0",
+  "Milky2018/milkir@0.5.0",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasmoon/cmd/wasmoon/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon/main.mbt
@@ -3,7 +3,7 @@
 /// by `scripts/tests/test_cli_version.py`. MoonBit gives the program no way
 /// to read its own module manifest, so the manifest stays the single source
 /// of truth and the test is what keeps this copy from drifting.
-const WASMOON_VERSION : String = "0.10.0"
+const WASMOON_VERSION : String = "0.11.0"
 
 ///|
 fn clap_parser(

--- a/modules/wasmoon/moon.mod
+++ b/modules/wasmoon/moon.mod
@@ -1,19 +1,19 @@
 name = "Milky2018/wasmoon"
 
-version = "0.10.0"
+version = "0.11.0"
 
 import {
   "moonbitlang/x@0.4.38",
   "TheWaWaR/clap@0.2.6",
-  "Milky2018/wasm_core@0.3.0",
-  "Milky2018/wasm_milkir@0.4.0",
-  "Milky2018/milkir@0.4.0",
-  "Milky2018/machv@0.6.0",
-  "Milky2018/milkir_machv@0.5.0",
-  "Milky2018/machv_regalloc@0.4.0",
-  "Milky2018/x64_target@0.3.0",
-  "Milky2018/aarch64_target@0.4.0",
-  "Milky2018/wasmoon_jit@0.5.0",
+  "Milky2018/wasm_core@0.4.0",
+  "Milky2018/wasm_milkir@0.5.0",
+  "Milky2018/milkir@0.5.0",
+  "Milky2018/machv@0.7.0",
+  "Milky2018/milkir_machv@0.6.0",
+  "Milky2018/machv_regalloc@0.5.0",
+  "Milky2018/x64_target@0.4.0",
+  "Milky2018/aarch64_target@0.5.0",
+  "Milky2018/wasmoon_jit@0.6.0",
   "moonbitlang/async@0.20.3",
 }
 

--- a/modules/wasmoon_jit/moon.mod
+++ b/modules/wasmoon_jit/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasmoon_jit"
 
-version = "0.5.0"
+version = "0.6.0"
 
 readme = "README.mbt.md"
 
@@ -14,15 +14,15 @@ description = "Wasmoon-specific JIT integration and native runtime glue"
 
 import {
   "moonbitlang/x@0.4.38",
-  "Milky2018/wasm_core@0.3.0",
-  "Milky2018/wasm_milkir@0.4.0",
-  "Milky2018/wasm_machv@0.3.0",
-  "Milky2018/milkir@0.4.0",
-  "Milky2018/machv@0.6.0",
-  "Milky2018/milkir_machv@0.5.0",
-  "Milky2018/machv_regalloc@0.4.0",
-  "Milky2018/aarch64_target@0.4.0",
-  "Milky2018/x64_target@0.3.0",
+  "Milky2018/wasm_core@0.4.0",
+  "Milky2018/wasm_milkir@0.5.0",
+  "Milky2018/wasm_machv@0.4.0",
+  "Milky2018/milkir@0.5.0",
+  "Milky2018/machv@0.7.0",
+  "Milky2018/milkir_machv@0.6.0",
+  "Milky2018/machv_regalloc@0.5.0",
+  "Milky2018/aarch64_target@0.5.0",
+  "Milky2018/x64_target@0.4.0",
 }
 
 preferred_target = "native"

--- a/modules/x64_target/moon.mod
+++ b/modules/x64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/x64_target"
 
-version = "0.3.0"
+version = "0.4.0"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "x64", "x86-64", "compiler", "codegen" ]
 description = "x64 target pipeline from semantic MachV to native code"
 
 import {
-  "Milky2018/milkir@0.4.0",
-  "Milky2018/machv@0.6.0",
-  "Milky2018/machv_regalloc@0.4.0",
-  "Milky2018/milkir_machv@0.5.0",
+  "Milky2018/milkir@0.5.0",
+  "Milky2018/machv@0.7.0",
+  "Milky2018/machv_regalloc@0.5.0",
+  "Milky2018/milkir_machv@0.6.0",
 }
 
 preferred_target = "wasm-gc"


### PR DESCRIPTION
Version bump only — no behaviour change. Publishing to mooncakes.io follows
once this is on main, so the registry never carries a version main does not.

Covers the correctness batch merged as #484: ISS-393 through ISS-400, plus the
audit of all 45 `abort()` calls in the backend packages.

| Module | | |
| --- | --- | --- |
| `milkir` | 0.4.0 | **0.5.0** |
| `machv` | 0.6.0 | **0.7.0** |
| `regalloc` | 0.5.0 | **0.6.0** |
| `wasm_core` | 0.3.0 | **0.4.0** |
| `machv_regalloc` | 0.4.0 | **0.5.0** |
| `milkir_machv` | 0.5.0 | **0.6.0** |
| `wasm_milkir` | 0.4.0 | **0.5.0** |
| `aarch64_target` | 0.4.0 | **0.5.0** |
| `x64_target` | 0.3.0 | **0.4.0** |
| `wasm_machv` | 0.3.0 | **0.4.0** |
| `wasmoon_jit` | 0.5.0 | **0.6.0** |
| `wasmoon` | 0.10.0 | **0.11.0** |

## Why minor and not patch

The batch is breaking:

- `wasm_core` deleted `Module::get_func_type` and replaced it with
  `func_type_at -> FuncType?` and `validated_func_type_at -> FuncType`
- `wasm_milkir`'s `RuntimeSymbols` gained eight fields, which is breaking for a
  `pub(all) struct`
- `wasmoon_jit` gained `GcSlot`, `value_to_slot` and `slot_to_value`

Under 0.x that is a minor bump, and it is what the previous release used.

Dependency pins move with the versions, so every module still resolves inside
the workspace. `WASMOON_VERSION` moves with `modules/wasmoon/moon.mod` — the
pre-commit hook pins them to each other, and `wasmoon --version` reports
`0.11.0`.

## Verification

- `moon check` clean, 2601/2601 native tests
- CLI behaviour tests pass, `scripts/tests` pass
- `moon publish --dry-run` on `milkir` returned `202 Accepted` from the
  registry, so packaging and credentials are good
