### PR TITLE
Route every range-limited branch through the fixup path (#486)

### DIFF
--- a/modules/aarch64_target/emit.mbt
+++ b/modules/aarch64_target/emit.mbt
@@ -22,9 +22,22 @@ fn trap_brk_payload(reason : @semantic.TrapReason) -> UInt {
 }
 
 ///|
+/// Where a branch lands.
+///
+/// Blocks resolve through `block_offsets` once the whole function is laid out.
+/// Labels are positions inside the emission that no block begins at: the join
+/// after an edge's parallel moves, the point a switch case's stub falls to.
+/// Both go through the same fixup list, which is what lets either be widened
+/// when it turns out not to reach.
+priv enum FixupTarget {
+  ToBlock(@vcode.Block)
+  ToLabel(Int)
+}
+
+///|
 priv struct BranchFixup {
   offset : Int
-  target : @vcode.Block
+  target : FixupTarget
   bits : Int
   // Two words were reserved here instead of one, so the patch may spend the
   // second on a long-range form. See `CodeBuffer::long_branches`.
@@ -35,6 +48,8 @@ priv struct BranchFixup {
 priv struct CodeBuffer {
   code : Array[Byte]
   fixups : Array[BranchFixup]
+  // Position of each local label, -1 until bound.
+  labels : Array[Int]
   relocations : Array[@code_object.Relocation]
   // Reserve a second word after every conditional branch, so one whose target
   // turns out to be beyond imm19's +/-1MB can be rewritten as an inverted
@@ -62,6 +77,8 @@ pub suberror AArch64EmitError {
   InvalidVectorInstruction
   InvalidConversionInstruction
   BranchTargetMissing(block~ : @vcode.Block)
+  BranchLabelUnbound(label~ : Int)
+  BranchSpanNotFixed(offset~ : Int)
   BranchOutOfRange(offset~ : Int, bits~ : Int)
 } derive(Debug)
 
@@ -72,7 +89,7 @@ pub impl Show for AArch64EmitError with fn output(self, logger) {
 
 ///|
 fn CodeBuffer::new(long_branches? : Bool = false) -> CodeBuffer {
-  { code: [], fixups: [], relocations: [], long_branches }
+  { code: [], fixups: [], labels: [], relocations: [], long_branches }
 }
 
 ///|
@@ -130,20 +147,64 @@ fn CodeBuffer::patch_word(self : CodeBuffer, offset : Int, word : UInt) -> Unit 
 }
 
 ///|
-fn CodeBuffer::emit_branch(
+/// Reserve a label whose position is filled in by `bind_label`.
+fn CodeBuffer::new_label(self : CodeBuffer) -> Int {
+  self.labels.push(-1)
+  self.labels.length() - 1
+}
+
+///|
+/// Fix `label` at the current position. Branches to it may already have been
+/// emitted; they are patched with the rest at the end of the function.
+fn CodeBuffer::bind_label(self : CodeBuffer, label : Int) -> Unit {
+  self.labels[label] = self.position()
+}
+
+///|
+/// Emit a branch whose displacement is filled in later.
+///
+/// Every relative branch that can be out of range goes through here, because
+/// widening one is only possible if the second word was reserved when the
+/// branch was emitted -- a patch applied later has nowhere to put it. Emitting
+/// a bare word and patching it directly leaves a branch that can only ever be
+/// short, which is what made `br_table` fail on large functions even with
+/// `long_branches` on.
+fn CodeBuffer::emit_fixup_branch(
   self : CodeBuffer,
-  target : @vcode.Block,
+  target : FixupTarget,
   bits : Int,
   base : UInt,
 ) -> Unit {
   let offset = self.position()
   self.emit_word(base)
   // Only imm19 can overflow within a function; `b` already reaches +/-128MB.
+  // Keeping imm26 to one word also holds the jump table's stride, which the
+  // `adr`/`add`/`br` sequence indexes as one instruction per case.
   let wide = bits == 19 && self.long_branches
   if wide {
     self.emit_word(AARCH64_NOP)
   }
   self.fixups.push({ offset, target, bits, wide })
+}
+
+///|
+fn CodeBuffer::emit_branch(
+  self : CodeBuffer,
+  target : @vcode.Block,
+  bits : Int,
+  base : UInt,
+) -> Unit {
+  self.emit_fixup_branch(ToBlock(target), bits, base)
+}
+
+///|
+fn CodeBuffer::emit_label_branch(
+  self : CodeBuffer,
+  label : Int,
+  bits : Int,
+  base : UInt,
+) -> Unit {
+  self.emit_fixup_branch(ToLabel(label), bits, base)
 }
 
 ///|
@@ -539,7 +600,7 @@ fn emit_atomic_rmw(
   )
   let retry = buffer.position()
   buffer.emit_word(0x35000000U | reg_bits(status))
-  patch_relative_branch(buffer, retry, loop_offset, 19)
+  patch_fixed_span_branch(buffer, retry, loop_offset, 19)
   loop_offset
 }
 
@@ -583,7 +644,7 @@ fn emit_atomic_compare_exchange(
   )
   let retry = buffer.position()
   buffer.emit_word(0x35000000U | reg_bits(status))
-  patch_relative_branch(buffer, retry, loop_offset, 19)
+  patch_fixed_span_branch(buffer, retry, loop_offset, 19)
   loop_offset
 }
 
@@ -3532,10 +3593,22 @@ fn patch_branches(
   block_offsets : Array[Int],
 ) -> Unit raise AArch64EmitError {
   for fixup in buffer.fixups {
-    let block_index = function.block_index(fixup.target).unwrap()
-    let target = block_offsets[block_index]
-    if target < 0 {
-      raise BranchTargetMissing(block=fixup.target)
+    let target = match fixup.target {
+      ToBlock(block) => {
+        let block_index = function.block_index(block).unwrap()
+        let offset = block_offsets[block_index]
+        if offset < 0 {
+          raise BranchTargetMissing(block~)
+        }
+        offset
+      }
+      ToLabel(label) => {
+        let offset = buffer.labels[label]
+        if offset < 0 {
+          raise BranchLabelUnbound(label~)
+        }
+        offset
+      }
     }
     if fixup.wide {
       patch_wide_conditional_branch(buffer, fixup.offset, target)
@@ -3576,6 +3649,34 @@ fn patch_wide_conditional_branch(
   patch_relative_branch(buffer, offset, offset + 8, 19)
   buffer.patch_word(offset + 4, AARCH64_BRANCH)
   patch_relative_branch(buffer, offset + 4, target, 26)
+}
+
+///|
+/// The longest span `patch_fixed_span_branch` accepts. A branch over a fixed
+/// instruction sequence is a handful of words; anything longer means the span
+/// grows with the program and the branch belongs on the fixup path.
+const FIXED_SPAN_LIMIT : Int = 64
+
+///|
+/// Patch a branch that skips a fixed number of instructions.
+///
+/// Anything whose distance depends on the program -- an edge's parallel moves,
+/// a switch's cases -- must go through `emit_fixup_branch` instead. Widening a
+/// branch spends a word reserved when the branch was emitted, so a branch
+/// patched directly can only ever be short, and a short branch that outgrows
+/// imm19 fails the whole compilation with no way to recover. The bound below
+/// is what keeps that distinction from being a matter of who read the comment.
+fn patch_fixed_span_branch(
+  buffer : CodeBuffer,
+  offset : Int,
+  target : Int,
+  bits : Int,
+) -> Unit raise AArch64EmitError {
+  let delta = target - offset
+  if delta > FIXED_SPAN_LIMIT || delta < -FIXED_SPAN_LIMIT {
+    raise BranchSpanNotFixed(offset=delta)
+  }
+  patch_relative_branch(buffer, offset, target, bits)
 }
 
 ///|

--- a/modules/aarch64_target/emit_edges.mbt
+++ b/modules/aarch64_target/emit_edges.mbt
@@ -173,11 +173,13 @@ fn emit_two_way_edges(
       buffer.emit_branch(threaded_true, 19, true_branch_base)
       emit_resolved_moves(buffer, frame, false_moves)
     } else {
-      let local_false_branch = buffer.position()
-      buffer.emit_word(false_branch_base)
+      // Skips the true edge's moves. The span is the size of those moves, so
+      // it is data-dependent and has to be able to widen.
+      let past_true_moves = buffer.new_label()
+      buffer.emit_label_branch(past_true_moves, 19, false_branch_base)
       emit_resolved_moves(buffer, frame, true_moves)
       buffer.emit_branch(threaded_true, 26, 0x14000000U)
-      patch_relative_branch(buffer, local_false_branch, buffer.position(), 19)
+      buffer.bind_label(past_true_moves)
       emit_resolved_moves(buffer, frame, false_moves)
     }
   } else if next_block == Some(when_true) {
@@ -185,11 +187,11 @@ fn emit_two_way_edges(
       buffer.emit_branch(threaded_false, 19, false_branch_base)
       emit_resolved_moves(buffer, frame, true_moves)
     } else {
-      let local_true_branch = buffer.position()
-      buffer.emit_word(true_branch_base)
+      let past_false_moves = buffer.new_label()
+      buffer.emit_label_branch(past_false_moves, 19, true_branch_base)
       emit_resolved_moves(buffer, frame, false_moves)
       buffer.emit_branch(threaded_false, 26, 0x14000000U)
-      patch_relative_branch(buffer, local_true_branch, buffer.position(), 19)
+      buffer.bind_label(past_false_moves)
       emit_resolved_moves(buffer, frame, true_moves)
     }
   } else if true_moves.is_empty() {
@@ -197,11 +199,11 @@ fn emit_two_way_edges(
     emit_resolved_moves(buffer, frame, false_moves)
     buffer.emit_branch(threaded_false, 26, 0x14000000U)
   } else {
-    let local_true_branch = buffer.position()
-    buffer.emit_word(true_branch_base)
+    let past_false_moves = buffer.new_label()
+    buffer.emit_label_branch(past_false_moves, 19, true_branch_base)
     emit_resolved_moves(buffer, frame, false_moves)
     buffer.emit_branch(threaded_false, 26, 0x14000000U)
-    patch_relative_branch(buffer, local_true_branch, buffer.position(), 19)
+    buffer.bind_label(past_false_moves)
     emit_resolved_moves(buffer, frame, true_moves)
     buffer.emit_branch(threaded_true, 26, 0x14000000U)
   }
@@ -308,9 +310,11 @@ fn emit_switch_edges(
       )
       None
     } else {
-      let branch = buffer.position()
-      buffer.emit_word(0x54000002U)
-      Some(branch)
+      // Reaches past the whole jump table and every stub below it, so on a
+      // switch with many cases this is the branch that outgrows imm19.
+      let past_table = buffer.new_label()
+      buffer.emit_label_branch(past_table, 19, 0x54000002U)
+      Some(past_table)
     }
     // The table begins three instructions after ADR. UXTW is required for an
     // I32 index so stale upper register bits cannot escape the bounds check.
@@ -341,13 +345,16 @@ fn emit_switch_edges(
           0x14000000U,
         )
       } else {
-        stubs.push((buffer.position(), successor_index))
-        buffer.emit_word(0x14000000U)
+        // One word, like every other table entry: the `adr`/`add`/`br` above
+        // indexes this table by instruction, so the stride cannot change.
+        let stub = buffer.new_label()
+        stubs.push((stub, successor_index))
+        buffer.emit_label_branch(stub, 26, 0x14000000U)
       }
     }
-    for stub in stubs {
-      let (branch, successor_index) = stub
-      patch_relative_branch(buffer, branch, buffer.position(), 26)
+    for entry in stubs {
+      let (stub, successor_index) = entry
+      buffer.bind_label(stub)
       emit_edge_moves(
         buffer, function, allocation, frame, block, successor_index,
       )
@@ -363,8 +370,8 @@ fn emit_switch_edges(
         0x14000000U,
       )
     }
-    if default_branch is Some(branch) {
-      patch_relative_branch(buffer, branch, buffer.position(), 19)
+    if default_branch is Some(label) {
+      buffer.bind_label(label)
       emit_resolved_moves(buffer, frame, default_moves)
       buffer.emit_branch(
         threaded_branch_target(
@@ -394,8 +401,11 @@ fn emit_switch_edges(
           0x54000000U,
         )
       } else {
-        case_branches.push((buffer.position(), successor_index))
-        buffer.emit_word(0x54000000U)
+        // Each of these reaches past every stub emitted before its own, so the
+        // last case in a large switch is the furthest reach in the function.
+        let stub = buffer.new_label()
+        case_branches.push((stub, successor_index))
+        buffer.emit_label_branch(stub, 19, 0x54000000U)
       }
     }
     emit_edge_moves(buffer, function, allocation, frame, block, cases.length())
@@ -409,8 +419,8 @@ fn emit_switch_edges(
       0x14000000U,
     )
     for entry in case_branches {
-      let (branch, successor_index) = entry
-      patch_relative_branch(buffer, branch, buffer.position(), 19)
+      let (stub, successor_index) = entry
+      buffer.bind_label(stub)
       emit_edge_moves(
         buffer, function, allocation, frame, block, successor_index,
       )

--- a/modules/aarch64_target/local_label_wbtest.mbt
+++ b/modules/aarch64_target/local_label_wbtest.mbt
@@ -1,0 +1,175 @@
+///|
+/// Branches to local labels (#486).
+///
+/// A branch can only be widened if the second word was reserved when it was
+/// emitted, so every relative branch that can outgrow imm19 has to go through
+/// `emit_fixup_branch`. Emitting a bare word and patching it directly gives a
+/// branch that is short forever: re-emitting with `long_branches` on does not
+/// help it, because there is still nowhere to put the long form.
+///
+/// That is what `emit_edges.mbt` used to do for the joins after an edge's
+/// parallel moves and for every `br_table` stub. Those spans grow with the
+/// program -- the switch ones with the number of cases -- so a large enough
+/// switch failed to compile no matter how many times emission was retried.
+///
+/// These cover the label path itself. That real `br_table` shapes still work
+/// once the reserved words are in place is covered by running the corpus with
+/// `emit_verified`'s `long_branches` default flipped to `true`, which forces
+/// every conditional branch through the wide form: 258/258 files and 62563
+/// assertions in both JIT and interpreter mode, on 2026-08-06.
+
+///|
+/// Resolve the label fixups in `buffer` the way `patch_branches` does.
+fn resolve_labels(buffer : CodeBuffer) -> Unit raise AArch64EmitError {
+  for fixup in buffer.fixups {
+    guard fixup.target is ToLabel(label) else { continue }
+    let target = buffer.labels[label]
+    if target < 0 {
+      raise BranchLabelUnbound(label~)
+    }
+    if fixup.wide {
+      patch_wide_conditional_branch(buffer, fixup.offset, target)
+    } else {
+      patch_relative_branch(buffer, fixup.offset, target, fixup.bits)
+    }
+  }
+}
+
+///|
+/// `b.eq`, condition 0000.
+const LABEL_TEST_BEQ : UInt = 0x54000000U
+
+///|
+/// A conditional branch to a label reserves its second word, which is the
+/// whole reason the label path exists.
+test "local label: an imm19 branch reserves a second word" {
+  let buffer = CodeBuffer::new(long_branches=true)
+  let label = buffer.new_label()
+  buffer.emit_label_branch(label, 19, LABEL_TEST_BEQ)
+  inspect(buffer.position(), content="8")
+  inspect(buffer.read_word(4) == AARCH64_NOP, content="true")
+}
+
+///|
+/// An imm26 branch does not, which is what holds a jump table's stride: the
+/// `adr`/`add`/`br` sequence indexes the table one instruction per case, so a
+/// stub entry gaining a word would send every case to the wrong place.
+test "local label: an imm26 branch stays one word even in wide mode" {
+  let buffer = CodeBuffer::new(long_branches=true)
+  for _ in 0..<4 {
+    let label = buffer.new_label()
+    buffer.emit_label_branch(label, 26, AARCH64_BRANCH)
+  }
+  inspect(buffer.position(), content="16")
+}
+
+///|
+/// Compact mode reserves nothing, so an ordinary function is the size it was.
+test "local label: compact mode reserves nothing" {
+  let buffer = CodeBuffer::new()
+  let label = buffer.new_label()
+  buffer.emit_label_branch(label, 19, LABEL_TEST_BEQ)
+  inspect(buffer.position(), content="4")
+}
+
+///|
+/// A label bound after the branch resolves to where it was bound.
+test "local label: a forward branch resolves to the bind point" {
+  let buffer = CodeBuffer::new()
+  let label = buffer.new_label()
+  buffer.emit_label_branch(label, 19, LABEL_TEST_BEQ)
+  for _ in 0..<5 {
+    buffer.emit_word(AARCH64_NOP)
+  }
+  buffer.bind_label(label)
+  resolve_labels(buffer)
+  // imm19 = 6 words on from the branch.
+  inspect(buffer.read_word(0) == (LABEL_TEST_BEQ | (6U << 5)), content="true")
+}
+
+///|
+/// The case #486 hits: the span past a switch's table and stubs runs beyond
+/// imm19, and because the word was reserved the branch can still be made.
+test "local label: a branch beyond imm19 takes the wide form" {
+  let buffer = CodeBuffer::new(long_branches=true)
+  let label = buffer.new_label()
+  buffer.emit_label_branch(label, 19, LABEL_TEST_BEQ)
+  let target = 1 << 21 // 2MB, past imm19's 1MB reach
+  while buffer.position() < target {
+    buffer.emit_word(AARCH64_NOP)
+  }
+  buffer.bind_label(label)
+  resolve_labels(buffer)
+  // b.ne +8, over the unconditional branch that carries the real distance.
+  inspect(
+    buffer.read_word(0) == ((LABEL_TEST_BEQ ^ 1U) | (2U << 5)),
+    content="true",
+  )
+  let from_b = (target - 4) / 4
+  inspect(
+    buffer.read_word(4) == (AARCH64_BRANCH | from_b.reinterpret_as_uint()),
+    content="true",
+  )
+}
+
+///|
+/// Without the reserved word the same span raises instead, which is the signal
+/// `emit` catches to re-emit in wide mode. Before the label path existed this
+/// raise came from a direct patch that the retry could not help, so the retry
+/// hit it again and the compilation failed.
+test "local label: compact mode reports the overflow rather than truncating" {
+  let buffer = CodeBuffer::new()
+  let label = buffer.new_label()
+  buffer.emit_label_branch(label, 19, LABEL_TEST_BEQ)
+  let target = 1 << 21
+  while buffer.position() < target {
+    buffer.emit_word(AARCH64_NOP)
+  }
+  buffer.bind_label(label)
+  let overflowed = try {
+    resolve_labels(buffer)
+    false
+  } catch {
+    BranchOutOfRange(_) => true
+    _ => false
+  }
+  inspect(overflowed, content="true")
+}
+
+///|
+/// A label nobody bound is a bug in the emitter, so it is reported rather than
+/// silently patched to offset zero.
+test "local label: an unbound label is reported" {
+  let buffer = CodeBuffer::new()
+  let label = buffer.new_label()
+  buffer.emit_label_branch(label, 19, LABEL_TEST_BEQ)
+  let unbound = try {
+    resolve_labels(buffer)
+    false
+  } catch {
+    BranchLabelUnbound(_) => true
+    _ => false
+  }
+  inspect(unbound, content="true")
+}
+
+///|
+/// Branches over a fixed instruction sequence stay on the direct path, and the
+/// bound is what keeps a data-dependent span from quietly joining them.
+test "fixed span: a short skip patches, a long one is rejected" {
+  let buffer = CodeBuffer::new()
+  buffer.emit_word(LABEL_TEST_BEQ)
+  for _ in 0..<40 {
+    buffer.emit_word(AARCH64_NOP)
+  }
+  patch_fixed_span_branch(buffer, 0, 16, 19)
+  inspect(buffer.read_word(0) == (LABEL_TEST_BEQ | (4U << 5)), content="true")
+  let rejected = try {
+    patch_fixed_span_branch(buffer, 0, 160, 19)
+    false
+  } catch {
+    BranchSpanNotFixed(_) => true
+    _ => false
+  }
+  inspect(rejected, content="true")
+}

--- a/modules/aarch64_target/pkg.generated.mbti
+++ b/modules/aarch64_target/pkg.generated.mbti
@@ -60,6 +60,8 @@ pub suberror AArch64EmitError {
   InvalidVectorInstruction
   InvalidConversionInstruction
   BranchTargetMissing(block~ : @vcode.Block)
+  BranchLabelUnbound(label~ : Int)
+  BranchSpanNotFixed(offset~ : Int)
   BranchOutOfRange(offset~ : Int, bits~ : Int)
 } derive(@debug.Debug)
 pub impl Show for AArch64EmitError


### PR DESCRIPTION
Fixes the defect a downstream user hit after #487: **the long-branch form only
ever covered branches that went through `CodeBuffer::emit_branch`.** Five sites
in `emit_edges.mbt` emitted a bare word and called `patch_relative_branch(...,
19)` directly, and those are precisely the ones whose span grows with the
program.

## Why the retry could not save them

Widening a conditional branch spends a word that has to be reserved **when the
branch is emitted**. A branch patched directly has nowhere to put the long form,
so it is short forever. The sequence was:

1. compact emission → a direct patch raises `BranchOutOfRange`
2. `emit` catches it and re-emits with `long_branches = true`
3. the same direct patch raises again — nothing about it changed
4. compilation fails

## The spans that actually grow

| site | reaches past |
|---|---|
| edge join | that edge's parallel moves |
| `br_table` default | the **entire jump table** and every stub below it |
| sparse `br_table` case | every stub emitted before its own |

The last one is O(N) in the number of cases, so in a switch with N cases the
final case branch is the furthest reach in the whole function. This is the
dictionary-dispatch shape the report describes.

## The fix

A branch target is now either a block or a **local label**, both carried in one
fixup list. `emit_fixup_branch` reserves for either, `patch_wide_conditional_branch`
widens either. There is one branch-emission path, so the class of bug is gone
rather than the instance.

imm26 deliberately stays one word — the jump table's `adr`/`add`/`br` indexes it
one instruction per case, and a stub gaining a word would send every case astray.

Two direct patches remain, the atomic retry loops, whose spans are 12 and 24
bytes of fixed sequence. They go through `patch_fixed_span_branch`, which
rejects anything past 64 bytes. **The distinction between a fixed span and a
data-dependent one is now enforced, not left to whoever reads the comment** —
that is what let the original bug in.

## Verification

The decisive run: `emit_verified`'s `long_branches` default forced to `true`, so
every conditional branch takes the wide form and every `br_table` carries
reserved words. **258/258 files, 62563 assertions, both JIT and interpreter.**
This is what covers the jump table stride — if a reserved word had landed inside
a table, every switch in the corpus would have failed.

Then normally: corpus 62563 again both modes, 1606/1606 native tests, 223/223
`aarch64_target` tests **including the golden-byte encodings, which are
unchanged** — compact mode emits exactly the same bytes as before. CLI behaviour
checks exit 0.

Eight new whitebox tests in `local_label_wbtest.mbt` cover reservation, the
imm26 one-word invariant, forward resolution, the wide form past imm19, the
overflow raise that triggers the retry, unbound labels, and the fixed-span bound.
I confirmed they are live by breaking one and checking it reported the real value.

## What is still not covered

I have not built a wasm module that actually drives a switch past imm19
end-to-end. Doing so needs roughly 40,000+ cases with edge moves, which is well
past what compiles in test time. So: the wide form is verified against real
`br_table`s at corpus scale, and the >1MB widening is verified at the buffer
level, but not the two joined in one wasm module. Saying so because that exact
seam is what made #487 look finished when it was not.

Items 1 and 2 of #486 are now addressed; item 3 and the unexplained 26×
MilkIR→VCode expansion remain open.