### PR TITLE
Release coordinated workspace patch versions

### DIFF
--- a/modules/aarch64_target/moon.mod
+++ b/modules/aarch64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/aarch64_target"
 
-version = "0.6.2"
+version = "0.6.3"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "aarch64", "compiler", "codegen", "jit" ]
 description = "AArch64 target pipeline from semantic MachV to native code"
 
 import {
-  "Milky2018/milkir@0.6.2",
-  "Milky2018/machv@0.8.2",
-  "Milky2018/machv_regalloc@0.6.2",
-  "Milky2018/milkir_machv@0.7.2",
+  "Milky2018/milkir@0.6.3",
+  "Milky2018/machv@0.8.3",
+  "Milky2018/machv_regalloc@0.6.3",
+  "Milky2018/milkir_machv@0.7.3",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/machv/moon.mod
+++ b/modules/machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv"
 
-version = "0.8.2"
+version = "0.8.3"
 
 readme = "README.mbt.md"
 

--- a/modules/machv_regalloc/moon.mod
+++ b/modules/machv_regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/machv_regalloc"
 
-version = "0.6.2"
+version = "0.6.3"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "Target VCode adapter for the reusable register allocator"
 
 import {
   "moonbitlang/x@0.4.48",
-  "Milky2018/machv@0.8.2",
-  "Milky2018/regalloc@0.7.2",
+  "Milky2018/machv@0.8.3",
+  "Milky2018/regalloc@0.7.3",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/milkir/moon.mod
+++ b/modules/milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir"
 
-version = "0.6.2"
+version = "0.6.3"
 
 readme = "README.mbt.md"
 

--- a/modules/milkir_machv/moon.mod
+++ b/modules/milkir_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/milkir_machv"
 
-version = "0.7.2"
+version = "0.7.3"
 
 readme = "README.mbt.md"
 
@@ -14,8 +14,8 @@ description = "MilkIR-to-MachV lowering"
 
 import {
   "moonbitlang/x@0.4.48",
-  "Milky2018/milkir@0.6.2",
-  "Milky2018/machv@0.8.2",
+  "Milky2018/milkir@0.6.3",
+  "Milky2018/machv@0.8.3",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/regalloc/moon.mod
+++ b/modules/regalloc/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/regalloc"
 
-version = "0.7.2"
+version = "0.7.3"
 
 readme = "README.mbt.md"
 

--- a/modules/wasm_core/moon.mod
+++ b/modules/wasm_core/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_core"
 
-version = "0.5.2"
+version = "0.5.3"
 
 readme = "README.mbt.md"
 

--- a/modules/wasm_machv/moon.mod
+++ b/modules/wasm_machv/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_machv"
 
-version = "0.5.2"
+version = "0.5.3"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "wasm", "webassembly", "milkir", "machv", "lowering" ]
 description = "WebAssembly MilkIR dialect adapter for target-neutral MachV"
 
 import {
-  "Milky2018/wasm_milkir@0.6.2",
-  "Milky2018/milkir@0.6.2",
-  "Milky2018/machv@0.8.2",
-  "Milky2018/milkir_machv@0.7.2",
+  "Milky2018/wasm_milkir@0.6.3",
+  "Milky2018/milkir@0.6.3",
+  "Milky2018/machv@0.8.3",
+  "Milky2018/milkir_machv@0.7.3",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasm_milkir/moon.mod
+++ b/modules/wasm_milkir/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasm_milkir"
 
-version = "0.6.2"
+version = "0.6.3"
 
 readme = "README.mbt.md"
 
@@ -13,7 +13,7 @@ keywords = [ "wasm", "webassembly", "milkir", "compiler", "dialect" ]
 description = "WebAssembly dialect adapter for MilkIR extension operations"
 
 import {
-  "Milky2018/milkir@0.6.2",
+  "Milky2018/milkir@0.6.3",
 }
 
 preferred_target = "wasm-gc"

--- a/modules/wasmoon/cmd/wasmoon/main.mbt
+++ b/modules/wasmoon/cmd/wasmoon/main.mbt
@@ -3,7 +3,7 @@
 /// by `scripts/tests/test_cli_version.py`. MoonBit gives the program no way
 /// to read its own module manifest, so the manifest stays the single source
 /// of truth and the test is what keeps this copy from drifting.
-const WASMOON_VERSION : String = "0.12.3"
+const WASMOON_VERSION : String = "0.12.4"
 
 ///|
 /// Print usage text as a diagnostic.

--- a/modules/wasmoon/moon.mod
+++ b/modules/wasmoon/moon.mod
@@ -1,19 +1,19 @@
 name = "Milky2018/wasmoon"
 
-version = "0.12.3"
+version = "0.12.4"
 
 import {
   "moonbitlang/x@0.4.48",
   "TheWaWaR/clap@0.2.6",
-  "Milky2018/wasm_core@0.5.2",
-  "Milky2018/wasm_milkir@0.6.2",
-  "Milky2018/milkir@0.6.2",
-  "Milky2018/machv@0.8.2",
-  "Milky2018/milkir_machv@0.7.2",
-  "Milky2018/machv_regalloc@0.6.2",
-  "Milky2018/x64_target@0.5.2",
-  "Milky2018/aarch64_target@0.6.2",
-  "Milky2018/wasmoon_jit@0.7.2",
+  "Milky2018/wasm_core@0.5.3",
+  "Milky2018/wasm_milkir@0.6.3",
+  "Milky2018/milkir@0.6.3",
+  "Milky2018/machv@0.8.3",
+  "Milky2018/milkir_machv@0.7.3",
+  "Milky2018/machv_regalloc@0.6.3",
+  "Milky2018/x64_target@0.5.3",
+  "Milky2018/aarch64_target@0.6.3",
+  "Milky2018/wasmoon_jit@0.7.3",
   "moonbitlang/async@0.20.5",
 }
 

--- a/modules/wasmoon_jit/moon.mod
+++ b/modules/wasmoon_jit/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/wasmoon_jit"
 
-version = "0.7.2"
+version = "0.7.3"
 
 readme = "README.mbt.md"
 
@@ -14,15 +14,15 @@ description = "Wasmoon-specific JIT integration and native runtime glue"
 
 import {
   "moonbitlang/x@0.4.48",
-  "Milky2018/wasm_core@0.5.2",
-  "Milky2018/wasm_milkir@0.6.2",
-  "Milky2018/wasm_machv@0.5.2",
-  "Milky2018/milkir@0.6.2",
-  "Milky2018/machv@0.8.2",
-  "Milky2018/milkir_machv@0.7.2",
-  "Milky2018/machv_regalloc@0.6.2",
-  "Milky2018/aarch64_target@0.6.2",
-  "Milky2018/x64_target@0.5.2",
+  "Milky2018/wasm_core@0.5.3",
+  "Milky2018/wasm_milkir@0.6.3",
+  "Milky2018/wasm_machv@0.5.3",
+  "Milky2018/milkir@0.6.3",
+  "Milky2018/machv@0.8.3",
+  "Milky2018/milkir_machv@0.7.3",
+  "Milky2018/machv_regalloc@0.6.3",
+  "Milky2018/aarch64_target@0.6.3",
+  "Milky2018/x64_target@0.5.3",
 }
 
 preferred_target = "native"

--- a/modules/x64_target/moon.mod
+++ b/modules/x64_target/moon.mod
@@ -1,6 +1,6 @@
 name = "Milky2018/x64_target"
 
-version = "0.5.2"
+version = "0.5.3"
 
 readme = "README.mbt.md"
 
@@ -13,10 +13,10 @@ keywords = [ "x64", "x86-64", "compiler", "codegen" ]
 description = "x64 target pipeline from semantic MachV to native code"
 
 import {
-  "Milky2018/milkir@0.6.2",
-  "Milky2018/machv@0.8.2",
-  "Milky2018/machv_regalloc@0.6.2",
-  "Milky2018/milkir_machv@0.7.2",
+  "Milky2018/milkir@0.6.3",
+  "Milky2018/machv@0.8.3",
+  "Milky2018/machv_regalloc@0.6.3",
+  "Milky2018/milkir_machv@0.7.3",
 }
 
 preferred_target = "wasm-gc"


### PR DESCRIPTION
## Summary

- bump all twelve published workspace modules by one patch version
- synchronize every internal dependency pin with the newly published versions
- update the Wasmoon CLI version constant to match `wasmoon@0.12.4`
- publish the modules in dependency order and verify the fetched registry manifests against this tree

## Released versions

- `Milky2018/wasm_core@0.5.3`
- `Milky2018/milkir@0.6.3`
- `Milky2018/machv@0.8.3`
- `Milky2018/regalloc@0.7.3`
- `Milky2018/wasm_milkir@0.6.3`
- `Milky2018/milkir_machv@0.7.3`
- `Milky2018/machv_regalloc@0.6.3`
- `Milky2018/wasm_machv@0.5.3`
- `Milky2018/x64_target@0.5.3`
- `Milky2018/aarch64_target@0.6.3`
- `Milky2018/wasmoon_jit@0.7.3`
- `Milky2018/wasmoon@0.12.4`

## Validation

- `moon info`
- `moon fmt`
- `moon check --target native --warn-list +73` (0 errors)
- `MACHV_REGALLOC_VALIDATION=1 moon test --target native` (2657/2657)
- `moon test --target all` (wasm, wasm-gc, and JavaScript: 1032/1032 each; native: 2657/2657)
- `python3 -m unittest scripts/tests/test_cli_version.py`
- `python3 scripts/cli_behavior_test.py`
- `python3 scripts/audit_module_boundaries.py`
- `./wasmoon --version` reports `0.12.4`
- every dry-run returned `202 Accepted`
- every real publication returned `200 OK`
- all twelve fetched registry manifests match the workspace manifests byte-for-byte
