### PR TITLE
Patch-bump the three modules changed since 0.11.0

### DIFF
--- a/modules/aarch64_target/moon.mod
+++ b/modules/aarch64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/aarch64_target"
 
-version = "0.5.0"
+version = "0.5.1"
 
 readme = "README.mbt.md"
 

--- a/modules/wasmoon/cmd/wasmoon/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon/main.mbt
@@ -3,7 +3,7 @@
 /// by `scripts/tests/test_cli_version.py`. MoonBit gives the program no way
 /// to read its own module manifest, so the manifest stays the single source
 /// of truth and the test is what keeps this copy from drifting.
-const WASMOON_VERSION : String = "0.11.0"
+const WASMOON_VERSION : String = "0.11.1"
 
 ///|
 fn clap_parser(

--- a/modules/wasmoon/moon.mod
+++ b/modules/wasmoon/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasmoon"
 
-version = "0.11.0"
+version = "0.11.1"
 
 import {
   "moonbitlang/x@0.4.38",
@@ -12,8 +12,8 @@ import {
   "Milky2018/milkir_machv@0.6.0",
   "Milky2018/machv_regalloc@0.5.0",
   "Milky2018/x64_target@0.4.0",
-  "Milky2018/aarch64_target@0.5.0",
-  "Milky2018/wasmoon_jit@0.6.0",
+  "Milky2018/aarch64_target@0.5.1",
+  "Milky2018/wasmoon_jit@0.6.1",
   "moonbitlang/async@0.20.3",
 }
 

--- a/modules/wasmoon_jit/moon.mod
+++ b/modules/wasmoon_jit/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasmoon_jit"
 
-version = "0.6.0"
+version = "0.6.1"
 
 readme = "README.mbt.md"
 
@@ -21,7 +21,7 @@ import {
   "Milky2018/machv@0.7.0",
   "Milky2018/milkir_machv@0.6.0",
   "Milky2018/machv_regalloc@0.5.0",
-  "Milky2018/aarch64_target@0.5.0",
+  "Milky2018/aarch64_target@0.5.1",
   "Milky2018/x64_target@0.4.0",
 }
 


### PR DESCRIPTION
Prepares a patch release for the two modules that changed since 0.11.0.

| module | | reason |
|---|---|---|
| `aarch64_target` | 0.5.0 → **0.5.1** | long-range conditional branch form (#487) |
| `wasmoon_jit` | 0.6.0 → **0.6.1** | unchanged; repins `aarch64_target` |
| `wasmoon` | 0.11.0 → **0.11.1** | pruned local threading (#488), repins both |

The other nine modules are untouched in content and in dependencies, so they
keep their versions. Giving them a patch release that differs from its
predecessor only by the number would add noise to mooncakes.io and churn to
every pin that references them.

`WASMOON_VERSION` in `cmd/wasmoon/main.mbt` moves with the manifest — that copy
exists because MoonBit gives the program no way to read its own manifest, and
`scripts/tests/test_cli_version.py` is what keeps it from drifting.

Verified locally: `moon check`, `moon build`, `./wasmoon --version` reports
`0.11.1`, CLI behaviour checks exit 0, and both version-pin tests pass under
`python3 -m unittest` (pytest is not installed on this machine, which is why
the pytest invocation fails — not the tests).

Publishing to mooncakes.io follows once this merges, in dependency order with
`moon update` between each: `aarch64_target` → `wasmoon_jit` → `wasmoon`.