### PR TITLE
Release 0.11.2

### DIFF
--- a/modules/aarch64_target/moon.mod
+++ b/modules/aarch64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/aarch64_target"
 
-version = "0.5.1"
+version = "0.5.2"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "aarch64", "compiler", "codegen", "jit" ]
 description = "AArch64 target pipeline from semantic MachV to native code"
 
 import {
-  "Milky2018/milkir@0.5.0",
-  "Milky2018/machv@0.7.0",
-  "Milky2018/machv_regalloc@0.5.0",
-  "Milky2018/milkir_machv@0.6.0",
+  "Milky2018/milkir@0.5.1",
+  "Milky2018/machv@0.7.1",
+  "Milky2018/machv_regalloc@0.5.1",
+  "Milky2018/milkir_machv@0.6.1",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/machv/moon.mod
+++ b/modules/machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv"
 
-version = "0.7.0"
+version = "0.7.1"
 
 readme = "README.mbt.md"
 

--- a/modules/machv_regalloc/moon.mod
+++ b/modules/machv_regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv_regalloc"
 
-version = "0.5.0"
+version = "0.5.1"
 
 readme = "README.mbt.md"
 
@@ -14,7 +14,7 @@ description = "Target VCode adapter for the reusable register allocator"
 
 import {
   "moonbitlang/x@0.4.48",
-  "Milky2018/machv@0.7.0",
+  "Milky2018/machv@0.7.1",
   "Milky2018/regalloc@0.6.0",
 }
 

--- a/modules/milkir/moon.mod
+++ b/modules/milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir"
 
-version = "0.5.0"
+version = "0.5.1"
 
 readme = "README.mbt.md"
 

--- a/modules/milkir_machv/moon.mod
+++ b/modules/milkir_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir_machv"
 
-version = "0.6.0"
+version = "0.6.1"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "MilkIR-to-MachV lowering"
 
 import {
   "moonbitlang/x@0.4.48",
-  "Milky2018/milkir@0.5.0",
-  "Milky2018/machv@0.7.0",
+  "Milky2018/milkir@0.5.1",
+  "Milky2018/machv@0.7.1",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasm_machv/moon.mod
+++ b/modules/wasm_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_machv"
 
-version = "0.4.0"
+version = "0.4.1"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "wasm", "webassembly", "milkir", "machv", "lowering" ]
 description = "WebAssembly MilkIR dialect adapter for target-neutral MachV"
 
 import {
-  "Milky2018/wasm_milkir@0.5.0",
-  "Milky2018/milkir@0.5.0",
-  "Milky2018/machv@0.7.0",
-  "Milky2018/milkir_machv@0.6.0",
+  "Milky2018/wasm_milkir@0.5.1",
+  "Milky2018/milkir@0.5.1",
+  "Milky2018/machv@0.7.1",
+  "Milky2018/milkir_machv@0.6.1",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasm_milkir/moon.mod
+++ b/modules/wasm_milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_milkir"
 
-version = "0.5.0"
+version = "0.5.1"
 
 readme = "README.mbt.md"
 
@@ -13,7 +13,7 @@ keywords = [ "wasm", "webassembly", "milkir", "compiler", "dialect" ]
 description = "WebAssembly dialect adapter for MilkIR extension operations"
 
 import {
-  "Milky2018/milkir@0.5.0",
+  "Milky2018/milkir@0.5.1",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasmoon/cmd/wasmoon/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon/main.mbt
@@ -3,7 +3,7 @@
 /// by `scripts/tests/test_cli_version.py`. MoonBit gives the program no way
 /// to read its own module manifest, so the manifest stays the single source
 /// of truth and the test is what keeps this copy from drifting.
-const WASMOON_VERSION : String = "0.11.1"
+const WASMOON_VERSION : String = "0.11.2"
 
 ///|
 fn clap_parser(

--- a/modules/wasmoon/moon.mod
+++ b/modules/wasmoon/moon.mod
@@ -1,19 +1,19 @@
 name = "Milky2018/wasmoon"
 
-version = "0.11.1"
+version = "0.11.2"
 
 import {
   "moonbitlang/x@0.4.48",
   "TheWaWaR/clap@0.2.6",
   "Milky2018/wasm_core@0.4.0",
-  "Milky2018/wasm_milkir@0.5.0",
-  "Milky2018/milkir@0.5.0",
-  "Milky2018/machv@0.7.0",
-  "Milky2018/milkir_machv@0.6.0",
-  "Milky2018/machv_regalloc@0.5.0",
-  "Milky2018/x64_target@0.4.0",
-  "Milky2018/aarch64_target@0.5.1",
-  "Milky2018/wasmoon_jit@0.6.1",
+  "Milky2018/wasm_milkir@0.5.1",
+  "Milky2018/milkir@0.5.1",
+  "Milky2018/machv@0.7.1",
+  "Milky2018/milkir_machv@0.6.1",
+  "Milky2018/machv_regalloc@0.5.1",
+  "Milky2018/x64_target@0.4.1",
+  "Milky2018/aarch64_target@0.5.2",
+  "Milky2018/wasmoon_jit@0.6.2",
   "moonbitlang/async@0.20.3",
 }
 

--- a/modules/wasmoon_jit/moon.mod
+++ b/modules/wasmoon_jit/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasmoon_jit"
 
-version = "0.6.1"
+version = "0.6.2"
 
 readme = "README.mbt.md"
 
@@ -15,14 +15,14 @@ description = "Wasmoon-specific JIT integration and native runtime glue"
 import {
   "moonbitlang/x@0.4.48",
   "Milky2018/wasm_core@0.4.0",
-  "Milky2018/wasm_milkir@0.5.0",
-  "Milky2018/wasm_machv@0.4.0",
-  "Milky2018/milkir@0.5.0",
-  "Milky2018/machv@0.7.0",
-  "Milky2018/milkir_machv@0.6.0",
-  "Milky2018/machv_regalloc@0.5.0",
-  "Milky2018/aarch64_target@0.5.1",
-  "Milky2018/x64_target@0.4.0",
+  "Milky2018/wasm_milkir@0.5.1",
+  "Milky2018/wasm_machv@0.4.1",
+  "Milky2018/milkir@0.5.1",
+  "Milky2018/machv@0.7.1",
+  "Milky2018/milkir_machv@0.6.1",
+  "Milky2018/machv_regalloc@0.5.1",
+  "Milky2018/aarch64_target@0.5.2",
+  "Milky2018/x64_target@0.4.1",
 }
 
 preferred_target = "native"

--- a/modules/x64_target/moon.mod
+++ b/modules/x64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/x64_target"
 
-version = "0.4.0"
+version = "0.4.1"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "x64", "x86-64", "compiler", "codegen" ]
 description = "x64 target pipeline from semantic MachV to native code"
 
 import {
-  "Milky2018/milkir@0.5.0",
-  "Milky2018/machv@0.7.0",
-  "Milky2018/machv_regalloc@0.5.0",
-  "Milky2018/milkir_machv@0.6.0",
+  "Milky2018/milkir@0.5.1",
+  "Milky2018/machv@0.7.1",
+  "Milky2018/machv_regalloc@0.5.1",
+  "Milky2018/milkir_machv@0.6.1",
 }
 
 preferred_target = "wasm-gc"


### PR DESCRIPTION
Three fixes have landed since the 0.11.1 publish and none of them are reachable from the registry yet:

- **#493** — the AArch64 branch-range fallback now sits on the path the JIT actually compiles through, so a function whose conditional branch exceeds imm19 compiles instead of failing (GitHub #486). `wasmoon run` also reports *why* the JIT refused a module instead of logging a bare string.
- **#492** — recursive CFG and e-graph walks replaced with explicit stacks, fixing the wasm-gc stack overflow on deep graphs (ISS-401).
- **#491** — off the deprecated `@sys` environment API onto `moonbitlang/core/env`, and moonbitlang/x to 0.4.48.

## Why this bump is wide

`machv` and `milkir` both carry source changes, so every module pinning them has to re-pin to reach the fix. 0.11.1 was a three-module release; this one touches everything except `regalloc` and `wasm_core`, which are untouched and keep their versions.

| module | | module | |
| --- | --- | --- | --- |
| `machv` | 0.7.0 → 0.7.1 | `wasm_machv` | 0.4.0 → 0.4.1 |
| `milkir` | 0.5.0 → 0.5.1 | `x64_target` | 0.4.0 → 0.4.1 |
| `machv_regalloc` | 0.5.0 → 0.5.1 | `aarch64_target` | 0.5.1 → 0.5.2 |
| `milkir_machv` | 0.6.0 → 0.6.1 | `wasmoon_jit` | 0.6.1 → 0.6.2 |
| `wasm_milkir` | 0.5.0 → 0.5.1 | `wasmoon` | 0.11.1 → 0.11.2 |

## Verification

- Workspace 2634/2634 native, 1028/1028 wasm-gc.
- `moon check` clean from a cold `moon clean`.
- WAST corpus 258/258 files, 62563 assertions, interpreter and JIT.
- Built binary reports `0.11.2`.

Publishing to mooncakes.io follows once this merges.