### PR TITLE
Thread only the locals a control merge can disagree about (#486 item 1)

### DIFF
--- a/modules/wasmoon/testsuite/local_threading_test.mbt
+++ b/modules/wasmoon/testsuite/local_threading_test.mbt
@@ -1,0 +1,279 @@
+///|
+/// Locals across control merges (#486 item 1).
+///
+/// A merge block carries only the locals its region writes; every other local
+/// keeps the value the translator already holds. That is a claim about which
+/// value each local has after the merge, so these run each shape through both
+/// the JIT and the interpreter and require them to agree -- a local that gets
+/// dropped from a merge it actually needed shows up here as a disagreement,
+/// not as a compile error.
+///
+/// Each case is driven by the function argument so both sides of every branch
+/// are taken across the calls.
+
+///|
+/// Written in one arm only: the merge has to reconcile the arm that wrote with
+/// the arm that did not.
+test "local_threading_if_then_only" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $x i32)
+    #|    (local.set $x (i32.const 5))
+    #|    (if (local.get 0) (then (local.set $x (i32.const 10))))
+    #|    (local.get $x)
+    #|  )
+    #|)
+  for arg in [0, 1] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// Each arm writes a different local, so the merge carries both even though
+/// neither arm writes both.
+test "local_threading_if_either_arm" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $x i32) (local $y i32)
+    #|    (local.set $x (i32.const 1))
+    #|    (local.set $y (i32.const 2))
+    #|    (if (local.get 0)
+    #|      (then (local.set $x (i32.const 10)))
+    #|      (else (local.set $y (i32.const 20))))
+    #|    (i32.add (local.get $x) (local.get $y))
+    #|  )
+    #|)
+  for arg in [0, 1] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// Neither arm writes the local, so it crosses the merge with no parameter at
+/// all. Its value after the `if` still has to be the one set before it.
+test "local_threading_if_untouched_local_survives" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $kept i32) (local $touched i32)
+    #|    (local.set $kept (i32.const 7))
+    #|    (if (local.get 0)
+    #|      (then (local.set $touched (i32.const 1)))
+    #|      (else (local.set $touched (i32.const 2))))
+    #|    (i32.add (local.get $kept) (local.get $touched))
+    #|  )
+    #|)
+  for arg in [0, 1] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// A write two regions deep still has to reach the code after the outer block.
+test "local_threading_nested_block_write_escapes" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $x i32)
+    #|    (local.set $x (i32.const 1))
+    #|    (block
+    #|      (block
+    #|        (if (local.get 0) (then (local.set $x (i32.const 99))))
+    #|      )
+    #|    )
+    #|    (local.get $x)
+    #|  )
+    #|)
+  for arg in [0, 1] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// A loop-carried counter and a loop-invariant local in the same loop: one
+/// needs a header parameter, the other must not lose its value to the absence
+/// of one.
+test "local_threading_loop_carried_and_invariant" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $i i32) (local $sum i32) (local $step i32)
+    #|    (local.set $step (i32.const 3))
+    #|    (block $done
+    #|      (loop $again
+    #|        (br_if $done (i32.ge_s (local.get $i) (local.get 0)))
+    #|        (local.set $sum (i32.add (local.get $sum) (local.get $step)))
+    #|        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+    #|        (br $again)
+    #|      )
+    #|    )
+    #|    (i32.add (local.get $sum) (local.get $step))
+    #|  )
+    #|)
+  for arg in [0, 1, 5] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// `br` out of a nested block carrying a local the outer region writes.
+test "local_threading_br_out_of_nest" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $x i32)
+    #|    (block $outer
+    #|      (block $inner
+    #|        (local.set $x (i32.const 11))
+    #|        (br_if $outer (local.get 0))
+    #|        (local.set $x (i32.const 22))
+    #|      )
+    #|      (local.set $x (i32.add (local.get $x) (i32.const 100)))
+    #|    )
+    #|    (local.get $x)
+    #|  )
+    #|)
+  for arg in [0, 1] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// `br_table` targets sit at different depths, so they no longer carry the
+/// same locals: `$inner` writes one, the regions above it write two. Each
+/// intermediate block builds its own argument list.
+test "local_threading_br_table_targets_differ" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $a i32) (local $b i32)
+    #|    (block $outer
+    #|      (block $mid
+    #|        (block $inner
+    #|          (local.set $a (i32.const 11))
+    #|          (br_table $inner $mid $outer (local.get 0))
+    #|        )
+    #|        (local.set $b (i32.const 22))
+    #|      )
+    #|      (local.set $b (i32.add (local.get $b) (i32.const 3)))
+    #|    )
+    #|    (i32.add (local.get $a) (local.get $b))
+    #|  )
+    #|)
+  for arg in [0, 1, 2, 7] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// A branch to function level goes through the return continuation, which
+/// carries no locals at all -- it only returns the result values. The locals
+/// written before the branch must not be needed on that edge.
+test "local_threading_branch_to_function_level" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $x i32)
+    #|    (local.set $x (i32.const 4))
+    #|    (block (result i32)
+    #|      (local.set $x (i32.const 8))
+    #|      (br_if 1 (i32.const 77) (local.get 0))
+    #|      (drop)
+    #|      (local.set $x (i32.const 9))
+    #|      (local.get $x)
+    #|    )
+    #|  )
+    #|)
+  for arg in [0, 1] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// `br_table` reaching function level alongside an in-function target: the
+/// return continuation takes results only, the block target takes its locals.
+test "local_threading_br_table_to_function_level" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $x i32)
+    #|    (block $b (result i32)
+    #|      (local.set $x (i32.const 6))
+    #|      (br_table $b 1 (i32.const 55) (local.get 0))
+    #|    )
+    #|    (i32.add (local.get $x))
+    #|  )
+    #|)
+  for arg in [0, 1, 3] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// A catch handler branches to a label outside the try, and has to supply that
+/// label's locals from the values restored out of spill storage.
+test "local_threading_catch_branch_carries_locals" {
+  let source =
+    #|(module
+    #|  (tag $e)
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $x i32)
+    #|    (local.set $x (i32.const 3))
+    #|    (block $h
+    #|      (try_table (catch $e $h)
+    #|        (local.set $x (i32.const 30))
+    #|        (if (local.get 0) (then (throw $e)))
+    #|        (local.set $x (i32.add (local.get $x) (i32.const 1)))
+    #|      )
+    #|    )
+    #|    (local.get $x)
+    #|  )
+    #|)
+  for arg in [0, 1] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}
+
+///|
+/// Many locals across many merges with only one of them written, which is the
+/// shape #486 reports. Correctness here is what makes the parameter count in
+/// `wasm_frontend/local_threading_test.mbt` meaningful.
+test "local_threading_many_locals_sparse_writes" {
+  let source =
+    #|(module
+    #|  (func (export "f") (param i32) (result i32)
+    #|    (local $a i32) (local $b i32) (local $c i32) (local $d i32)
+    #|    (local $e i32) (local $f i32) (local $g i32) (local $h i32)
+    #|    (local.set $a (i32.const 1))
+    #|    (local.set $b (i32.const 2))
+    #|    (local.set $c (i32.const 3))
+    #|    (local.set $d (i32.const 4))
+    #|    (local.set $e (i32.const 5))
+    #|    (local.set $f (i32.const 6))
+    #|    (local.set $g (i32.const 7))
+    #|    (if (local.get 0) (then (local.set $h (i32.const 10))))
+    #|    (if (local.get 0) (then (local.set $h (i32.add (local.get $h) (i32.const 1)))))
+    #|    (if (local.get 0) (then (local.set $h (i32.add (local.get $h) (i32.const 1)))))
+    #|    (i32.add (local.get $h)
+    #|      (i32.add (i32.add (local.get $a) (local.get $b))
+    #|        (i32.add (i32.add (local.get $c) (local.get $d))
+    #|          (i32.add (i32.add (local.get $e) (local.get $f)) (local.get $g)))))
+    #|  )
+    #|)
+  for arg in [0, 1] {
+    let result = compare_jit_interp(source, "f", [I32(arg)])
+    inspect(result, content="matched")
+  }
+}

--- a/modules/wasmoon/wasm_frontend/ir/local_threading.mbt
+++ b/modules/wasmoon/wasm_frontend/ir/local_threading.mbt
@@ -1,0 +1,107 @@
+///|
+/// Which locals a control merge has to carry.
+///
+/// A merge block needs a parameter for a local only when the edges reaching it
+/// can disagree about that local's value. Every edge into a structured region's
+/// merge point leaves from inside that region, and every one of them starts
+/// from the state at the region's entry, so two edges can disagree only about a
+/// local the region writes. For any other local each edge carries the one value
+/// that flowed in, and a parameter for it would be a phi whose arguments are
+/// all the same value.
+///
+/// So a merge carries exactly the locals written somewhere in its region,
+/// nested regions included. That is a fact about the values, not a heuristic: a
+/// local outside the set provably cannot differ between predecessors, which is
+/// what lets the translator keep using the value it already holds instead of
+/// reading a parameter back.
+///
+/// This says nothing about locals that are written and then never read. That
+/// half needs whole-function liveness, `eliminate_dead_block_params` in
+/// `milkir` already computes it, and it can answer precisely what a pass over
+/// the region tree here could only approximate.
+
+///|
+/// Mark every local index written anywhere in `body`, nested regions included.
+/// `local.set` and `local.tee` are the only instructions that write a local.
+fn mark_written_locals(
+  body : Array[@types.Instruction],
+  written : Array[Bool],
+) -> Unit {
+  for instr in body {
+    match instr {
+      LocalSet(idx) | LocalTee(idx) =>
+        if idx >= 0 && idx < written.length() {
+          written[idx] = true
+        }
+      Block(_, inner) | Loop(_, inner) => mark_written_locals(inner, written)
+      If(_, then_body, else_body) => {
+        mark_written_locals(then_body, written)
+        mark_written_locals(else_body, written)
+      }
+      TryTable(_, _, inner) => mark_written_locals(inner, written)
+      _ => ()
+    }
+  }
+}
+
+///|
+/// The local indices a region's merge block carries, ascending, which is also
+/// the order they appear in the block's parameter list. `bodies` is every
+/// instruction sequence the region covers -- two of them for an `if`.
+fn Translator::region_local_params(
+  self : Translator,
+  bodies : Array[Array[@types.Instruction]],
+) -> Array[Int] {
+  let written = Array::make(self.locals.length(), false)
+  for body in bodies {
+    mark_written_locals(body, written)
+  }
+  let indices = []
+  for idx, is_written in written {
+    if is_written {
+      indices.push(idx)
+    }
+  }
+  indices
+}
+
+///|
+/// Give `block` one parameter per carried local, typed from the local it
+/// stands for. Call once, right after the block's explicit parameters.
+fn Translator::add_local_block_params(
+  self : Translator,
+  block : Block,
+  local_params : Array[Int],
+) -> Unit {
+  for idx in local_params {
+    self.builder.add_block_param(block, self.locals[idx].ty) |> ignore
+  }
+}
+
+///|
+/// Append the current value of each local the target block carries, in
+/// parameter order, to a branch's argument list.
+fn Translator::push_local_args(
+  self : Translator,
+  args : Array[Value],
+  local_params : Array[Int],
+) -> Unit {
+  for idx in local_params {
+    args.push(self.locals[idx])
+  }
+}
+
+///|
+/// Adopt a merge block's parameters as the current values of the locals it
+/// carries. Locals it does not carry are left alone: they hold the same value
+/// on every edge into the block, so the value already in hand is correct.
+fn Translator::adopt_local_params(
+  self : Translator,
+  block : Block,
+  local_params : Array[Int],
+  start : Int,
+) -> Unit {
+  for i, idx in local_params {
+    self.locals[idx] = block.params[start + i].0
+  }
+}

--- a/modules/wasmoon/wasm_frontend/ir/translator_control.mbt
+++ b/modules/wasmoon/wasm_frontend/ir/translator_control.mbt
@@ -4,7 +4,8 @@
 /// On-demand loading:
 /// - Support block params (multi-value extension)
 /// - Pass params to both then and else blocks
-/// - Pass all mutable locals through continuation for SSA phi nodes
+/// - Pass the locals either arm can redefine through the continuation as SSA
+///   phi nodes; see `region_local_params` for why the rest need none
 fn Translator::translate_if(
   self : Translator,
   block_type : @types.BlockType,
@@ -47,11 +48,10 @@ fn Translator::translate_if(
     self.builder.add_block_param(continuation, ty) |> ignore
   }
 
-  // Add continuation parameters for ALL locals (SSA phi nodes)
+  // Add continuation parameters for the locals either arm can redefine
+  let local_params = self.region_local_params([then_body, else_body])
   let local_param_start = result_types.length()
-  for loc in self.locals {
-    self.builder.add_block_param(continuation, loc.ty) |> ignore
-  }
+  self.add_local_block_params(continuation, local_params)
 
   // Branch with param values (only if not unreachable)
   // Note: pass params to both then and else blocks
@@ -80,6 +80,7 @@ fn Translator::translate_if(
   let frame : BlockFrame = {
     block: continuation,
     result_types,
+    local_params,
     stack_height: stack_height_after_params,
     has_predecessor: false,
   }
@@ -109,10 +110,7 @@ fn Translator::translate_if(
       args.push(self.pop())
     }
     args.rev_in_place()
-    // Pass locals
-    for loc in self.locals {
-      args.push(loc)
-    }
+    self.push_local_args(args, local_params)
     self.block_stack[frame_idx].has_predecessor = true
     self.builder.jump(continuation, args)
   } else if block.terminator is None {
@@ -149,10 +147,7 @@ fn Translator::translate_if(
       args.push(self.pop())
     }
     args.rev_in_place()
-    // Pass locals
-    for loc in self.locals {
-      args.push(loc)
-    }
+    self.push_local_args(args, local_params)
     self.block_stack[frame_idx].has_predecessor = true
     self.builder.jump(continuation, args)
   } else if block.terminator is None {
@@ -178,10 +173,8 @@ fn Translator::translate_if(
       self.push(continuation.params[i].0)
     }
 
-    // Update locals to use the continuation's phi values
-    for i, _loc in self.locals {
-      self.locals[i] = continuation.params[local_param_start + i].0
-    }
+    // Update the carried locals to use the continuation's phi values
+    self.adopt_local_params(continuation, local_params, local_param_start)
   }
 }
 
@@ -199,10 +192,7 @@ fn Translator::translate_br(self : Translator, depth : Int) -> Unit {
       args.push(self.pop())
     }
     args.rev_in_place()
-    // Always pass current local values
-    for loc in self.locals {
-      args.push(loc)
-    }
+    self.push_local_args(args, frame.local_params)
     self.mark_block_frame_reachable(idx)
     self.builder.jump(frame.block, args)
   } else if idx == -1 {
@@ -214,10 +204,6 @@ fn Translator::translate_br(self : Translator, depth : Int) -> Unit {
       args.push(self.pop())
     }
     args.rev_in_place()
-    // Always pass current local values
-    for loc in self.locals {
-      args.push(loc)
-    }
     self.builder.jump(ret_cont, args)
   }
   // After br, code is unreachable
@@ -248,10 +234,7 @@ fn Translator::translate_br_if(self : Translator, depth : Int) -> Unit {
       )
     }
 
-    // Always pass current local values
-    for loc in self.locals {
-      args.push(loc)
-    }
+    self.push_local_args(args, frame.local_params)
 
     // Branch: taken goes to intermediate block, not-taken falls through
     self.builder.brnz(cond, taken, fallthrough)
@@ -275,11 +258,6 @@ fn Translator::translate_br_if(self : Translator, depth : Int) -> Unit {
         self.func_result_types.length() +
         i],
       )
-    }
-
-    // Always pass current local values
-    for loc in self.locals {
-      args.push(loc)
     }
 
     // Branch: taken goes to intermediate block, not-taken falls through
@@ -321,10 +299,7 @@ fn Translator::translate_br_on_null(self : Translator, depth : Int) -> Unit {
       )
     }
 
-    // Always pass current local values
-    for loc in self.locals {
-      args.push(loc)
-    }
+    self.push_local_args(args, frame.local_params)
 
     // Branch: if null, go to taken block; otherwise fall through
     self.builder.brnz(is_null, taken, fallthrough)
@@ -347,9 +322,6 @@ fn Translator::translate_br_on_null(self : Translator, depth : Int) -> Unit {
         self.func_result_types.length() +
         i],
       )
-    }
-    for loc in self.locals {
-      args.push(loc)
     }
     self.builder.brnz(is_null, taken, fallthrough)
     self.builder.switch_to_block(taken)
@@ -392,10 +364,7 @@ fn Translator::translate_br_on_non_null(self : Translator, depth : Int) -> Unit 
     // Add the ref as the last value (the non-null ref being passed)
     args.push(ref_val)
 
-    // Always pass current local values
-    for loc in self.locals {
-      args.push(loc)
-    }
+    self.push_local_args(args, frame.local_params)
 
     // Branch: if NOT null (is_null == false), go to taken block; otherwise fall through
     // Since is_null is 1 if null, 0 if non-null, we branch to fallthrough if null
@@ -421,9 +390,6 @@ fn Translator::translate_br_on_non_null(self : Translator, depth : Int) -> Unit 
       )
     }
     args.push(ref_val)
-    for loc in self.locals {
-      args.push(loc)
-    }
     self.builder.brnz(is_null, fallthrough, taken)
     self.builder.switch_to_block(taken)
     self.builder.jump(ret_cont, args)
@@ -477,9 +443,7 @@ fn Translator::translate_br_on_cast(
       args.push(v)
     }
     args.push(cast_val)
-    for loc in self.locals {
-      args.push(loc)
-    }
+    self.push_local_args(args, frame.local_params)
     self.mark_block_frame_reachable(idx)
     self.builder.jump(frame.block, args)
     // Continue with fallthrough - push the original ref back
@@ -510,9 +474,6 @@ fn Translator::translate_br_on_cast(
       args.push(v)
     }
     args.push(cast_val)
-    for loc in self.locals {
-      args.push(loc)
-    }
     self.builder.jump(ret_cont, args)
     self.builder.switch_to_block(fallthrough)
     self.push(ref_val)
@@ -554,9 +515,7 @@ fn Translator::translate_br_on_cast_fail(
       args.push(v)
     }
     args.push(ref_val)
-    for loc in self.locals {
-      args.push(loc)
-    }
+    self.push_local_args(args, frame.local_params)
     // Branch: if NOT matches (matches == 0), go to taken; otherwise fall through
     // brnz branches if non-zero, so we invert: if matches, go to fallthrough
     self.builder.brnz(matches, fallthrough, taken)
@@ -590,9 +549,6 @@ fn Translator::translate_br_on_cast_fail(
       args.push(v)
     }
     args.push(ref_val)
-    for loc in self.locals {
-      args.push(loc)
-    }
     self.builder.brnz(matches, fallthrough, taken)
     self.builder.switch_to_block(taken)
     self.builder.jump(ret_cont, args)
@@ -619,37 +575,48 @@ fn Translator::translate_br_table(
 ) -> Unit {
   let index = self.pop()
 
-  // Helper to get target block and result types for a given depth
-  // Returns (target_block, result_types, is_function_level)
-  fn get_target(self : Translator, depth : Int) -> (Block, Array[Type], Bool) {
+  // Helper to get a target's block, result types, and carried locals for a
+  // given depth. The return continuation carries no locals.
+  // Returns (target_block, result_types, local_params)
+  fn get_target(
+    self : Translator,
+    depth : Int,
+  ) -> (Block, Array[Type], Array[Int]) {
     let idx = self.block_stack.length() - 1 - depth
     if idx >= 0 && idx < self.block_stack.length() {
       let frame = self.block_stack[idx]
       self.mark_block_frame_reachable(idx)
-      (frame.block, frame.result_types, false)
+      (frame.block, frame.result_types, frame.local_params)
     } else {
       // Function level
       let ret_cont = self.get_or_create_return_continuation()
-      (ret_cont, self.func_result_types, true)
+      (ret_cont, self.func_result_types, [])
     }
   }
 
   // Get default target info
-  let (default_block, default_result_types, _) = get_target(self, default_)
+  let (default_block, default_result_types, default_local_params) = get_target(
+    self, default_,
+  )
 
-  // Collect arguments that would be passed on branch (same for all targets)
-  // All targets must have the same result type as the default
-  let args : Array[Value] = []
+  // The explicit results are the same for every target -- all targets share the
+  // default's result type. The locals are not: each target carries only what
+  // its own region can redefine, so every target builds its own argument list
+  // off this shared prefix.
+  let result_args : Array[Value] = []
   let num_results = default_result_types.length()
   // Only collect results if we have enough values on the stack
   if self.value_stack.length() >= num_results {
     for i in 0..<num_results {
-      args.push(self.value_stack[self.value_stack.length() - num_results + i])
+      result_args.push(
+        self.value_stack[self.value_stack.length() - num_results + i],
+      )
     }
   }
-  // Always pass current local values
-  for loc in self.locals {
-    args.push(loc)
+  fn target_args(self : Translator, local_params : Array[Int]) -> Array[Value] {
+    let args = result_args.copy()
+    self.push_local_args(args, local_params)
+    args
   }
 
   // Phase 1: Create intermediate blocks for unique target depths.
@@ -684,14 +651,14 @@ fn Translator::translate_br_table(
     guard depth_to_intermediate.get(depth) is Some(intermediate) else {
       continue
     }
-    let (target_block, _, _) = get_target(self, depth)
+    let (target_block, _, local_params) = get_target(self, depth)
     self.builder.switch_to_block(intermediate)
-    self.builder.jump(target_block, args)
+    self.builder.jump(target_block, target_args(self, local_params))
   }
 
   // Fill in default intermediate
   self.builder.switch_to_block(default_intermediate)
-  self.builder.jump(default_block, args)
+  self.builder.jump(default_block, target_args(self, default_local_params))
 
   // br_table is a terminator, code after it is unreachable
   // Don't switch back to original - leave current_block as the last intermediate

--- a/modules/wasmoon/wasm_frontend/ir/translator_core.mbt
+++ b/modules/wasmoon/wasm_frontend/ir/translator_core.mbt
@@ -68,6 +68,10 @@ priv struct Translator {
 priv struct BlockFrame {
   block : Block // The continuation block
   result_types : Array[Type]
+  // Local indices the block carries as parameters, in parameter order, from
+  // `region_local_params`. A branch to this frame supplies one argument per
+  // entry after the explicit results.
+  local_params : Array[Int]
   // Stack height at block entry
   stack_height : Int
   mut has_predecessor : Bool
@@ -812,9 +816,6 @@ fn Translator::translate(
         }
       }
       args.rev_in_place()
-      for loc in self.locals {
-        args.push(loc)
-      }
       self.builder.jump(ret_cont, args)
     } else {
       // No one jumped to function level, just return directly
@@ -848,13 +849,13 @@ fn Translator::get_or_create_return_continuation(self : Translator) -> Block {
     Some(block) => block
     None => {
       let ret_cont = self.builder.create_block()
-      // Add block parameters for function results
+      // Add block parameters for function results.
+      //
+      // No local parameters: this block only returns the result values, so a
+      // local threaded into it could never be read. Every branch to function
+      // level therefore passes results and nothing else.
       for ty in self.func_result_types {
         self.builder.add_block_param(ret_cont, ty) |> ignore
-      }
-      // Add block parameters for ALL locals (SSA phi nodes)
-      for loc in self.locals {
-        self.builder.add_block_param(ret_cont, loc.ty) |> ignore
       }
       self.return_continuation = Some(ret_cont)
       ret_cont
@@ -881,19 +882,16 @@ fn Translator::emit_catch_branch(
   // This is required so that throw_ref doesn't loop back to the same handler
   @wasm_milkir.try_table_end(self.builder, handler_id)
 
-  // Also pass current local values (for SSA correctness)
-  for loc in self.locals {
-    args.push(loc)
-  }
-
   // Branch to the handler label
   let idx = self.block_stack.length() - 1 - label_depth
   if idx >= 0 && idx < self.block_stack.length() {
     let frame = self.block_stack[idx]
+    // Also pass the locals the handler's block carries (for SSA correctness)
+    self.push_local_args(args, frame.local_params)
     self.mark_block_frame_reachable(idx)
     self.builder.jump(frame.block, args)
   } else {
-    // Function-level branch
+    // Function-level branch, which carries no locals
     let ret_cont = self.get_or_create_return_continuation()
     self.builder.jump(ret_cont, args)
   }
@@ -921,15 +919,11 @@ fn Translator::emit_catch_ref_branch(
   // Pop the exception handler AFTER reading values
   @wasm_milkir.try_table_end(self.builder, handler_id)
 
-  // Also pass current local values
-  for loc in self.locals {
-    args.push(loc)
-  }
-
   // Branch to the handler label
   let idx = self.block_stack.length() - 1 - label_depth
   if idx >= 0 && idx < self.block_stack.length() {
     let frame = self.block_stack[idx]
+    self.push_local_args(args, frame.local_params)
     self.mark_block_frame_reachable(idx)
     self.builder.jump(frame.block, args)
   } else {
@@ -951,15 +945,11 @@ fn Translator::emit_catch_all_branch(
   // catch_all doesn't pass exception values, just branches
   let args : Array[Value] = []
 
-  // Pass current local values
-  for loc in self.locals {
-    args.push(loc)
-  }
-
   // Branch to the handler label
   let idx = self.block_stack.length() - 1 - label_depth
   if idx >= 0 && idx < self.block_stack.length() {
     let frame = self.block_stack[idx]
+    self.push_local_args(args, frame.local_params)
     self.mark_block_frame_reachable(idx)
     self.builder.jump(frame.block, args)
   } else {
@@ -984,15 +974,11 @@ fn Translator::emit_catch_all_ref_branch(
   let exnref_i64 = self.builder.sextend(I64, exnref)
   args.push(self.builder.bitcast(Ref, exnref_i64))
 
-  // Pass current local values
-  for loc in self.locals {
-    args.push(loc)
-  }
-
   // Branch to the handler label
   let idx = self.block_stack.length() - 1 - label_depth
   if idx >= 0 && idx < self.block_stack.length() {
     let frame = self.block_stack[idx]
+    self.push_local_args(args, frame.local_params)
     self.mark_block_frame_reachable(idx)
     self.builder.jump(frame.block, args)
   } else {
@@ -1267,9 +1253,11 @@ fn Translator::translate_simd_store_lane(
 ///|
 /// Translate a block construct
 ///
-/// For proper SSA form, we need to pass all mutable locals through the
-/// continuation block as parameters. This ensures locals modified inside the
-/// block (or nested loops) are properly threaded through phi nodes.
+/// For proper SSA form, the locals the body writes -- nested regions included
+/// -- are threaded through the continuation block as parameters, so a value
+/// modified inside the block reaches the code after it as a phi. Locals the
+/// body never writes hold the same value on every edge into the continuation
+/// and get no parameter; `region_local_params` states the invariant.
 fn Translator::translate_block(
   self : Translator,
   block_type : @types.BlockType,
@@ -1297,16 +1285,16 @@ fn Translator::translate_block(
     self.builder.add_block_param(continuation, ty) |> ignore
   }
 
-  // Add block parameters for ALL locals (SSA phi nodes)
+  // Add block parameters for the locals the body can redefine
+  let local_params = self.region_local_params([body])
   let local_param_start = result_types.length()
-  for loc in self.locals {
-    self.builder.add_block_param(continuation, loc.ty) |> ignore
-  }
+  self.add_local_block_params(continuation, local_params)
 
   // Push block frame
   let frame : BlockFrame = {
     block: continuation,
     result_types,
+    local_params,
     stack_height: stack_height_after_params,
     has_predecessor: false,
   }
@@ -1336,10 +1324,8 @@ fn Translator::translate_block(
       args.push(self.pop())
     }
     args.rev_in_place()
-    // Then, all locals
-    for loc in self.locals {
-      args.push(loc)
-    }
+    // Then, the carried locals
+    self.push_local_args(args, local_params)
     self.block_stack[frame_idx].has_predecessor = true
     self.builder.jump(continuation, args)
   }
@@ -1369,18 +1355,18 @@ fn Translator::translate_block(
       self.push(continuation.params[i].0)
     }
 
-    // Update locals to use the continuation's phi values
-    for i, _loc in self.locals {
-      self.locals[i] = continuation.params[local_param_start + i].0
-    }
+    // Update the carried locals to use the continuation's phi values
+    self.adopt_local_params(continuation, local_params, local_param_start)
   }
 }
 
 ///|
 /// Translate a loop construct
 ///
-/// For proper SSA form, we need to pass all mutable locals through the loop
-/// header as parameters. This creates phi nodes for loop-carried variables.
+/// For proper SSA form, the locals the body writes are threaded through the
+/// loop header as parameters, which is what makes them loop-carried. A local
+/// the body never writes has the same value on the entry edge and every back
+/// edge, so it needs no parameter; see `region_local_params`.
 fn Translator::translate_loop(
   self : Translator,
   block_type : @types.BlockType,
@@ -1398,11 +1384,11 @@ fn Translator::translate_loop(
     self.builder.add_block_param(loop_header, ty) |> ignore
   }
 
-  // Add loop header parameters for ALL locals (SSA phi nodes for loop-carried values)
+  // Add loop header parameters for the locals the body can redefine, which are
+  // exactly the ones a back edge can disagree with the entry edge about
+  let local_params = self.region_local_params([body])
   let local_param_start = param_types.length()
-  for loc in self.locals {
-    self.builder.add_block_param(loop_header, loc.ty) |> ignore
-  }
+  self.add_local_block_params(loop_header, local_params)
 
   // Add continuation parameters for results
   for ty in result_types {
@@ -1418,10 +1404,8 @@ fn Translator::translate_loop(
       header_args.push(self.pop())
     }
     header_args.rev_in_place()
-    // Then, all locals
-    for loc in self.locals {
-      header_args.push(loc)
-    }
+    // Then, the loop-carried locals
+    self.push_local_args(header_args, local_params)
     self.builder.jump(loop_header, header_args)
   }
 
@@ -1437,16 +1421,14 @@ fn Translator::translate_loop(
     self.push(loop_header.params[i].0)
   }
 
-  // Update locals to use the loop header's phi values
-  for i, _loc in self.locals {
-    self.locals[i] = loop_header.params[local_param_start + i].0
-  }
+  // Update the loop-carried locals to use the loop header's phi values
+  self.adopt_local_params(loop_header, local_params, local_param_start)
 
   // Push block frame (br targets loop header for loops)
-  // Store local_param_start so br can pass locals too
   let frame : BlockFrame = {
     block: loop_header, // Loop's br target is the header
     result_types: param_types, // For br, we need params not results
+    local_params,
     stack_height: self.value_stack.length(),
     has_predecessor: false,
   }

--- a/modules/wasmoon/wasm_frontend/local_threading_test.mbt
+++ b/modules/wasmoon/wasm_frontend/local_threading_test.mbt
@@ -1,0 +1,145 @@
+///|
+/// How many locals a control merge carries (#486 item 1).
+///
+/// The frontend used to give every merge one parameter per local, so a function
+/// with L locals and M merges built L*M merge parameters regardless of what the
+/// merges did with them. These pin the property that replaced it: a merge
+/// carries the locals its region writes and nothing else, so the count follows
+/// the writes instead of the product.
+///
+/// The counts here are of parameters the translator emits, before any
+/// optimization. That is the number that matters for #486, because it is what
+/// the translator has to build and hold before an optimizer ever sees it.
+
+///|
+fn count_block_params(func : @milkir.Function) -> Int {
+  let mut total = 0
+  for block in func.blocks {
+    total = total + block.params.length()
+  }
+  total
+}
+
+///|
+/// A function of `num_locals` i32 locals whose body is `num_merges` sequential
+/// `if`s, each writing the first `written_per_merge` of them. The locals are
+/// the function's parameters, which is what the translator threads.
+fn locals_by_merges(
+  num_locals : Int,
+  num_merges : Int,
+  written_per_merge : Int,
+) -> @types.Module {
+  let params : Array[@types.ValueType] = []
+  for _ in 0..<num_locals {
+    params.push(I32)
+  }
+  let body : Array[@types.Instruction] = []
+  for _ in 0..<num_merges {
+    let then_body : Array[@types.Instruction] = []
+    for i in 0..<written_per_merge {
+      then_body.push(I32Const(1))
+      then_body.push(LocalSet(i))
+    }
+    body.push(LocalGet(0))
+    body.push(If(Empty, then_body, []))
+  }
+  @types.Module::simple(params, [], body, "run")
+}
+
+///|
+/// Merge parameters beyond what the function's own entry block carries, so the
+/// signature contributes nothing to the comparison.
+fn merge_params(num_locals : Int, num_merges : Int, written : Int) -> Int raise {
+  let baseline = count_block_params(
+    translate_function(native_test_env(), locals_by_merges(num_locals, 0, 0), 0),
+  )
+  let func = translate_function(
+    native_test_env(),
+    locals_by_merges(num_locals, num_merges, written),
+    0,
+  )
+  @wasm_milkir.verify_function(func)
+  count_block_params(func) - baseline
+}
+
+///|
+/// 32 locals across 24 merges, one local written per merge. Threading every
+/// local would build 32 * 24 = 768 parameters; only the written one needs to
+/// cross each merge, so 24 do.
+test "sparse writes cost one merge parameter each, not the product" {
+  inspect(merge_params(32, 24, 1), content="24")
+}
+
+///|
+/// The same shape with every local written keeps the full product, which is
+/// the point: the parameters that disappeared were the ones no edge could
+/// disagree about, not ones the merge needed.
+test "dense writes still cost the full product" {
+  inspect(merge_params(32, 24, 32), content="768")
+}
+
+///|
+/// Growth in the number of merges stays linear in what they write rather than
+/// in the local count, which is the sub-product property #486 asks for.
+test "merge parameters track writes, not locals times merges" {
+  inspect(merge_params(64, 8, 1), content="8")
+  inspect(merge_params(64, 16, 1), content="16")
+  inspect(merge_params(64, 16, 2), content="32")
+}
+
+///|
+/// A merge whose region writes nothing carries nothing: the value in hand is
+/// already correct on every edge into the continuation.
+test "a region that writes no local carries no local" {
+  inspect(merge_params(32, 24, 0), content="0")
+}
+
+///|
+/// A write buried in a nested region still reaches every enclosing merge,
+/// since a branch out of the nest can carry it past all of them.
+test "a nested write reaches every enclosing merge" {
+  let inner : Array[@types.Instruction] = [I32Const(1), LocalSet(3)]
+  let mod_ = @types.Module::simple(
+    [I32, I32, I32, I32],
+    [],
+    [Block(Empty, [Block(Empty, [Loop(Empty, inner)])])],
+    "nested",
+  )
+  let func = translate_function(native_test_env(), mod_, 0)
+  @wasm_milkir.verify_function(func)
+  let baseline = count_block_params(
+    translate_function(
+      native_test_env(),
+      @types.Module::simple([I32, I32, I32, I32], [], [], "nested"),
+      0,
+    ),
+  )
+  // One parameter on each of the two block continuations and the loop header,
+  // for the single local written at the bottom.
+  inspect(count_block_params(func) - baseline, content="3")
+}
+
+///|
+/// An `if` merges both arms, so a local either arm writes has to cross even
+/// though no single arm writes both.
+test "an if carries what either arm writes" {
+  let mod_ = @types.Module::simple(
+    [I32, I32, I32],
+    [],
+    [
+      LocalGet(0),
+      If(Empty, [I32Const(1), LocalSet(1)], [I32Const(2), LocalSet(2)]),
+    ],
+    "either_arm",
+  )
+  let func = translate_function(native_test_env(), mod_, 0)
+  @wasm_milkir.verify_function(func)
+  let baseline = count_block_params(
+    translate_function(
+      native_test_env(),
+      @types.Module::simple([I32, I32, I32], [], [], "either_arm"),
+      0,
+    ),
+  )
+  inspect(count_block_params(func) - baseline, content="2")
+}


### PR DESCRIPTION
Closes the first of #486's three items: the frontend gave every structured
merge one block parameter per local and made every branch pass the whole local
vector, so a function with L locals and M merges built L*M merge parameters
regardless of what the merges did with them.

## The invariant

A merge needs a parameter for a local only when the edges reaching it can
disagree about its value. Every edge into a structured region's merge leaves
from inside that region and starts from the state at the region's entry, so two
edges can disagree only about a local the region **writes**. For anything else
each edge carries the one value that flowed in, and the parameter would be a
phi whose arguments are all the same value.

This is stated as a property of the values, which is what the issue asked for —
not as a hint with an optimizer expected to clean up after it. `region_local_params`
computes the set by walking the region for `local.set`/`local.tee`, nested
regions included, and `BlockFrame` carries it so branches supply exactly those
arguments.

The complementary half — a local that is written and then never read — is left
to `eliminate_dead_block_params`, which already exists in `milkir` and has
whole-function liveness. A pass over the region tree here could only approximate
what it answers exactly.

## Two things fell out

**The return continuation drops its local parameters entirely.** It only emits
`return_` over the result parameters, so a local threaded into it could never be
read. All ten-odd branches to function level were passing the whole local vector
into a block that ignored it.

**`br_table` needed restructuring.** It built one argument list and reused it for
every target, which stops working once targets at different depths carry
different locals. Each intermediate block now builds its own list off the shared
result prefix.

Net −51 lines in the two translator files.

## Measured

| | before | after |
|---|---|---|
| 32 locals × 24 merges, 1 written per merge | 768 merge params | **24** |
| 32 locals × 24 merges, all written | 768 | 768 (unchanged, correctly) |
| 58 real `.wat` modules (`examples/`, `scripts/smith_diff/`) | 388 block params | **65** |

The dense row is the control: the parameters that disappeared are the ones no
edge could disagree about, not ones a merge needed. The real-module count is over
the same 523 blocks in both builds.

## Tests

`modules/wasmoon/wasm_frontend/local_threading_test.mbt` — six tests pinning
exact parameter counts, including the dense control and the nested-write case.
I verified these are live by breaking one expectation and confirming it reported
the real value.

`modules/wasmoon/testsuite/local_threading_test.mbt` — eleven end-to-end cases
run through both the JIT and the interpreter and required to agree: writes in one
arm, in either arm, in neither; nested-block escape; loop-carried vs
loop-invariant; `br` out of a nest; `br_table` with targets at differing depths;
branches to function level; a catch handler supplying an outer label's locals.
A local wrongly dropped from a merge surfaces here as a disagreement rather than
a compile error, which is the failure mode that matters.

Full run: 62563 wast assertions in both modes across 258/258 corpus files,
1606/1606 native tests, CLI behaviour checks exit 0.

## One pre-existing failure, not from this change

`milkir`'s `egraph survives a deep dominator spine` overflows the stack on the
**wasm-gc** backend (`postorder_visit` recursion in `cfg.mbt`). It reproduces
identically with these changes stashed. Native is unaffected. Worth its own
issue; not touched here.

## What this does not do

My earlier measurement said this is not the lever behind #486's reported
26× MilkIR→VCode expansion, and this change does not contradict that — merge
parameters were never the code-size driver, and the report's own data shows zero
surviving parameters after O2. What it does address is the acceptance criterion
as written ("control merges no longer add and pass every local unconditionally")
and the translator's transient cost, which is where the report's
`next_value_id = 514,639` lives. I have not measured transient SSA directly, so
I am not claiming a number there.

Items 3 (a wasm-level case that actually overflows imm19) and the unexplained
expansion remain open.