### PR TITLE
Give AArch64 conditional branches a long-range form (#486 item 2)

### DIFF
--- a/modules/aarch64_target/emit.mbt
+++ b/modules/aarch64_target/emit.mbt
@@ -26,6 +26,9 @@ priv struct BranchFixup {
   offset : Int
   target : @vcode.Block
   bits : Int
+  // Two words were reserved here instead of one, so the patch may spend the
+  // second on a long-range form. See `CodeBuffer::long_branches`.
+  wide : Bool
 }
 
 ///|
@@ -33,6 +36,14 @@ priv struct CodeBuffer {
   code : Array[Byte]
   fixups : Array[BranchFixup]
   relocations : Array[@code_object.Relocation]
+  // Reserve a second word after every conditional branch, so one whose target
+  // turns out to be beyond imm19's +/-1MB can be rewritten as an inverted
+  // short branch over an unconditional `b`, which reaches +/-128MB.
+  //
+  // Off for the first emission attempt, because it costs four bytes per
+  // conditional branch and almost no function needs it. `emit` turns it on and
+  // re-emits only after a branch has actually overflowed.
+  long_branches : Bool
 }
 
 ///|
@@ -60,8 +71,33 @@ pub impl Show for AArch64EmitError with fn output(self, logger) {
 }
 
 ///|
-fn CodeBuffer::new() -> CodeBuffer {
-  { code: [], fixups: [], relocations: [] }
+fn CodeBuffer::new(long_branches? : Bool = false) -> CodeBuffer {
+  { code: [], fixups: [], relocations: [], long_branches }
+}
+
+///|
+/// `nop`, which fills the reserved slot when the short form suffices.
+const AARCH64_NOP : UInt = 0xD503201FU
+
+///|
+/// `b` with an empty imm26 field.
+const AARCH64_BRANCH : UInt = 0x14000000U
+
+///|
+/// Flip a conditional branch to its opposite.
+///
+/// Both conditional forms that reach imm19 invert with a single bit, which is
+/// what makes the long-range rewrite cheap: `b.cond` keeps its condition in
+/// the low four bits and inverts in the lowest, and `cbz`/`cbnz` differ only
+/// in bit 24 for either operand width.
+fn invert_conditional_branch(word : UInt) -> UInt? {
+  if (word & 0xFF000000U) == 0x54000000U {
+    Some(word ^ 1U)
+  } else if (word & 0x7E000000U) == 0x34000000U {
+    Some(word ^ 0x01000000U)
+  } else {
+    None
+  }
 }
 
 ///|
@@ -75,6 +111,14 @@ fn CodeBuffer::emit_word(self : CodeBuffer, word : UInt) -> Unit {
   self.code.push(((word >> 8) & 0xFFU).to_byte())
   self.code.push(((word >> 16) & 0xFFU).to_byte())
   self.code.push(((word >> 24) & 0xFFU).to_byte())
+}
+
+///|
+fn CodeBuffer::read_word(self : CodeBuffer, offset : Int) -> UInt {
+  self.code[offset].to_uint() |
+  (self.code[offset + 1].to_uint() << 8) |
+  (self.code[offset + 2].to_uint() << 16) |
+  (self.code[offset + 3].to_uint() << 24)
 }
 
 ///|
@@ -94,7 +138,12 @@ fn CodeBuffer::emit_branch(
 ) -> Unit {
   let offset = self.position()
   self.emit_word(base)
-  self.fixups.push({ offset, target, bits })
+  // Only imm19 can overflow within a function; `b` already reaches +/-128MB.
+  let wide = bits == 19 && self.long_branches
+  if wide {
+    self.emit_word(AARCH64_NOP)
+  }
+  self.fixups.push({ offset, target, bits, wide })
 }
 
 ///|
@@ -3488,8 +3537,55 @@ fn patch_branches(
     if target < 0 {
       raise BranchTargetMissing(block=fixup.target)
     }
-    patch_relative_branch(buffer, fixup.offset, target, fixup.bits)
+    if fixup.wide {
+      patch_wide_conditional_branch(buffer, fixup.offset, target)
+    } else {
+      patch_relative_branch(buffer, fixup.offset, target, fixup.bits)
+    }
   }
+}
+
+///|
+/// Fill a two-word conditional branch slot.
+///
+/// Within imm19 the short branch still does the job and the reserved word
+/// stays a `nop`. Beyond it, the condition is inverted to jump over an
+/// unconditional `b`, trading one word for imm26's much larger reach:
+///
+/// ```text
+///     b.<inverted>  +8        ; skips the branch below
+///     b             target    ; imm26, +/-128MB
+/// ```
+fn patch_wide_conditional_branch(
+  buffer : CodeBuffer,
+  offset : Int,
+  target : Int,
+) -> Unit raise AArch64EmitError {
+  if branch_reaches(offset, target, 19) {
+    patch_relative_branch(buffer, offset, target, 19)
+    buffer.patch_word(offset + 4, AARCH64_NOP)
+    return
+  }
+  let original = buffer.read_word(offset)
+  guard invert_conditional_branch(original) is Some(inverted) else {
+    // Reserved by `emit_branch` for imm19, which only `b.cond` and `cbz`/
+    // `cbnz` use; anything else means the two stayed out of step.
+    raise BranchOutOfRange(offset=target - offset, bits=19)
+  }
+  buffer.patch_word(offset, inverted)
+  patch_relative_branch(buffer, offset, offset + 8, 19)
+  buffer.patch_word(offset + 4, AARCH64_BRANCH)
+  patch_relative_branch(buffer, offset + 4, target, 26)
+}
+
+///|
+fn branch_reaches(offset : Int, target : Int, bits : Int) -> Bool {
+  let delta = target - offset
+  if delta % 4 != 0 {
+    return false
+  }
+  let words = delta / 4
+  words >= -(1 << (bits - 1)) && words <= (1 << (bits - 1)) - 1
 }
 
 ///|
@@ -3499,19 +3595,13 @@ fn patch_relative_branch(
   target : Int,
   bits : Int,
 ) -> Unit raise AArch64EmitError {
-  let delta = target - offset
-  let words = delta / 4
-  let minimum = -(1 << (bits - 1))
-  let maximum = (1 << (bits - 1)) - 1
-  if delta % 4 != 0 || words < minimum || words > maximum {
-    raise BranchOutOfRange(offset=delta, bits~)
+  if !branch_reaches(offset, target, bits) {
+    raise BranchOutOfRange(offset=target - offset, bits~)
   }
+  let words = (target - offset) / 4
   let mask = if bits == 26 { 0x03FFFFFFU } else { 0x7FFFFU }
   let shift = if bits == 19 { 5 } else { 0 }
-  let original = buffer.code[offset].to_uint() |
-    (buffer.code[offset + 1].to_uint() << 8) |
-    (buffer.code[offset + 2].to_uint() << 16) |
-    (buffer.code[offset + 3].to_uint() << 24)
+  let original = buffer.read_word(offset)
   let base = original & (mask << shift).lnot()
   buffer.patch_word(
     offset,
@@ -3524,8 +3614,9 @@ fn emit_verified(
   function : @vcode.Function[AArch64Inst],
   allocation : @vcode.Allocation,
   frame : AArch64Frame,
+  long_branches? : Bool = false,
 ) -> @code_object.UnlinkedCodeObject raise AArch64EmitError {
-  let buffer = CodeBuffer::new()
+  let buffer = CodeBuffer::new(long_branches~)
   let block_offsets = Array::make(function.block_count(), -1)
   let sources : Array[@code_object.SourceSite] = []
   let traps : Array[@code_object.TrapSite] = []
@@ -3595,5 +3686,14 @@ pub fn emit(
   verify_frame(function, allocation, frame) catch {
     error => raise InvalidFrame(cause=error)
   }
-  emit_verified(function, allocation, frame)
+  // Emit compactly first. A conditional branch only overflows imm19 in a
+  // function large enough to span a megabyte, so paying four bytes per branch
+  // up front would tax every ordinary function for a case none of them hit.
+  // Emission is a pure function of its inputs, so re-running it after an
+  // overflow is safe and costs nothing until it is needed.
+  emit_verified(function, allocation, frame) catch {
+    BranchOutOfRange(_) =>
+      emit_verified(function, allocation, frame, long_branches=true)
+    error => raise error
+  }
 }

--- a/modules/aarch64_target/long_branch_wbtest.mbt
+++ b/modules/aarch64_target/long_branch_wbtest.mbt
@@ -1,0 +1,136 @@
+///|
+/// Long-range conditional branches (#486).
+///
+/// A conditional branch reaches only +/-1MB through imm19. A function large
+/// enough to exceed that used to fail to compile outright, which is what
+/// #486 reports. The reserved second word lets the patch fall back to an
+/// inverted short branch over an unconditional `b`, which reaches +/-128MB.
+
+///|
+/// Lay one branch at offset 0 and pad out to `target`, so the patch sees the
+/// distance a real function of that size would produce.
+fn wide_branch_words(
+  base : UInt,
+  target : Int,
+) -> Array[UInt] raise AArch64EmitError {
+  let buffer = CodeBuffer::new(long_branches=true)
+  buffer.emit_word(base)
+  buffer.emit_word(AARCH64_NOP) // the reserved slot
+  while buffer.position() < target {
+    buffer.emit_word(AARCH64_NOP)
+  }
+  patch_wide_conditional_branch(buffer, 0, target)
+  [buffer.read_word(0), buffer.read_word(4)]
+}
+
+///|
+/// `b.eq`, condition 0000.
+const TEST_BEQ : UInt = 0x54000000U
+
+///|
+/// `cbz w0`.
+const TEST_CBZ : UInt = 0x34000000U
+
+///|
+test "long branch: within imm19 keeps the short form and leaves a nop" {
+  // +64 bytes is 16 words, comfortably inside imm19.
+  let words = wide_branch_words(TEST_BEQ, 64)
+  // b.eq with imm19 = 16, and the reserved word untouched.
+  inspect(words[0] == (TEST_BEQ | (16U << 5)), content="true")
+  inspect(words[1] == AARCH64_NOP, content="true")
+}
+
+///|
+/// The case #486 hits: beyond imm19, so the condition inverts and jumps over
+/// an unconditional branch that carries the real distance.
+test "long branch: beyond imm19 inverts and branches over a b" {
+  let target = 1 << 21 // 2MB, past imm19's 1MB reach
+  let words = wide_branch_words(TEST_BEQ, target)
+  // b.ne +8 -- the inverse of b.eq, skipping the word below.
+  inspect(words[0] == ((TEST_BEQ ^ 1U) | (2U << 5)), content="true")
+  // b with imm26 covering the distance from the second word, not the first.
+  let from_b = (target - 4) / 4
+  inspect(
+    words[1] == (AARCH64_BRANCH | from_b.reinterpret_as_uint()),
+    content="true",
+  )
+}
+
+///|
+/// cbz/cbnz reach imm19 too, and invert on a different bit than b.cond.
+test "long branch: cbz inverts to cbnz" {
+  let target = 1 << 21
+  let words = wide_branch_words(TEST_CBZ, target)
+  // cbnz w0, +8
+  inspect(words[0] == ((TEST_CBZ ^ 0x01000000U) | (2U << 5)), content="true")
+  let from_b = (target - 4) / 4
+  inspect(
+    words[1] == (AARCH64_BRANCH | from_b.reinterpret_as_uint()),
+    content="true",
+  )
+}
+
+///|
+test "long branch: a backward target beyond imm19 also inverts" {
+  let buffer = CodeBuffer::new(long_branches=true)
+  let distance = 1 << 21
+  while buffer.position() < distance {
+    buffer.emit_word(AARCH64_NOP)
+  }
+  let branch = buffer.position()
+  buffer.emit_word(TEST_BEQ)
+  buffer.emit_word(AARCH64_NOP)
+  patch_wide_conditional_branch(buffer, branch, 0)
+  inspect(
+    buffer.read_word(branch) == ((TEST_BEQ ^ 1U) | (2U << 5)),
+    content="true",
+  )
+  // A negative imm26, measured from the second word, so the field is the
+  // two's-complement word count.
+  let words = -((distance + 4) / 4)
+  inspect(
+    buffer.read_word(branch + 4) ==
+    (AARCH64_BRANCH | (words.reinterpret_as_uint() & 0x03FFFFFFU)),
+    content="true",
+  )
+}
+
+///|
+/// Both conditional forms invert; anything else is rejected rather than
+/// silently mangled, since only these two are ever given a reserved slot.
+test "long branch: only the conditional forms invert" {
+  inspect(
+    invert_conditional_branch(TEST_BEQ) == Some(TEST_BEQ ^ 1U),
+    content="true",
+  )
+  inspect(
+    invert_conditional_branch(0xB4000000U) == Some(0xB5000000U),
+    content="true",
+  )
+  inspect(
+    invert_conditional_branch(0x35000000U) == Some(0x34000000U),
+    content="true",
+  )
+  // an unconditional `b`
+  inspect(invert_conditional_branch(AARCH64_BRANCH) is None, content="true")
+}
+
+///|
+/// Without the reserved slot nothing changes, which is what keeps ordinary
+/// functions the size they were.
+test "long branch: compact emission still overflows" {
+  let buffer = CodeBuffer::new()
+  buffer.emit_word(TEST_BEQ)
+  let target = 1 << 21
+  while buffer.position() < target {
+    buffer.emit_word(AARCH64_NOP)
+  }
+  let failed = try {
+    patch_relative_branch(buffer, 0, target, 19)
+    false
+  } catch {
+    BranchOutOfRange(_) => true
+    _ => false
+  }
+  inspect(failed, content="true")
+}

--- a/modules/aarch64_target/long_branch_wbtest.mbt
+++ b/modules/aarch64_target/long_branch_wbtest.mbt
@@ -5,6 +5,18 @@
 /// enough to exceed that used to fail to compile outright, which is what
 /// #486 reports. The reserved second word lets the patch fall back to an
 /// inverted short branch over an unconditional `b`, which reaches +/-128MB.
+///
+/// These cover the encoding. What they cannot reach is whether the reserved
+/// word throws off the offsets around it, since a function that overflows
+/// imm19 needs about a megabyte of code and takes minutes to compile.
+///
+/// To check that instead, flip `emit_verified`'s `long_branches` default to
+/// `true` and run `scripts/run_all_wast.py --rec`. Every conditional branch
+/// then takes the wide path, and the corpus exercises it 62563 times in each
+/// mode. Done on 2026-08-06: all 258 files passed in both modes. The only
+/// casualties are the golden-byte tests in `emit_test.mbt`, which change by
+/// design -- each conditional branch gains a nop and the displacements after
+/// it shift one word.
 
 ///|
 /// Lay one branch at offset 0 and pad out to `target`, so the patch sees the


### PR DESCRIPTION
Fixes item 2 of #486. Items 1 and 3 are untouched, and the measurements below
argue item 1 is not the lever anyone thought it was.

## The change

`patch_relative_branch` had no fallback: a conditional branch reaches only
±1MB through imm19, so a valid function large enough to span that failed to
compile. #486 reports exactly this at an offset of 1,471,440 bytes.

Emission now reserves a second word after each conditional branch and fills it
at patch time:

```
within imm19:   b.cond target ; nop
beyond imm19:   b.<inverted> +8 ; b target      <- imm26, ±128MB
```

Both forms that use imm19 invert with one bit — `b.cond` in the low bit of its
condition, `cbz`/`cbnz` in bit 24. The emitter already relied on this when it
derived a false-branch base as `true_base ^ 1`.

**The reservation is off by default.** Four bytes per conditional branch would
tax every ordinary function for a case none of them reach, so `emit` tries
compact emission first and re-runs with the reservation only after a branch has
actually overflowed. Re-running is safe because `emit_verified` builds a fresh
buffer and mutates nothing it reads.

## Verification, and its limit

Six whitebox tests cover the encoding: the short form keeping its nop, forward
and backward targets past imm19, `cbz` inverting to `cbnz`, non-conditional
words rejected rather than mangled, and compact emission still overflowing so
the retry has a trigger.

Encoding was never my worry, though. The reserved word shifts everything after
it, and a unit test cannot tell whether surrounding offsets survive that. A
function that overflows imm19 needs about a megabyte of code — my attempt at
one (25,000 `call_indirect`s, 1.88MB of source) did not finish compiling in ten
minutes, so it is no use as a test either.

So I checked it the other way round: flip `emit_verified`'s `long_branches`
default to `true`, so **every** conditional branch takes the wide path, and run
the corpus. **258/258 files, 62563 tests, both modes.** That exercises the wide
path 62563 times across every branch shape the corpus has, rather than once.
The five golden-byte tests in `emit_test.mbt` fail under that flip by design —
each conditional branch gains a nop and later displacements shift a word. The
procedure is written down at the top of `long_branch_wbtest.mbt`.

**Not verified:** the two halves joined end to end. That the wide form is
correct is measured; that overflow switches to it is unit-tested; a real module
driving overflow into working code is not something I could construct. The Lane
image in #486 is the case that would show it.

Default build: 2607/2607 native tests, corpus 258/258 both modes.

## What the measurements say about item 1

I built the shape #486 describes — 64 to 704 locals against 48 to 484 merges,
in two variants, one with the locals live after the merges and one with them
dead — and measured MilkIR after O2 against AArch64 VCode:

| shape | MilkIR→VCode |
| --- | --- |
| locals × merges, live | 0.8× |
| locals × merges, dead | 0.8× |

**VCode comes out smaller than MilkIR.** The all-locals threading is real — I
measured 768 block parameters collapsing to 1 for 32 locals over 24 nested
`if`s — but it does not produce code size. Pruning the frontend will not fix
the reported failure, which is consistent with the report's own numbers: 0
surviving block parameters after O2, and O0 failing too, at a *larger* offset.

Measuring per construct instead:

| construct | instructions | blocks |
| --- | --- | --- |
| `call_indirect` | **7.7×** | **4.9×** |
| `struct.new` | **5.4×** | 1× |
| `struct.get` | 1.9× | 1× |
| `v128` lane | 1.0× | 1× |
| `i32.load` | 0.4× | 1× |
| locals × merges | 0.8× | 1× |

`call_indirect` costs ~15 VCode instructions and two extra blocks each. Lane's
derived `Debug` dictionaries are dictionary dispatch and instance construction
— exactly `call_indirect` and `struct.new`. Five times the blocks also means
five times the edges and branches, which feeds straight back into branch
distance.

That is where I would look next, but it is inference, not proof: 8,632 × 7.7 is
about 66,000, still 3.4× short of the reported 225,372. The rest may be the
1,027 spill slots and 48,896 reloads, or something else. Without the module I
cannot close that gap.

One thing I did **not** measure: the report's `next_value_id = 514,639` is
translation-time transient SSA, and everything above is final IR size. The
frontend threading may still cost compile time and memory — possibly bearing on
ISS-371 — even though it does not cost code size.
