### PR TITLE
Update moonbitlang/x to 0.4.48 and move off its deprecated env API

### DIFF
--- a/issues/ISS-367.md
+++ b/issues/ISS-367.md
@@ -156,4 +156,9 @@ Do not disable UBSan for the whole sanitizer step.
   Its practical effect here was three consecutive red runs on `main`, which
   the removal also ends.
 
+- 2026-08-06: Checked the registry while updating the other dependencies.
+  `0.20.3` is still the newest `moonbitlang/async` release, so the pin cannot
+  move and this stays blocked on upstream. Recorded so the next dependency
+  sweep does not have to look it up again.
+
 ## Close Notes

--- a/modules/machv_regalloc/moon.mod
+++ b/modules/machv_regalloc/moon.mod
@@ -13,7 +13,7 @@ keywords = [ "compiler", "register-allocation", "machv", "jit" ]
 description = "Target VCode adapter for the reusable register allocator"
 
 import {
-  "moonbitlang/x@0.4.38",
+  "moonbitlang/x@0.4.48",
   "Milky2018/machv@0.7.0",
   "Milky2018/regalloc@0.6.0",
 }

--- a/modules/milkir_machv/moon.mod
+++ b/modules/milkir_machv/moon.mod
@@ -13,7 +13,7 @@ keywords = [ "compiler", "lowering", "isa", "codegen" ]
 description = "MilkIR-to-MachV lowering"
 
 import {
-  "moonbitlang/x@0.4.38",
+  "moonbitlang/x@0.4.48",
   "Milky2018/milkir@0.5.0",
   "Milky2018/machv@0.7.0",
 }

--- a/modules/wasmoon/cmd/wasmoon-tools/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon-tools/main.mbt
@@ -225,8 +225,8 @@ fn exit_error(msg : String) -> Unit {
 ///|
 fn read_file(path : String) -> Bytes {
   @fs.read_file_to_bytes(path) catch {
-    e => {
-      exit_error("reading file '\{path}': \{e}")
+    @fs.IOError(message) => {
+      exit_error("reading file '\{path}': \{message}")
       panic() // unreachable
     }
   }
@@ -235,14 +235,14 @@ fn read_file(path : String) -> Bytes {
 ///|
 fn write_text_file(path : String, content : String) -> Unit {
   @fs.write_string_to_file(path, content) catch {
-    e => exit_error("writing file '\{path}': \{e}")
+    @fs.IOError(message) => exit_error("writing file '\{path}': \{message}")
   }
 }
 
 ///|
 fn write_bytes_file(path : String, data : Bytes) -> Unit {
   @fs.write_bytes_to_file(path, data) catch {
-    e => exit_error("writing file '\{path}': \{e}")
+    @fs.IOError(message) => exit_error("writing file '\{path}': \{message}")
   }
 }
 
@@ -254,15 +254,15 @@ fn write_binary_file(path : String, data : Array[Int]) -> Unit {
   }
   let bytes = Bytes::from_array(byte_arr)
   @fs.write_bytes_to_file(path, bytes) catch {
-    e => exit_error("writing file '\{path}': \{e}")
+    @fs.IOError(message) => exit_error("writing file '\{path}': \{message}")
   }
 }
 
 ///|
 fn read_text_file(path : String) -> String {
   @fs.read_file_to_string(path) catch {
-    e => {
-      exit_error("reading file '\{path}': \{e}")
+    @fs.IOError(message) => {
+      exit_error("reading file '\{path}': \{message}")
       panic()
     }
   }
@@ -559,8 +559,8 @@ fn is_dir(path : String) -> Bool {
 ///|
 fn read_wit_dir(path : String) -> @wit.Package {
   let entries = @fs.read_dir(path) catch {
-    e => {
-      exit_error(e.to_string())
+    @fs.IOError(message) => {
+      exit_error(message)
       panic()
     }
   }
@@ -614,8 +614,8 @@ fn read_wit_deps(root : String) -> Array[@wit.Package] {
     return []
   }
   let entries = @fs.read_dir(deps_dir) catch {
-    e => {
-      exit_error(e.to_string())
+    @fs.IOError(message) => {
+      exit_error(message)
       panic()
     }
   }
@@ -659,8 +659,8 @@ fn read_wit_dir_allow_missing_package(path : String) -> @wit.Package {
   // Like read_wit_dir(), but used for deps entries where the container name is arbitrary.
   // The WIT files themselves must still declare a `package` somewhere; this is validated later.
   let entries = @fs.read_dir(path) catch {
-    e => {
-      exit_error(e.to_string())
+    @fs.IOError(message) => {
+      exit_error(message)
       panic()
     }
   }
@@ -708,8 +708,8 @@ fn write_wit_out_dir(
     }
   } else {
     @fs.create_dir(out_dir) catch {
-      e => {
-        exit_error(e.to_string())
+      @fs.IOError(message) => {
+        exit_error(message)
         panic()
       }
     }
@@ -726,8 +726,8 @@ fn write_wit_out_dir(
     }
   } else {
     @fs.create_dir(deps_dir) catch {
-      e => {
-        exit_error(e.to_string())
+      @fs.IOError(message) => {
+        exit_error(message)
         panic()
       }
     }

--- a/modules/wasmoon/cmd/wasmoon/commands/explore.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/explore.mbt
@@ -294,8 +294,8 @@ pub fn run_explore(
     }
     let html = generate_html_report(compiled_funcs)
     @fs.write_string_to_file(path, html) catch {
-      e => {
-        @logger.error("writing HTML report: \{e}")
+      @fs.IOError(message) => {
+        @logger.error("writing HTML report: \{message}")
         exit_failure()
         return
       }

--- a/modules/wasmoon/cmd/wasmoon/commands/moon.pkg
+++ b/modules/wasmoon/cmd/wasmoon/commands/moon.pkg
@@ -18,6 +18,7 @@ import {
   "Milky2018/wasmoon_jit/perf",
   "Milky2018/wasmoon/wasi",
   "moonbitlang/x/sys",
+  "moonbitlang/core/env",
   "moonbitlang/x/fs",
   "Milky2018/wasmoon/executor",
   "Milky2018/wasmoon/runtime",

--- a/modules/wasmoon/cmd/wasmoon/commands/run.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/run.mbt
@@ -394,7 +394,7 @@ pub fn run_wasm(
   // Handle inherit-env option
   if inherit_env {
     @logger.debug("Inheriting host environment variables")
-    let host_envs = @sys.get_env_vars()
+    let host_envs = @env.get_env_vars()
     let mut inherited_count = 0
     for key, value in host_envs {
       // Keep explicit --env values authoritative when keys overlap.
@@ -835,7 +835,7 @@ fn int_array_to_bytes(ints : Array[Int]) -> Bytes {
 
 ///|
 fn run_jit_cache_dir() -> String {
-  match @sys.get_env_var("WASMOON_JIT_CACHE_DIR") {
+  match @env.get_env_var("WASMOON_JIT_CACHE_DIR") {
     Some(dir) if dir.length() > 0 => dir
     _ => "/tmp/wasmoon-jit-cache"
   }
@@ -1959,14 +1959,14 @@ fn compile_validated_module_to_jit(
   if module_tick is Some(tick) {
     @perf.set_module_compile_us(@perf.elapsed_us(tick))
     let report = @perf.export_json()
-    let output_path = match @sys.get_env_var("WASMOON_PERF_METRICS_FILE") {
+    let output_path = match @env.get_env_var("WASMOON_PERF_METRICS_FILE") {
       Some(path) => path
       None => "target/wasmoon-perf-metrics.json"
     }
     @fs.write_string_to_file(output_path, report) catch {
-      e =>
+      @fs.IOError(message) =>
         @logger.warn(
-          "Failed to write perf metrics report to '\{output_path}': \{e}",
+          "Failed to write perf metrics report to '\{output_path}': \{message}",
         )
     }
   }

--- a/modules/wasmoon/cmd/wasmoon/commands/run_wbtest.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/run_wbtest.mbt
@@ -115,7 +115,7 @@ fn write_cache_test_bytes(path : String, bytes : Bytes) -> Unit {
     _ => ()
   }
   @fs.write_bytes_to_file(path, bytes) catch {
-    err => abort("failed to write cache fixture: \{err}")
+    @fs.IOError(message) => abort("failed to write cache fixture: \{message}")
   }
 }
 

--- a/modules/wasmoon/cmd/wasmoon/commands/wast.mbt
+++ b/modules/wasmoon/cmd/wasmoon/commands/wast.mbt
@@ -20,8 +20,8 @@ fn run_wast(wast_path : String, use_jit : Bool, show_success : Bool) -> Unit {
   wast_jit_attempts.val = 0
   // Read WAST file
   let content = @fs.read_file_to_string(wast_path) catch {
-    e => {
-      @logger.error("reading file: \{e}")
+    @fs.IOError(message) => {
+      @logger.error("reading file: \{message}")
       exit_failure()
       return
     }
@@ -72,7 +72,7 @@ fn run_wast(wast_path : String, use_jit : Bool, show_success : Bool) -> Unit {
       println("  - \{failure}")
     }
   }
-  if (match @sys.get_env_var("WASMOON_WAST_JIT_TRACE") {
+  if (match @env.get_env_var("WASMOON_WAST_JIT_TRACE") {
       Some(v) => is_truthy_env(v)
       None => false
     }) {

--- a/modules/wasmoon/executor/context.mbt
+++ b/modules/wasmoon/executor/context.mbt
@@ -29,7 +29,7 @@ fn is_truthy_env_flag(value : String) -> Bool {
 
 ///|
 fn gc_stress_enabled() -> Bool {
-  match @sys.get_env_var(GC_STRESS_ENV) {
+  match @env.get_env_var(GC_STRESS_ENV) {
     Some(v) => is_truthy_env_flag(v)
     None => false
   }
@@ -53,7 +53,7 @@ fn parse_decimal_int(value : String) -> Int? {
 
 ///|
 fn gc_stress_every() -> Int {
-  match @sys.get_env_var(GC_STRESS_EVERY_ENV) {
+  match @env.get_env_var(GC_STRESS_EVERY_ENV) {
     Some(raw_value) =>
       match parse_decimal_int(raw_value) {
         Some(parsed) if parsed > 0 => parsed

--- a/modules/wasmoon/executor/moon.pkg
+++ b/modules/wasmoon/executor/moon.pkg
@@ -2,7 +2,7 @@ import {
   "Milky2018/wasm_core/types",
   "Milky2018/wasmoon/runtime",
   "Milky2018/wasmoon/logger",
-  "moonbitlang/x/sys",
+  "moonbitlang/core/env",
   "moonbitlang/core/buffer",
   "moonbitlang/core/debug",
   "moonbitlang/core/double",

--- a/modules/wasmoon/moon.mod
+++ b/modules/wasmoon/moon.mod
@@ -3,7 +3,7 @@ name = "Milky2018/wasmoon"
 version = "0.11.1"
 
 import {
-  "moonbitlang/x@0.4.38",
+  "moonbitlang/x@0.4.48",
   "TheWaWaR/clap@0.2.6",
   "Milky2018/wasm_core@0.4.0",
   "Milky2018/wasm_milkir@0.5.0",

--- a/modules/wasmoon/runtime/moon.pkg
+++ b/modules/wasmoon/runtime/moon.pkg
@@ -2,5 +2,5 @@ import {
   "Milky2018/wasm_core/types",
   "Milky2018/wasmoon_jit",
   "Milky2018/wasmoon/logger",
-  "moonbitlang/x/sys",
+  "moonbitlang/core/env",
 }

--- a/modules/wasmoon/runtime/store.mbt
+++ b/modules/wasmoon/runtime/store.mbt
@@ -117,7 +117,7 @@ fn parse_decimal_int(value : String) -> Int? {
 
 ///|
 fn c_heap_initial_capacity() -> Int {
-  match @sys.get_env_var(GC_HEAP_CAPACITY_ENV) {
+  match @env.get_env_var(GC_HEAP_CAPACITY_ENV) {
     Some(raw_value) =>
       match parse_decimal_int(raw_value) {
         Some(parsed) if parsed > 0 => parsed

--- a/modules/wasmoon/testsuite/wit_component_encoding_test.mbt
+++ b/modules/wasmoon/testsuite/wit_component_encoding_test.mbt
@@ -132,8 +132,8 @@ test "wit component encode (non-scalar + resources + use)" {
 ///|
 test "wit component decode (wasm-tools fixture)" {
   let bytes = @fs.read_file_to_bytes("testsuite/fixtures/witpkg.wasm") catch {
-    e => {
-      fail(e.to_string())
+    @fs.IOError(message) => {
+      fail(message)
       panic()
     }
   }

--- a/modules/wasmoon_jit/moon.mod
+++ b/modules/wasmoon_jit/moon.mod
@@ -13,7 +13,7 @@ keywords = [ "wasm", "jit", "runtime", "native" ]
 description = "Wasmoon-specific JIT integration and native runtime glue"
 
 import {
-  "moonbitlang/x@0.4.38",
+  "moonbitlang/x@0.4.48",
   "Milky2018/wasm_core@0.4.0",
   "Milky2018/wasm_milkir@0.5.0",
   "Milky2018/wasm_machv@0.4.0",

--- a/modules/wasmoon_jit/moon.pkg
+++ b/modules/wasmoon_jit/moon.pkg
@@ -12,7 +12,7 @@ import {
   "Milky2018/wasmoon_jit/artifact",
   "Milky2018/wasmoon_jit/perf",
   "moonbitlang/x/crypto",
-  "moonbitlang/x/sys",
+  "moonbitlang/core/env",
   "moonbitlang/core/cmp",
   "moonbitlang/core/hashset",
 }

--- a/modules/wasmoon_jit/perf/metrics.mbt
+++ b/modules/wasmoon_jit/perf/metrics.mbt
@@ -17,7 +17,7 @@ fn is_truthy_env(v : String) -> Bool {
 
 ///|
 pub fn enabled() -> Bool {
-  match @sys.get_env_var("WASMOON_PERF_METRICS") {
+  match @env.get_env_var("WASMOON_PERF_METRICS") {
     Some(v) => is_truthy_env(v)
     None => false
   }
@@ -30,7 +30,7 @@ pub fn enabled() -> Bool {
 /// Default: disabled (compact mode).
 /// Enable explicitly with WASMOON_PERF_METRICS_DETAIL=1/true/full.
 let perf_detail_metrics_enabled : Bool = match
-  @sys.get_env_var("WASMOON_PERF_METRICS_DETAIL") {
+  @env.get_env_var("WASMOON_PERF_METRICS_DETAIL") {
   Some(v) => is_truthy_env(v) || v == "full" || v == "FULL"
   None => false
 }

--- a/modules/wasmoon_jit/perf/metrics_test.mbt
+++ b/modules/wasmoon_jit/perf/metrics_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "compile metrics preserve every production phase and allocation summary" {
-  let previous = @sys.get_env_var("WASMOON_PERF_METRICS")
-  @sys.set_env_var("WASMOON_PERF_METRICS", "1")
+  let previous = @env.get_env_var("WASMOON_PERF_METRICS")
+  @env.set_env_var("WASMOON_PERF_METRICS", "1")
   reset_module(1)
   begin_function(7, "measured", 2, 30)
   record_stage_us(Optimize, 10L)
@@ -48,7 +48,7 @@ test "compile metrics preserve every production phase and allocation summary" {
     ),
   )
   match previous {
-    Some(value) => @sys.set_env_var("WASMOON_PERF_METRICS", value)
-    None => @sys.unset_env_var("WASMOON_PERF_METRICS")
+    Some(value) => @env.set_env_var("WASMOON_PERF_METRICS", value)
+    None => @env.unset_env_var("WASMOON_PERF_METRICS")
   }
 }

--- a/modules/wasmoon_jit/perf/moon.pkg
+++ b/modules/wasmoon_jit/perf/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "Milky2018/milkir",
   "moonbitlang/core/json",
-  "moonbitlang/x/sys",
+  "moonbitlang/core/env",
 }
 
 options(

--- a/modules/wasmoon_jit/regalloc_validation.mbt
+++ b/modules/wasmoon_jit/regalloc_validation.mbt
@@ -20,7 +20,7 @@ fn regalloc_validation() -> Bool {
   match regalloc_validation_enabled.val {
     Some(value) => value
     None => {
-      let value = match @sys.get_env_var("MACHV_REGALLOC_VALIDATION") {
+      let value = match @env.get_env_var("MACHV_REGALLOC_VALIDATION") {
         Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("on") =>
           true
         _ => false


### PR DESCRIPTION
`moonbitlang/x` was pinned at **0.4.38**, ten releases behind **0.4.48**. The
bump surfaces two independent breakages — both had to be handled, and the second
was not a deprecation but a hard compile error.

## `@sys` environment API is deprecated

The whole environment surface moved to `moonbitlang/core/env`:

| deprecated | replacement |
|---|---|
| `@sys.get_env_var` | `@env.get_env_var` |
| `@sys.get_env_vars` | `@env.get_env_vars` |
| `@sys.set_env_var` | `@env.set_env_var` |
| `@sys.unset_env_var` | `@env.unset_env_var` |
| `@sys.get_cli_args` | `@env.args` |

**Only `@sys.exit` survives.** So packages that used `@sys` purely for
environment access now import `moonbitlang/core/env` instead, and the two that
also exit keep both imports. `@env.args` was already in use for command-line
arguments, so this ends up with one source per concern rather than two.

## `@fs.IOError` no longer implements `Show`

0.4.44 *"Removed deprecated `Show` implementations"* across the library in favour
of derived `Debug`. Fifteen sites interpolated the error or called `to_string()`
on it and stopped compiling.

They now destructure it — `@fs.IOError(message) => ...` — which also prints the
bare message rather than wrapping it in the constructor name, so the CLI's error
text improves rather than just compiling again.

## The other dependencies are already current

- `TheWaWaR/clap` — 0.2.6 is the newest.
- `moonbitlang/async` — 0.20.3 is the newest. This is the pin #367 is waiting
  on and **no fixed release exists yet**, so it cannot move. Recorded in
  `issues/ISS-367.md` so the next sweep doesn't have to look it up.

## Verification

`moon check` clean, **zero warnings** — the bump initially produced 14
deprecation warnings and 15 errors. 1606/1606 native tests. 258/258 corpus files,
62563 assertions, both JIT and interpreter. CLI behaviour checks exit 0.
`--version` still reports 0.11.1.

**The environment migration is not covered by the corpus**, so I checked it
directly rather than assuming `@env.get_env_var` behaves like `@sys.get_env_var`:

- control run, no variables set → no metrics file written
- same run with `WASMOON_PERF_METRICS=1` and `WASMOON_PERF_METRICS_FILE` set →
  populated 586-byte report written

Those two reads live in different packages (`wasmoon_jit/perf` and
`wasmoon/cmd/wasmoon/commands`), so both migrated paths are exercised. The
`perf/metrics_test.mbt` tests additionally round-trip set/get/unset through
`@env`.

The pre-existing wasm-gc failure in `milkir` (deep dominator spine, stack
overflow in `postorder_visit`) is unrelated and unchanged.